### PR TITLE
Create sdist on GHA using swig4.0.1

### DIFF
--- a/.github/workflows/deploy_branch.yml
+++ b/.github/workflows/deploy_branch.yml
@@ -4,9 +4,9 @@ jobs:
   dockerhub:
     # https://github.com/marketplace/actions/publish-docker
     name: Deploy Dockerhub
-    
+
     runs-on: ubuntu-latest
-    
+
     steps:
     - uses: actions/checkout@master
     - run: git archive -o docker/amici.tar.gz --format=tar.gz HEAD
@@ -30,10 +30,12 @@ jobs:
       with:
         fetch-depth: 20
 
-    - name: apt
+    - run: echo "::set-env name=AMICI_DIR::$(pwd)"
+    - run: echo ::set-env name=SWIG::${AMICI_DIR}/ThirdParty/swig-4.0.1/install/bin/swig
+
+    - name: Build swig4
       run: |
-        sudo apt-get update \
-          && sudo apt-get install -y swig
+        sudo scripts/downloadAndBuildSwig.sh
 
     - name: Create AMICI sdist
       run: |

--- a/.github/workflows/deploy_release.yml
+++ b/.github/workflows/deploy_release.yml
@@ -32,7 +32,7 @@ jobs:
     - name: Run doxygen
       run: |
         scripts/run-doxygen.sh
-        
+
     - name: Deploy 🚀
       uses: JamesIves/github-pages-deploy-action@3.5.7
       with:
@@ -50,11 +50,13 @@ jobs:
       with:
         fetch-depth: 20
 
-    - name: apt
+    - run: echo "::set-env name=AMICI_DIR::$(pwd)"
+    - run: echo ::set-env name=SWIG::${AMICI_DIR}/ThirdParty/swig-4.0.1/install/bin/swig
+
+    - name: Build swig4
       run: |
-        sudo apt-get update \
-          && sudo apt-get install -y swig
-          
+        sudo scripts/downloadAndBuildSwig.sh
+
     - name: sdist
       run: |
         scripts/buildSdist.sh
@@ -65,4 +67,4 @@ jobs:
         user: __token__
         password: ${{ secrets.pypi_password }}
         packages_dir: python/sdist/dist
-        
+


### PR DESCRIPTION
Swig from Ubuntu is still 3.x

AMICI 0.11.5 from pypi fails to import extension. Seems it's due to that.

Previously: 

>  ImportError: /home/dweindl/.local/lib/python3.8/site-packages/amici/_amici.cpython-38-x86_64-linux-gnu.so: undefined symbol: _ZN5amici4hdf521readModelDataFromHDF5ERKN2H56H5FileERNS_5ModelERKNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEE

Now works with sdist from GHA.
