### PR TITLE
Refactor swigging - generate one single wrapper (Closes #1212)

### DIFF
--- a/python/amici/__init__.py
+++ b/python/amici/__init__.py
@@ -110,7 +110,6 @@ amiciSwigPath = os.path.join(amici_path, 'swig')
 amiciSrcPath = os.path.join(amici_path, 'src')
 amiciModulePath = os.path.dirname(__file__)
 
-hdf5_enabled = os.path.isfile(os.path.join(amici_path, 'amici.py'))
 has_clibs = any([os.path.isfile(os.path.join(amici_path, wrapper))
                  for wrapper in ['amici.py', 'amici_without_hdf5.py']])
 
@@ -128,12 +127,8 @@ __commit__ = _get_commit_hash()
 # Import SWIG module and swig-dependent submodules if required and available
 if not _imported_from_setup():
     if has_clibs:
-        if hdf5_enabled:
-            from . import amici
-            from .amici import *
-        else:
-            from . import amici_without_hdf5 as amici
-            from .amici_without_hdf5 import *
+        from . import amici
+        from .amici import *
 
         # These module require the swig interface and other dependencies
         from .numpy import ReturnDataView, ExpDataView
@@ -148,6 +143,8 @@ if not _imported_from_setup():
     # These modules don't require the swig interface
     from .sbml_import import SbmlImporter, assignmentRules2observables
     from .ode_export import ODEModel, ODEExporter
+
+hdf5_enabled = 'readSolverSettingsFromHDF5' in dir()
 
 
 def runAmiciSimulation(

--- a/python/amici/custom_commands.py
+++ b/python/amici/custom_commands.py
@@ -202,8 +202,6 @@ class AmiciBuildExt(build_ext):
         lib_dir = "" if self.inplace \
             else self.get_finalized_command('build_py').build_lib
 
-        remove_swig_wrappers(self.extensions, no_clibs, lib_dir)
-
         if no_clibs:
             # Nothing to build
             return
@@ -351,38 +349,3 @@ def set_compiler_specific_extension_options(
         except AttributeError:
             # No compiler-specific options set
             pass
-
-
-def remove_swig_wrappers(extensions: 'setuptools.Extension',
-                         no_clibs: bool, lib_dir: str) -> None:
-    """Remove swig wrapper files not needed by the built extensions"""
-
-    # remove swig-python-wrapper files
-    unused_swig_wrappers = {
-        # they will also have '/' on windows!
-        "amici/amici_wrap.cxx",
-        "amici/amici_wrap_without_hdf5.cxx"
-    }
-
-    if not no_clibs:
-        # check for used c++ interface files
-        for ext in extensions:
-            unused_swig_wrappers -= set(ext.sources)
-
-    if "amici/amici_wrap.cxx" in unused_swig_wrappers:
-        unused_swig_wrappers.add(os.path.join("amici", "amici.py"))
-    if "amici/amici_wrap_without_hdf5.cxx" in unused_swig_wrappers:
-        unused_swig_wrappers.add(
-            os.path.join("amici", "amici_without_hdf5.py"))
-
-    # Path matching may go wrong. If we remove all, we will run into trouble.
-    # Let's detect it here instead of running into AttributeErrors later on...
-    max_num_wrappers = 4
-    if not no_clibs and len(unused_swig_wrappers) == max_num_wrappers:
-        raise RuntimeError("Removing all SWIG wrappers. "
-                           "This shouldn't happen.")
-
-    for filename in unused_swig_wrappers:
-        with contextlib.suppress(FileNotFoundError):
-            log.info(f"Removing unused SWIG wrapper {os.path.realpath(filename)}")
-            os.remove(os.path.join(lib_dir, filename))

--- a/python/amici/setuptools.py
+++ b/python/amici/setuptools.py
@@ -219,10 +219,11 @@ def add_debug_flags_if_required(cxx_flags: List[str],
         linker_flags.extend(['-g'])
 
 
-def generate_swig_interface_files() -> None:
+def generate_swig_interface_files(with_hdf5: bool = None) -> None:
     """
     Compile the swig python interface to amici
     """
+
     swig_outdir = os.path.join(os.path.abspath(os.getcwd()), "amici")
     swig_exe = find_swig()
     swig_version = get_swig_version(swig_exe)
@@ -238,35 +239,23 @@ def generate_swig_interface_files() -> None:
 
     log.info(f"Found SWIG version {swig_version}")
 
-    # Swig AMICI interface without HDF5 dependency
-    swig_cmd = [swig_exe,
-                *swig_args,
-                '-DAMICI_SWIG_WITHOUT_HDF5',
-                '-outdir', swig_outdir,
-                '-o', os.path.join("amici", "amici_wrap_without_hdf5.cxx"),
-                os.path.join("amici", "swig", "amici.i")]
+    # Are HDF5 includes available to generate the wrapper?
+    if with_hdf5 is None:
+        with_hdf5 = get_hdf5_config()['found']
+
+    if not with_hdf5:
+        swig_args.append('-DAMICI_SWIG_WITHOUT_HDF5')
 
     # Do we have -doxygen?
     if swig_version >= (4, 0, 0):
-        swig_cmd.insert(1, '-doxygen')
+        swig_args.append('-doxygen')
 
-    log.info(f"Running SWIG: {' '.join(swig_cmd)}")
-    sp = subprocess.run(swig_cmd, stdout=subprocess.PIPE,
-                        stderr=sys.stdout.buffer)
-    if not sp.returncode == 0:
-        raise AssertionError('Swigging AMICI failed:\n'
-                             + sp.stdout.decode('utf-8'))
-    shutil.move(os.path.join(swig_outdir, 'amici.py'),
-                os.path.join(swig_outdir, 'amici_without_hdf5.py'))
-
-    # Swig AMICI interface with HDF5 dependency
     swig_cmd = [swig_exe,
                 *swig_args,
                 '-outdir', swig_outdir,
                 '-o', os.path.join("amici", "amici_wrap.cxx"),
                 os.path.join("amici", "swig", "amici.i")]
-    if swig_version >= (4, 0, 0):
-        swig_cmd.insert(1, '-doxygen')
+
     log.info(f"Running SWIG: {' '.join(swig_cmd)}")
     sp = subprocess.run(swig_cmd, stdout=subprocess.PIPE,
                         stderr=sys.stdout.buffer)

--- a/python/sdist/setup.py
+++ b/python/sdist/setup.py
@@ -103,8 +103,6 @@ def main():
             [f'-l{lib}' for lib in
              ['hdf5_hl_cpp', 'hdf5_hl', 'hdf5_cpp', 'hdf5']])
         define_macros.extend(h5pkgcfg['define_macros'])
-        define_macros.append(('AMICI_SWIG_WITH_HDF5', None))
-
     else:
         print("HDF5 library NOT found. Building AMICI WITHOUT HDF5 support.")
         define_macros.append(('AMICI_SWIG_WITHOUT_HDF5', None))

--- a/swig/hdf5.i
+++ b/swig/hdf5.i
@@ -2,9 +2,19 @@
 
 // Add necessary symbols to generated header
 %{
+#ifndef AMICI_SWIG_WITHOUT_HDF5
 #include "amici/hdf5.h"
 using namespace amici;
+#endif
+%}
+
+%wrapper %{
+#ifndef AMICI_SWIG_WITHOUT_HDF5
 %}
 
 // Process symbols in header
 %include "amici/hdf5.h"
+
+%wrapper %{
+#endif // AMICI_SWIG_WITHOUT_HDF5
+%}


### PR DESCRIPTION
If hdf5 is available for wrapper generation, generate with hdf5 support.

If hdf5 is available for wrapper compilation, build with hdf5 support.