### PR TITLE
Documentation: use sphinx-hoverxref for hover tooltips in documentation

### DIFF
--- a/documentation/conf.py
+++ b/documentation/conf.py
@@ -118,6 +118,7 @@ extensions = [
     'sphinx.ext.coverage',
     'sphinx.ext.intersphinx',
     'sphinx.ext.autosummary',
+    'sphinx.ext.viewcode',
     'nbsphinx',
     'recommonmark',
     'sphinx_autodoc_typehints',

--- a/documentation/conf.py
+++ b/documentation/conf.py
@@ -172,6 +172,7 @@ set_type_checking_flag = True
 
 # hoverxref
 hoverxref_auto_ref = True
+hoverxref_roles = ['term']
 
 # -- Options for HTML output -------------------------------------------------
 

--- a/documentation/conf.py
+++ b/documentation/conf.py
@@ -173,6 +173,7 @@ set_type_checking_flag = True
 # hoverxref
 hoverxref_auto_ref = True
 hoverxref_roles = ['term']
+hoverxref_domains = ['py']
 
 # -- Options for HTML output -------------------------------------------------
 

--- a/documentation/conf.py
+++ b/documentation/conf.py
@@ -121,6 +121,7 @@ extensions = [
     'nbsphinx',
     'recommonmark',
     'sphinx_autodoc_typehints',
+    'hoverxref.extension',
 ]
 
 intersphinx_mapping = {
@@ -168,6 +169,8 @@ typehints_fully_qualified = True
 typehints_document_rtype = True
 set_type_checking_flag = True
 
+# hoverxref
+hoverxref_auto_ref = True
 
 # -- Options for HTML output -------------------------------------------------
 

--- a/documentation/rtd_requirements.txt
+++ b/documentation/rtd_requirements.txt
@@ -9,3 +9,4 @@ recommonmark>=0.6.0
 sphinx_rtd_theme>=0.4.3
 petab>=0.1.5
 sphinx-autodoc-typehints>=1.10.3
+git+https://github.com/readthedocs/sphinx-hoverxref@master


### PR DESCRIPTION
(only working on RTD, not locally)