### PR TITLE
Don't deploy documentation to gh-pages

### DIFF
--- a/.github/workflows/deploy_release.yml
+++ b/.github/workflows/deploy_release.yml
@@ -5,41 +5,6 @@ on:
       - published
 
 jobs:
-  pages:
-    name: Deploy GH-Pages
-
-    runs-on: ubuntu-20.04
-
-    steps:
-    - uses: actions/checkout@master
-    - run: git fetch --prune --unshallow
-
-    - run: echo "::set-env name=AMICI_DIR::$(pwd)"
-
-    - name: apt
-      run: |
-        sudo apt-get update \
-          && sudo apt-get install -y \
-          bison \
-          ragel \
-          graphviz \
-          texlive-latex-extra
-
-    - name: Build doxygen
-      run: |
-        sudo scripts/downloadAndBuildDoxygen.sh
-
-    - name: Run doxygen
-      run: |
-        scripts/run-doxygen.sh
-
-    - name: Deploy 🚀
-      uses: JamesIves/github-pages-deploy-action@3.5.7
-      with:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        BRANCH: gh-pages # The branch the action should deploy to.
-        FOLDER: doc # The folder the action should deploy.
-
   pypi:
     name: Deploy PyPI
 


### PR DESCRIPTION
Documentation there is incomplete. Full documentation available at https://readthedocs.org/projects/amici/.
gh-pages will be turned into redirect to RTD (839df38a3c39aff69673f00c3cdbe33ae7d13824).