### PR TITLE
Simplify code for sx0_fixedParameters

### DIFF
--- a/python/amici/ode_export.py
+++ b/python/amici/ode_export.py
@@ -2547,6 +2547,23 @@ class ODEExporter:
         if function == 'sx0_fixedParameters':
             # here we only want to overwrite values where x0_fixedParameters
             # was applied
+
+            lines.extend([
+                # Keep list of indices fixed parameters occuring in x0
+                "static const std::array<int, "
+                + str(len(self.model._x0_fixedParameters_idx))
+                + "> _x0_fixedParameters_idxs = {",
+                ', '.join(str(x) for x in self.model._x0_fixedParameters_idx),
+                "};",
+                "",
+                # Set all parameters that are to be reset to 0, so that the
+                #  switch statement below only needs to handle non-zero entries
+                #  (which usually reduces file size and speeds up
+                #  compilation significantly).
+                "for(auto idx: _x0_fixedParameters_idxs) {",
+                "sx0_fixedParameters[idx] = 0.0;",
+                "}"])
+
             cases = dict()
             for ipar in range(self.model.num_par()):
                 expressions = []
@@ -2554,8 +2571,10 @@ class ODEExporter:
                         self.model._x0_fixedParameters_idx,
                         equations[:, ipar]
                 ):
-                    expressions.append(f'{function}[{index}] = '
-                                       f'{_print_with_exception(formula)};')
+                    if not formula.is_zero:
+                        expressions.append(
+                            f'{function}[{index}] = '
+                            f'{_print_with_exception(formula)};')
                 cases[ipar] = expressions
             lines.extend(get_switch_statement('ip', cases, 1))
 

--- a/python/amici/ode_export.py
+++ b/python/amici/ode_export.py
@@ -2375,6 +2375,8 @@ class ODEExporter:
             '#include "amici/symbolic_functions.h"',
             '#include "amici/defines.h"',
             '#include "sundials/sundials_types.h"',
+            '',
+            '#include <array>',
         ]
 
         # function signature

--- a/python/amici/ode_export.py
+++ b/python/amici/ode_export.py
@@ -2551,12 +2551,13 @@ class ODEExporter:
             # was applied
 
             lines.extend([
-                # Keep list of indices fixed parameters occuring in x0
+                # Keep list of indices of fixed parameters occurring in x0
                 "    static const std::array<int, "
                 + str(len(self.model._x0_fixedParameters_idx))
                 + "> _x0_fixedParameters_idxs = {",
                 "        "
-                + ', '.join(str(x) for x in self.model._x0_fixedParameters_idx),
+                + ', '.join(str(x)
+                            for x in self.model._x0_fixedParameters_idx),
                 "    };",
                 "",
                 # Set all parameters that are to be reset to 0, so that the

--- a/python/amici/ode_export.py
+++ b/python/amici/ode_export.py
@@ -2550,19 +2550,20 @@ class ODEExporter:
 
             lines.extend([
                 # Keep list of indices fixed parameters occuring in x0
-                "static const std::array<int, "
+                "    static const std::array<int, "
                 + str(len(self.model._x0_fixedParameters_idx))
                 + "> _x0_fixedParameters_idxs = {",
-                ', '.join(str(x) for x in self.model._x0_fixedParameters_idx),
-                "};",
+                "        "
+                + ', '.join(str(x) for x in self.model._x0_fixedParameters_idx),
+                "    };",
                 "",
                 # Set all parameters that are to be reset to 0, so that the
                 #  switch statement below only needs to handle non-zero entries
                 #  (which usually reduces file size and speeds up
                 #  compilation significantly).
-                "for(auto idx: _x0_fixedParameters_idxs) {",
-                "sx0_fixedParameters[idx] = 0.0;",
-                "}"])
+                "    for(auto idx: _x0_fixedParameters_idxs) {",
+                "        sx0_fixedParameters[idx] = 0.0;",
+                "    }"])
 
             cases = dict()
             for ipar in range(self.model.num_par()):


### PR DESCRIPTION
Simplify code for `sx0_fixedParameters` by only including non-zero entries in switch statement.

For performance test model, this reduces file size from ~32MB to < 200KB and speeds up compilation:

* gcc (Ubuntu 9.3.0-17ubuntu1~20.04) 9.3.0

  `-O2`
  
  before: User time (seconds): **112.97**, Maximum resident set size (kbytes): **2502824**
  now: User time (seconds): **0.37**, Maximum resident set size (kbytes): **75636**

* icc (ICC) 19.0.5.281 20190815

    `-O3`

  before: killed after **5h**
  now: User time (seconds): **1.87**, Maximum resident set size (kbytes): 228984
 
Closes #1297 
