### PR TITLE
CI: Replace deprecated GHA ::set-env and ::add-path

### DIFF
--- a/.github/workflows/deploy_branch.yml
+++ b/.github/workflows/deploy_branch.yml
@@ -12,8 +12,8 @@ jobs:
       with:
         fetch-depth: 20
 
-    - run: echo "::set-env name=AMICI_DIR::$(pwd)"
-    - run: echo "::set-env name=SWIG::${AMICI_DIR}/ThirdParty/swig-4.0.1/install/bin/swig"
+    - run: echo "AMICI_DIR=$(pwd)" >> $GITHUB_ENV
+    - run: echo "SWIG=${AMICI_DIR}/ThirdParty/swig-4.0.1/install/bin/swig" >> $GITHUB_ENV
 
     - name: Build swig4
       run: |

--- a/.github/workflows/deploy_release.yml
+++ b/.github/workflows/deploy_release.yml
@@ -15,8 +15,8 @@ jobs:
       with:
         fetch-depth: 20
 
-    - run: echo "::set-env name=AMICI_DIR::$(pwd)"
-    - run: echo "::set-env name=SWIG::${AMICI_DIR}/ThirdParty/swig-4.0.1/install/bin/swig"
+    - run: echo "AMICI_DIR=$(pwd)" >> $GITHUB_ENV
+    - run: echo "SWIG=${AMICI_DIR}/ThirdParty/swig-4.0.1/install/bin/swig" >> $GITHUB_ENV
 
     - name: Build swig4
       run: |

--- a/.github/workflows/test_benchmark_collection_models.yml
+++ b/.github/workflows/test_benchmark_collection_models.yml
@@ -33,9 +33,10 @@ jobs:
         pip3 install --upgrade --user wheel \
           && pip3 install --upgrade --user setuptools
     - run: pip3 install pytest shyaml
-    - run: |
-        echo ::add-path::${HOME}/.local/bin/
-        echo ::add-path::${GITHUB_WORKSPACE}/tests/performance/
+
+    - run: echo "${HOME}/.local/bin/" >> $GITHUB_PATH
+    - run: echo "${GITHUB_WORKSPACE}/tests/performance/" >> $GITHUB_PATH
+
     # install AMICI
     - name: Create AMICI sdist
       run: |

--- a/.github/workflows/test_doc.yml
+++ b/.github/workflows/test_doc.yml
@@ -46,8 +46,8 @@ jobs:
       - uses: actions/checkout@master
       - run: git fetch --prune --unshallow
 
-      - run: echo "::set-env name=AMICI_DIR::$(pwd)"
-      - run: echo "::set-env name=SWIG::${AMICI_DIR}/ThirdParty/swig-4.0.1/install/bin/swig"
+      - run: echo "AMICI_DIR=$(pwd)" >> $GITHUB_ENV
+      - run: echo "SWIG=${AMICI_DIR}/ThirdParty/swig-4.0.1/install/bin/swig" >> $GITHUB_ENV
 
       - name: Build doxygen
         run: |

--- a/.github/workflows/test_install.yml
+++ b/.github/workflows/test_install.yml
@@ -11,7 +11,7 @@ jobs:
     - uses: actions/checkout@master
     - run: git fetch --prune --unshallow
 
-    - run: echo "::set-env name=AMICI_DIR::$(pwd)"
+    - run: echo "AMICI_DIR=$(pwd)" >> $GITHUB_ENV
 
     # install amici dependencies
     - name: apt
@@ -58,7 +58,7 @@ jobs:
     - uses: actions/checkout@master
     - run: git fetch --prune --unshallow
 
-    - run: echo "::set-env name=AMICI_DIR::$(pwd)"
+    - run: echo "AMICI_DIR=$(pwd)" >> $GITHUB_ENV
 
     # install amici dependencies
     - name: apt

--- a/.github/workflows/test_performance.yml
+++ b/.github/workflows/test_performance.yml
@@ -33,9 +33,10 @@ jobs:
         pip3 install --upgrade --user wheel \
           && pip3 install --upgrade --user setuptools
     - run: pip3 install petab shyaml
-    - run: |
-        echo ::add-path::${HOME}/.local/bin/
-        echo ::add-path::${GITHUB_WORKSPACE}/tests/performance/
+
+    - run: echo "${HOME}/.local/bin/" >> $GITHUB_PATH
+    - run: echo "${GITHUB_WORKSPACE}/tests/performance/" >> $GITHUB_PATH
+
     # install AMICI
     - name: Create AMICI sdist
       run: |

--- a/.github/workflows/test_petab_test_suite.yml
+++ b/.github/workflows/test_petab_test_suite.yml
@@ -46,9 +46,9 @@ jobs:
           scripts/buildBNGL.sh
 
       - run: |
-          echo ::add-path::${HOME}/.local/bin/
-          echo ::add-path::${GITHUB_WORKSPACE}/tests/performance/
-          echo ::set-env name=BNGPATH::${GITHUB_WORKSPACE}/ThirdParty/BioNetGen-2.3.2
+          echo "${HOME}/.local/bin/" >> $GITHUB_PATH
+          echo "${GITHUB_WORKSPACE}/tests/performance/" >> $GITHUB_PATH
+          echo "BNGPATH=${GITHUB_WORKSPACE}/ThirdParty/BioNetGen-2.3.2" >> $GITHUB_ENV
 
       # install AMICI
       - name: Install python package

--- a/.github/workflows/test_python_cplusplus.yml
+++ b/.github/workflows/test_python_cplusplus.yml
@@ -16,15 +16,15 @@ jobs:
     - uses: actions/checkout@master
     - run: git fetch --prune --unshallow
 
-    - run: echo "::set-env name=AMICI_DIR::$(pwd)"
-    - run: echo "::set-env name=BNGPATH::${AMICI_DIR}/ThirdParty/BioNetGen-2.3.2"
+    - run: echo "AMICI_DIR=$(pwd)" >> $GITHUB_ENV
+    - run: echo "BNGPATH=${GITHUB_WORKSPACE}/ThirdParty/BioNetGen-2.3.2" >> $GITHUB_ENV
 
     # sonar cloud
-    - run: echo "::set-env name=SONAR_SCANNER_VERSION::4.2.0.1873"
-    - run: echo "::set-env name=SONAR_SCANNER_HOME::$HOME/.sonar/sonar-scanner-$SONAR_SCANNER_VERSION-linux"
-    - run: echo "::set-env name=SONAR_SCANNER_OPTS::-server"
-    - run: echo "::add-path::${SONAR_SCANNER_HOME}/bin"
-    - run: echo "::add-path::$HOME/.sonar/build-wrapper-linux-x86"
+    - run: echo "SONAR_SCANNER_VERSION=4.2.0.1873" >> $GITHUB_ENV
+    - run: echo "SONAR_SCANNER_HOME=${HOME}/.sonar/sonar-scanner-$SONAR_SCANNER_VERSION-linux" >> $GITHUB_ENV
+    - run: echo "SONAR_SCANNER_OPTS=-server" >> $GITHUB_ENV
+    - run: echo "${SONAR_SCANNER_HOME}/bin" >> $GITHUB_PATH
+    - run: echo "${HOME}/.sonar/build-wrapper-linux-x86" >> $GITHUB_PATH
 
     # TODO: add to ci image
     - name: Install sonarcloud tools
@@ -129,8 +129,8 @@ jobs:
     - uses: actions/checkout@master
     - run: git fetch --prune --unshallow
 
-    - run: echo "::set-env name=AMICI_DIR::$(pwd)"
-    - run: echo "::set-env name=BNGPATH::${AMICI_DIR}/ThirdParty/BioNetGen-2.3.2"
+    - run: echo "AMICI_DIR=$(pwd)" >> $GITHUB_ENV
+    - run: echo "BNGPATH=${AMICI_DIR}/ThirdParty/BioNetGen-2.3.2" >> $GITHUB_ENV
 
     # install amici dependencies
     - name: homebrew

--- a/.github/workflows/test_python_ver_matrix.yml
+++ b/.github/workflows/test_python_ver_matrix.yml
@@ -24,8 +24,8 @@ jobs:
         python-version: [3.6, 3.7, 3.8, 3.9]
 
     steps:
-    - run: echo "::set-env name=AMICI_DIR::$(pwd)"
-    - run: echo "::set-env name=BNGPATH::${AMICI_DIR}/ThirdParty/BioNetGen-2.3.2"
+    - run: echo "AMICI_DIR=$(pwd)" >> $GITHUB_ENV
+    - run: echo "BNGPATH=${AMICI_DIR}/ThirdParty/BioNetGen-2.3.2" >> $GITHUB_ENV
 
     - name: Set up Python ${{ matrix.python-version }}
       uses: actions/setup-python@v2


### PR DESCRIPTION
https://github.blog/changelog/2020-10-01-github-actions-deprecating-set-env-and-add-path-commands/

Closes #1301 