### PR TITLE
iterable constant parameters for backwards compatibility

### DIFF
--- a/python/amici/sbml_import.py
+++ b/python/amici/sbml_import.py
@@ -193,7 +193,7 @@ class SbmlImporter:
                    model_name: str = None,
                    output_dir: str = None,
                    observables: Dict[str, Dict[str, str]] = None,
-                   constant_parameters: List[str] = None,
+                   constant_parameters: Iterable[str] = None,
                    sigmas: Dict[str, Union[str, float]] = None,
                    noise_distributions: Dict[str, Union[str, Callable]] = None,
                    verbose: Union[int, bool] = logging.ERROR,
@@ -287,6 +287,7 @@ class SbmlImporter:
 
         elif constant_parameters is None:
             constant_parameters = []
+        constant_parameters = list(constant_parameters)
 
         if sigmas is None:
             sigmas = {}


### PR DESCRIPTION
Cell 4 of the [pyPESTO AMICI import notebook](https://github.com/ICB-DCM/pyPESTO/blob/master/doc/example/amici_import.ipynb) has `constantParameters = {'ratio', 'specC17'}`. This results in an error related to adding a `set` to a `list` in [AMICI develop](https://github.com/AMICI-dev/AMICI/blob/develop/python/amici/sbml_import.py#L744). Wasn't sure whether to fix the notebook or do this PR, but this might save other users a little time.

Will merge into the SBML refactor PR branch. Can also merge directly into develop.