### PR TITLE
Raise minimum sympy version to 1.7.1

### DIFF
--- a/python/sdist/setup.py
+++ b/python/sdist/setup.py
@@ -200,7 +200,7 @@ def main():
                 'amici_import_petab.py = amici.petab_import:main'
             ]
         },
-        install_requires=['sympy>=1.6.0',
+        install_requires=['sympy>=1.7.1',
                           'python-libsbml',
                           'h5py',
                           'pandas',


### PR DESCRIPTION
Closes #1367

#1356 tried to remain compatible to sympy 1.6.* and 1.7.*, but failed for `_CXXCodePrinterBase` (`sympy.printing.cxx` vs. `sympy.printing.cxxcode`). I'd prefer to just raise the requirement instead of trying both modules.