### PR TITLE
Python: Add numpy minimum version requirements

### DIFF
--- a/python/sdist/pyproject.toml
+++ b/python/sdist/pyproject.toml
@@ -1,3 +1,17 @@
 [build-system]
-requires = ["setuptools>=40.6.3", "wheel", "numpy"]
+requires = [
+    "setuptools>=40.6.3",
+    "wheel",
+    # We pin numpy here to the lowest supported version to have
+    # ABI-compatibility with the numpy version in the runtime environment.
+    # There seems to be no easy way to require the numpy version from the
+    # runtime environment for the build requirement here. The only alternative
+    # would be pinning the setup.py numpy requirement to the same version as
+    # here, which we want to avoid.
+    # cf. discussion at https://github.com/numpy/numpy/issues/5888
+    # These requirements are taken from the h5py package, we depend on.
+    "numpy==1.14.5; python_version=='3.7'",
+    "numpy==1.17.5; python_version=='3.8'",
+    "numpy==1.19.3; python_version>='3.9'",
+]
 build-backend = "setuptools.build_meta"

--- a/python/sdist/setup.cfg
+++ b/python/sdist/setup.cfg
@@ -28,6 +28,9 @@ package_dir =
 python_requires = >=3.6
 install_requires =
     sympy>=1.7.1
+    numpy>=1.14.5; python_version=='3.7'
+    numpy>=1.17.5; python_version=='3.8'
+    numpy>=1.19.3; python_version>='3.9'
     python-libsbml
     h5py
     pandas


### PR DESCRIPTION
Should prevent errors like

```
RuntimeError: module compiled against API version 0xe but this version of numpy is 0xd
[...]
ImportError: numpy.core.multiarray failed to import
```