### PR TITLE
Fix Dockerfile: add python3-venv

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -7,6 +7,7 @@ RUN apt update \
     python3 \
     python3-dev \
     python3-pip \
+    python3-venv \
     swig
 
 COPY amici.tar.gz /tmp


### PR DESCRIPTION
Not sure what changed, but seems to be required now... https://github.com/AMICI-dev/AMICI/runs/1882360437?check_suite_focus=true