### PR TITLE
Fix: No context for inspect.getouterframes

### DIFF
--- a/python/amici/__init__.py
+++ b/python/amici/__init__.py
@@ -72,7 +72,7 @@ def _imported_from_setup() -> bool:
     # we are not interested in)
     package_root = os.path.realpath(os.path.dirname(os.path.dirname(__file__)))
 
-    for frame in getouterframes(currentframe()):
+    for frame in getouterframes(currentframe(), context=0):
         # Need to compare the full path, in case a user tries to import AMICI
         # from a module `*setup.py`. Will still cause trouble if some package
         # requires the AMICI extension during its installation, but seems


### PR DESCRIPTION
Same as #1348 