### PR TITLE
Sx0 in adjoint preequilibration

### DIFF
--- a/include/amici/rdata.h
+++ b/include/amici/rdata.h
@@ -618,10 +618,12 @@ class ReturnData: public ModelDimensions {
      * if preequilibration was run in adjoint mode
      * @param model model that was used for forward/backward simulation
      * @param preeq SteadystateProblem for preequilibration
+     * @param llhS0 contribution to likelihood for initial state sensitivities
+     * of preequilibration
      * @param xQB vector with quadratures from adjoint computation
      */
     void handleSx0Backward(const Model &model, SteadystateProblem const &preeq,
-                           AmiVector &xQB) const;
+                           std::vector<realtype> &llhS0, AmiVector &xQB) const;
 
     /**
      * @brief Updates contribution to likelihood for initial state sensitivities

--- a/include/amici/steadystateproblem.h
+++ b/include/amici/steadystateproblem.h
@@ -248,7 +248,6 @@ class SteadystateProblem {
         return x_;
     };
 
-
     /**
      * @brief Returns state sensitivity at steadystate
      * @return sx
@@ -322,6 +321,12 @@ class SteadystateProblem {
     void getAdjointUpdates(Model &model, const ExpData &edata);
 
     /**
+     * @brief Accessor for xB
+     * @return xB
+     */
+    AmiVector const& getAdjointState() const { return xB_; }
+
+    /**
      * @brief Accessor for xQB
      * @return xQB
      */
@@ -372,7 +377,7 @@ class SteadystateProblem {
     AmiVector xQ_;
     /** quadrature state vector */
     AmiVector xQB_;
-    /** quadrature state vector */
+    /** time-derivative of quadrature state vector */
     AmiVector xQBdot_;
 
     /** maximum number of steps for Newton solver for allocating numlinsteps */

--- a/include/amici/steadystateproblem.h
+++ b/include/amici/steadystateproblem.h
@@ -321,8 +321,8 @@ class SteadystateProblem {
     void getAdjointUpdates(Model &model, const ExpData &edata);
 
     /**
-     * @brief Accessor for xB
-     * @return xB
+     * @brief Return the adjoint state
+     * @return xB adjoint state
      */
     AmiVector const& getAdjointState() const { return xB_; }
 

--- a/src/rdata.cpp
+++ b/src/rdata.cpp
@@ -442,22 +442,22 @@ void ReturnData::handleSx0Backward(const Model &model,
        and so is the scalar product. Instead of the scalar product, the
        quadratures xQB from preequilibration contribute to the gradient
        (see example notebook on equilibration for further documentation). */
-    auto xQBpreeq = preeq.getAdjointQuadrature();
+    const auto &xQBpreeq = preeq.getAdjointQuadrature();
     for (int ip = 0; ip < model.nplist(); ++ip)
-        xQB[ip] += xQBpreeq[ip];
+        xQB[ip] += xQBpreeq.at(ip);
 
     /* Prefer explicit type declaration here, since this MUST be a reference
      * (for memory reasons), rather than passing this thing by value */
-    const AmiVectorArray &sx0preeq = preeq.getStateSensitivity();
+    const auto& sx0preeq = preeq.getStateSensitivity();
     const auto& xBpreeq = preeq.getAdjointState();
 
     /* Add the contribution for sx0 from preequilibration. If backward
      * preequilibration was done by simulation due to a singular Jacobian,
-     * xB is not necessarily 0 and we get a non-zero contribution here. */
+     * xB is not necessarily 0 and we may get a non-zero contribution here. */
     for (int ip = 0; ip < model.nplist(); ++ip) {
         llhS0[ip] = 0.0;
         for (int ix = 0; ix < model.nxtrue_solver; ++ix) {
-            llhS0[ip] += xBpreeq[ix] * sx0preeq.at(ix, ip);
+            llhS0[ip] += xBpreeq.at(ix) * sx0preeq.at(ix, ip);
         }
     }
 }

--- a/src/rdata.cpp
+++ b/src/rdata.cpp
@@ -457,7 +457,7 @@ void ReturnData::handleSx0Backward(const Model &model,
     for (int ip = 0; ip < model.nplist(); ++ip) {
         llhS0[ip] = 0.0;
         for (int ix = 0; ix < model.nxtrue_solver; ++ix) {
-            llhS0[ip] += xB[ix] * sx0preeq.at(ix, ip);
+            llhS0[ip] += xBpreeq[ix] * sx0preeq.at(ix, ip);
         }
     }
 }

--- a/src/rdata.cpp
+++ b/src/rdata.cpp
@@ -453,7 +453,7 @@ void ReturnData::handleSx0Backward(const Model &model,
 
     /* Add the contribution for sx0 from preequilibration. If backward
      * preequilibration was done by simulation due to a singular Jacobian,
-     * xB does not need to be 0 and we get a non-zero contribution here. */
+     * xB is not necessarily 0 and we get a non-zero contribution here. */
     for (int ip = 0; ip < model.nplist(); ++ip) {
         llhS0[ip] = 0.0;
         for (int ix = 0; ix < model.nxtrue_solver; ++ix) {

--- a/src/rdata.cpp
+++ b/src/rdata.cpp
@@ -446,8 +446,7 @@ void ReturnData::handleSx0Backward(const Model &model,
     for (int ip = 0; ip < model.nplist(); ++ip)
         xQB[ip] += xQBpreeq.at(ip);
 
-    /* Prefer explicit type declaration here, since this MUST be a reference
-     * (for memory reasons), rather than passing this thing by value */
+    /* We really need references here, as sx0 can be large... */
     const auto& sx0preeq = preeq.getStateSensitivity();
     const auto& xBpreeq = preeq.getAdjointState();
 

--- a/src/rdata.cpp
+++ b/src/rdata.cpp
@@ -449,7 +449,7 @@ void ReturnData::handleSx0Backward(const Model &model,
     /* Prefer explicit type declaration here, since this MUST be a reference
      * (for memory reasons), rather than passing this thing by value */
     const AmiVectorArray &sx0preeq = preeq.getStateSensitivity();
-    auto xBpreeq = preeq.getAdjointState();
+    const auto& xBpreeq = preeq.getAdjointState();
 
     /* Add the contribution for sx0 from preequilibration. If backward
      * preequilibration was done by simulation due to a singular Jacobian,

--- a/src/steadystateproblem.cpp
+++ b/src/steadystateproblem.cpp
@@ -101,9 +101,6 @@ void SteadystateProblem::workSteadyStateBackwardProblem(Solver *solver,
     clock_t starttime = clock();
     computeSteadyStateQuadrature(newtonSolver.get(), solver, model);
     cpu_timeB_ = (double)((clock() - starttime) * 1000) / CLOCKS_PER_SEC;
-
-    /* Finalize by setting adjoint state to zero (its steady state) */
-    xB_.zero();
 }
 
 void SteadystateProblem::findSteadyState(Solver *solver,
@@ -288,6 +285,9 @@ void SteadystateProblem::getQuadratureByLinSolve(NewtonSolver *newtonSolver,
     } catch (NewtonFailure const &) {
         hasQuadrature_ = false;
     }
+
+    /* Finalize by setting adjoint state to zero (its steady state) */
+    xB_.zero();
 }
 
 void SteadystateProblem::getQuadratureBySimulation(const Solver *solver,

--- a/src/steadystateproblem.cpp
+++ b/src/steadystateproblem.cpp
@@ -282,12 +282,12 @@ void SteadystateProblem::getQuadratureByLinSolve(NewtonSolver *newtonSolver,
         computeQBfromQ(model, xQ_, xQB_);
         /* set flag that quadratures is available (for processing in rdata) */
         hasQuadrature_ = true;
+        
+        /* Finalize by setting adjoint state to zero (its steady state) */
+        xB_.zero();
     } catch (NewtonFailure const &) {
         hasQuadrature_ = false;
     }
-
-    /* Finalize by setting adjoint state to zero (its steady state) */
-    xB_.zero();
 }
 
 void SteadystateProblem::getQuadratureBySimulation(const Solver *solver,


### PR DESCRIPTION
If adjoint preequllibraiton was not solved algebraically but via integration, there may be a contribution from sx0 * xB, as xB may be != 0 for singular Jacobians... So we may get a non-trivial contribution here. This PR tries to fix that...