### PR TITLE
Add residuals for quadratic nllhs with parameter dependent sigma

### DIFF
--- a/include/amici/model.h
+++ b/include/amici/model.h
@@ -648,7 +648,7 @@ class Model : public AbstractModel, public ModelDimensions {
      * activated, this lower boundary must ensure that log(sigma) + min_sigma > 0.
      * @param min_sigma lower boundary
      */
-    void setMinimumSigmaResiduals(float min_sigma) {
+    void setMinimumSigmaResiduals(double min_sigma) {
         min_sigma_ = min_sigma;
     }
     
@@ -662,7 +662,8 @@ class Model : public AbstractModel, public ModelDimensions {
     
     /**
      * @brief Specifies whether residuals should be added to account for parameter dependent sigma.
-     * If set to true, additional residuals of the form `sqrt{log(\sigma) + C}` will be added. This enables
+     *
+     * If set to true, additional residuals of the form \f[ \sqrt{\log(\sigma) + C} \f] will be added. This enables
      * least-squares optimization for variables with Gaussian noise assumption and parameter dependent
      * standard deviation sigma. The constant C can be set via :meth:`setMinimumSigmaResiduals`.
      * @param sigma_res if true, additional residuals are added

--- a/include/amici/model.h
+++ b/include/amici/model.h
@@ -666,6 +666,7 @@ class Model : public AbstractModel, public ModelDimensions {
      * If set to true, additional residuals of the form \f[ \sqrt{\log(\sigma) + C} \f] will be added. This enables
      * least-squares optimization for variables with Gaussian noise assumption and parameter dependent
      * standard deviation sigma. The constant C can be set via :meth:`setMinimumSigmaResiduals`.
+     *
      * @param sigma_res if true, additional residuals are added
      */
     void setAddSigmaResiduals(bool sigma_res) {

--- a/include/amici/model.h
+++ b/include/amici/model.h
@@ -1742,7 +1742,7 @@ class Model : public AbstractModel, public ModelDimensions {
      */
     bool always_check_finite_ {false};
     
-    /** indicates whether sigma residuals are to be added for every  */
+    /** indicates whether sigma residuals are to be added for every datapoint  */
     bool sigma_res_ {false};
     
     /** offset to ensure positivity of sigma residuals, only has an effect when `sigma_res_` is `true`  */

--- a/include/amici/model.h
+++ b/include/amici/model.h
@@ -662,7 +662,7 @@ class Model : public AbstractModel, public ModelDimensions {
     
     /**
      * @brief Specifies whether residuals should be added to account for parameter dependent sigma.
-     * If set to true, additional residuals of the form :math:`\sqrt{log(\sigma) + C} will be added. This enables
+     * If set to true, additional residuals of the form :math:`\sqrt{log(\sigma) + C}` will be added. This enables
      * least-squares optimization for variables with Gaussian noise assumption and parameter dependent
      * standard deviation sigma. The constant C can be set via :meth:`setMinimumSigmaResiduals`.
      * @param sigma_res if true, additional residuals are added

--- a/include/amici/model.h
+++ b/include/amici/model.h
@@ -645,7 +645,7 @@ class Model : public AbstractModel, public ModelDimensions {
     
     /**
      * @brief Sets the estimated lower boundary for sigma_y. When :meth:`setAddSigmaResiduals` is
-     * activated, this lower boundary must ensure that log(sigma) > min_sigma.
+     * activated, this lower boundary must ensure that log(sigma) + min_sigma > 0.
      * @param min_sigma lower boundary
      */
     void setMinimumSigmaResiduals(float min_sigma) {
@@ -662,7 +662,7 @@ class Model : public AbstractModel, public ModelDimensions {
     
     /**
      * @brief Specifies whether residuals should be added to account for parameter dependent sigma.
-     * If set to true, additional residuals of the form :math:`\sqrt{\sigma - C} will be added. This enables
+     * If set to true, additional residuals of the form :math:`\sqrt{log(\sigma) + C} will be added. This enables
      * least-squares optimization for variables with Gaussian noise assumption and parameter dependent
      * standard deviation sigma. The constant C can be set via :meth:`setMinimumSigmaResiduals`.
      * @param sigma_res if true, additional residuals are added

--- a/include/amici/model.h
+++ b/include/amici/model.h
@@ -642,6 +642,42 @@ class Model : public AbstractModel, public ModelDimensions {
             throw AmiException("Mismatch in conservation law sensitivity size");
         state_ = state;
     };
+    
+    /**
+     * @brief Sets the estimated lower boundary for sigma_y. When :meth:`setAddSigmaResiduals` is
+     * activated, this lower boundary must ensure that log(sigma) > min_sigma.
+     * @param min_sigma lower boundary
+     */
+    void setMinimumSigmaResiduals(float min_sigma) {
+        min_sigma_ = min_sigma;
+    }
+    
+    /**
+     * @brief Gets the specified estimated lower boundary for sigma_y.
+     * @return lower boundary
+     */
+    realtype getMinimumSigmaResiduals() const {
+        return min_sigma_;
+    }
+    
+    /**
+     * @brief Specifies whether residuals should be added to account for parameter dependent sigma.
+     * If set to true, additional residuals of the form :math:`\sqrt{\sigma - C} will be added. This enables
+     * least-squares optimization for variables with Gaussian noise assumption and parameter dependent
+     * standard deviation sigma. The constant C can be set via :meth:`setMinimumSigmaResiduals`.
+     * @param sigma_res if true, additional residuals are added
+     */
+    void setAddSigmaResiduals(bool sigma_res) {
+        sigma_res_ = sigma_res;
+    }
+    
+    /**
+     * @brief Checks whether residuals should be added to account for parameter dependent sigma.
+     * @return sigma_res
+     */
+    bool getAddSigmaResiduals() const {
+        return sigma_res_;
+    }
 
     /**
      * @brief Get the list of parameters for which sensitivities are computed.
@@ -1704,6 +1740,11 @@ class Model : public AbstractModel, public ModelDimensions {
      * checked for finiteness
      */
     bool always_check_finite_ {false};
+    
+    /** indicates whether sigma residuals are to be added for every  */
+    bool sigma_res_ {false};
+    
+    realtype min_sigma_ {50.0};
 
   private:
     /** Sparse dwdp implicit temporary storage (shape `ndwdp`) */

--- a/include/amici/model.h
+++ b/include/amici/model.h
@@ -663,9 +663,10 @@ class Model : public AbstractModel, public ModelDimensions {
     /**
      * @brief Specifies whether residuals should be added to account for parameter dependent sigma.
      *
-     * If set to true, additional residuals of the form \f[ \sqrt{\log(\sigma) + C} \f] will be added. This enables
-     * least-squares optimization for variables with Gaussian noise assumption and parameter dependent
-     * standard deviation sigma. The constant C can be set via :meth:`setMinimumSigmaResiduals`.
+     * If set to true, additional residuals of the form \f$ \sqrt{\log(\sigma) + C} \f$ will be added.
+     * This enables least-squares optimization for variables with Gaussian noise assumption and parameter
+     * dependent standard deviation sigma. The constant \f$ C \f$ can be set via
+     * :meth:`setMinimumSigmaResiduals`.
      *
      * @param sigma_res if true, additional residuals are added
      */
@@ -805,7 +806,7 @@ class Model : public AbstractModel, public ModelDimensions {
     /**
      * @brief Get sensitivity of time-resolved observables.
      *
-     * Total derivative \f$sy = dydx * sx + dydp\f$
+     * Total derivative \f$ sy = dydx * sx + dydp\f$
      * (only for forward sensitivities).
      * @param sy buffer (shape `ny` x `nplist`, row-major)
      * @param t Timpoint
@@ -839,7 +840,7 @@ class Model : public AbstractModel, public ModelDimensions {
                                        const int it, const ExpData *edata);
 
     /**
-     * @brief Add time-resolved measurement negative log-likelihood \f$Jy\f$.
+     * @brief Add time-resolved measurement negative log-likelihood \f$ Jy \f$.
      * @param Jy Buffer (shape 1)
      * @param it Timepoint index
      * @param x State variables
@@ -850,7 +851,7 @@ class Model : public AbstractModel, public ModelDimensions {
 
     /**
      * @brief Add sensitivity of time-resolved measurement negative log-likelihood
-     * \f$Jy\f$.
+     * \f$ Jy \f$.
      *
      * @param sllh First-order buffer (shape `nplist`)
      * @param s2llh Second-order buffer (shape `nJ - 1` x `nplist`, row-major)
@@ -867,7 +868,7 @@ class Model : public AbstractModel, public ModelDimensions {
 
     /**
      * @brief Add sensitivity of time-resolved measurement negative
-     * log-likelihood \f$Jy\f$.
+     * log-likelihood \f$ Jy \f$.
      *
      * Partial derivative (to be used with adjoint sensitivities).
      *
@@ -885,7 +886,7 @@ class Model : public AbstractModel, public ModelDimensions {
                                                   const ExpData &edata);
 
     /**
-     * @brief Get state sensitivity of the negative loglikelihood \f$Jy\f$,
+     * @brief Get state sensitivity of the negative loglikelihood \f$ Jy \f$,
      * partial derivative (to be used with adjoint sensitivities).
      *
      * @param dJydx Output buffer (shape `nJ` x `nx_solver`, row-major)
@@ -1016,7 +1017,7 @@ class Model : public AbstractModel, public ModelDimensions {
 
     /**
      * @brief Add sensitivity of time-resolved measurement negative
-     * log-likelihood \f$Jy\f$.
+     * log-likelihood \f$ Jy \f$.
      *
      * Total derivative (to be used with forward sensitivities).
      *
@@ -1039,7 +1040,7 @@ class Model : public AbstractModel, public ModelDimensions {
 
     /**
      * @brief Add sensitivity of time-resolved measurement negative
-     * log-likelihood \f$Jy\f$.
+     * log-likelihood \f$ Jy \f$.
      *
      * Partial derivative (to be used with adjoint sensitivities).
      *
@@ -1060,7 +1061,7 @@ class Model : public AbstractModel, public ModelDimensions {
                                              const ExpData &edata);
 
     /**
-     * @brief State sensitivity of the negative loglikelihood \f$Jz\f$.
+     * @brief State sensitivity of the negative loglikelihood \f$ Jz \f$.
      *
      * Partial derivative (to be used with adjoint sensitivities).
      *
@@ -1343,7 +1344,7 @@ class Model : public AbstractModel, public ModelDimensions {
     void fy(realtype t, const AmiVector &x);
 
     /**
-     * @brief Compute partial derivative of observables \f$y\f$ w.r.t. model
+     * @brief Compute partial derivative of observables \f$ y \f$ w.r.t. model
      * parameters `p`.
      * @param t Current timepoint
      * @param x Current state
@@ -1351,7 +1352,7 @@ class Model : public AbstractModel, public ModelDimensions {
     void fdydp(realtype t, const AmiVector &x);
 
     /**
-     * @brief Compute partial derivative of observables \f$y\f$ w.r.t. state
+     * @brief Compute partial derivative of observables \f$ y \f$ w.r.t. state
      * variables `x`.
      * @param t Current timepoint
      * @param x Current state
@@ -1374,7 +1375,7 @@ class Model : public AbstractModel, public ModelDimensions {
     void fdsigmaydp(int it, const ExpData *edata);
 
     /**
-     * @brief Compute negative log-likelihood of measurements \f$y\f$.
+     * @brief Compute negative log-likelihood of measurements \f$ y \f$.
      *
      * @param Jy Variable to which llh will be added
      * @param it Timepoint index
@@ -1385,7 +1386,7 @@ class Model : public AbstractModel, public ModelDimensions {
 
     /**
      * @brief Compute partial derivative of time-resolved measurement negative
-     * log-likelihood \f$Jy\f$.
+     * log-likelihood \f$ Jy \f$.
      * @param it timepoint index
      * @param x state variables
      * @param edata Pointer to experimental data
@@ -1403,7 +1404,7 @@ class Model : public AbstractModel, public ModelDimensions {
 
     /**
      * @brief Compute sensitivity of time-resolved measurement negative
-     * log-likelihood \f$Jy\f$ w.r.t. parameters for the given timepoint.
+     * log-likelihood \f$ Jy \f$ w.r.t. parameters for the given timepoint.
      * @param it timepoint index
      * @param x state variables
      * @param edata pointer to experimental data instance
@@ -1412,7 +1413,7 @@ class Model : public AbstractModel, public ModelDimensions {
 
     /**
      * @brief Sensitivity of time-resolved measurement negative log-likelihood
-     * \f$Jy\f$ w.r.t. state variables.
+     * \f$ Jy \f$ w.r.t. state variables.
      * @param it Timepoint index
      * @param x State variables
      * @param edata Pointer to experimental data instance
@@ -1466,7 +1467,7 @@ class Model : public AbstractModel, public ModelDimensions {
     void fdrzdp(int ie, realtype t, const AmiVector &x);
 
     /**
-     * @brief Compute sensitivity of event-resolved measurements \f$rz\f$ w.r.t.
+     * @brief Compute sensitivity of event-resolved measurements \f$ rz \f$ w.r.t.
      * model states `x`.
      * @param ie Event index
      * @param t Current timepoint
@@ -1507,7 +1508,7 @@ class Model : public AbstractModel, public ModelDimensions {
 
     /**
      * @brief Compute partial derivative of event measurement negative
-     * log-likelihood \f$Jz\f$.
+     * log-likelihood \f$ Jz \f$.
      * @param ie Event index
      * @param nroots Event index
      * @param t Current timepoint
@@ -1519,7 +1520,7 @@ class Model : public AbstractModel, public ModelDimensions {
 
     /**
      * @brief Compute sensitivity of event measurement negative log-likelihood
-     * \f$Jz\f$ w.r.t. standard deviation sigmaz.
+     * \f$ Jz \f$ w.r.t. standard deviation sigmaz.
      * @param ie Event index
      * @param nroots Event index
      * @param t Current timepoint

--- a/include/amici/model.h
+++ b/include/amici/model.h
@@ -662,7 +662,7 @@ class Model : public AbstractModel, public ModelDimensions {
     
     /**
      * @brief Specifies whether residuals should be added to account for parameter dependent sigma.
-     * If set to true, additional residuals of the form :math:`\sqrt{log(\sigma) + C}` will be added. This enables
+     * If set to true, additional residuals of the form `sqrt{log(\sigma) + C}` will be added. This enables
      * least-squares optimization for variables with Gaussian noise assumption and parameter dependent
      * standard deviation sigma. The constant C can be set via :meth:`setMinimumSigmaResiduals`.
      * @param sigma_res if true, additional residuals are added
@@ -1744,6 +1744,7 @@ class Model : public AbstractModel, public ModelDimensions {
     /** indicates whether sigma residuals are to be added for every  */
     bool sigma_res_ {false};
     
+    /** offset to ensure positivity of sigma residuals, only has an effect when `sigma_res_` is `true`  */
     realtype min_sigma_ {50.0};
 
   private:

--- a/include/amici/rdata.h
+++ b/include/amici/rdata.h
@@ -54,6 +54,7 @@ class ReturnData: public ModelDimensions {
      * @param quadratic_llh whether model defines a quadratic nllh and
      * computing res, sres and FIM makes sense
      * @param sigma_res indicates whether additional residuals are to be added for each sigma
+     * @param sigma_offset offset to ensure real-valuedness of sigma residuals
      */
     ReturnData(std::vector<realtype> ts,
                ModelDimensions const& model_dimensions,

--- a/include/amici/rdata.h
+++ b/include/amici/rdata.h
@@ -53,6 +53,7 @@ class ReturnData: public ModelDimensions {
      * @param rdrm see amici::Solver::rdata_reporting
      * @param quadratic_llh whether model defines a quadratic nllh and
      * computing res, sres and FIM makes sense
+     * @param sigma_res indicates whether additional residuals are to be added for each sigma
      */
     ReturnData(std::vector<realtype> ts,
                ModelDimensions const& model_dimensions,
@@ -60,7 +61,8 @@ class ReturnData: public ModelDimensions {
                int newton_maxsteps,
                std::vector<ParameterScaling> pscale, SecondOrderMode o2mode,
                SensitivityOrder sensi, SensitivityMethod sensi_meth,
-               RDataReporting rdrm, bool quadratic_llh);
+               RDataReporting rdrm, bool quadratic_llh, bool sigma_res,
+               realtype sigma_offset);
 
     /**
      * @brief constructor that uses information from model and solver to
@@ -372,9 +374,15 @@ class ReturnData: public ModelDimensions {
     template <class Archive>
     friend void boost::serialization::serialize(Archive &ar, ReturnData &r,
                                                 unsigned int version);
+    
+    /** boolean indicating whether residuals for standard deviations have been added */
+    bool sigma_res;
 
   protected:
-
+    
+    /** offset for sigma_residuals */
+    realtype sigma_offset;
+    
     /** timepoint for model evaluation*/
     realtype t_;
 
@@ -517,8 +525,9 @@ class ReturnData: public ModelDimensions {
     /**
      * @brief Chi-squared function
      * @param it time index
+     * @param edata ExpData instance containing observable data
      */
-    void fchi2(int it);
+    void fchi2(int it, const ExpData &edata);
 
     /**
      * @brief Residual sensitivity function

--- a/python/amici/gradient_check.py
+++ b/python/amici/gradient_check.py
@@ -196,18 +196,18 @@ def check_derivatives(model: Model,
 
     if 'ssigmay' in rdata.keys() \
             and rdata['ssigmay'] is not None \
-            and rdata['ssigmay'].any():
+            and rdata['ssigmay'].any() and not model.getAddSigmaResiduals():
         leastsquares_applicable = False
 
     if check_least_squares and leastsquares_applicable:
         fields += ['res', 'y']
 
         check_results(rdata, 'FIM',
-                      np.dot(rdata['sres'].transpose(), rdata['sres']),
+                      np.dot(rdata['sres'].T, rdata['sres']),
                       assert_fun,
                       1e-8, 1e-4)
         check_results(rdata, 'sllh',
-                      -np.dot(rdata['res'].transpose(), rdata['sres']),
+                      -np.dot(rdata['res'].T, rdata['sres']),
                       assert_fun,
                       1e-8, 1e-4)
     for ip, pval in enumerate(p):

--- a/python/amici/numpy.py
+++ b/python/amici/numpy.py
@@ -195,8 +195,10 @@ class ReturnDataView(SwigPtrView):
             'sllh': [rdata.nplist],
             's2llh': [rdata.np, rdata.nplist],
 
-            'res': [rdata.nt * rdata.nytrue],
-            'sres': [rdata.nt * rdata.nytrue, rdata.nplist],
+            'res': [rdata.nt * rdata.nytrue *
+                    (2 if rdata.sigma_res else 1)],
+            'sres': [rdata.nt * rdata.nytrue *
+                     (2 if rdata.sigma_res else 1), rdata.nplist],
             'FIM': [rdata.nplist, rdata.nplist],
 
             # diagnosis

--- a/python/amici/parameter_mapping.py
+++ b/python/amici/parameter_mapping.py
@@ -238,9 +238,8 @@ def fill_in_parameters_for_condition(
 
     # plist
     plist = [
-        amici_model.getParameterIds().index(name)
-        for name, val in parameter_mapping.map_sim_var.items()
-        if not isinstance(val, numbers.Number)
+        ip for ip, par_id in enumerate(amici_model.getParameterIds())
+        if isinstance(parameter_mapping.map_sim_var[par_id], str)
     ]
 
     if parameters:

--- a/python/tests/test_pregenerated_models.py
+++ b/python/tests/test_pregenerated_models.py
@@ -181,6 +181,7 @@ def test_pregenerated_model(sub_test, case):
 
         model.setMinimumSigmaResiduals(-10)
         rdata = amici.runAmiciSimulation(model, solver, edata)
+        # check whether having a bad minimum results in nan chi2
         assert np.isnan(rdata.chi2)
 
     with pytest.raises(RuntimeError):

--- a/python/tests/test_pregenerated_models.py
+++ b/python/tests/test_pregenerated_models.py
@@ -13,7 +13,7 @@ import numpy as np
 
 
 options_file = os.path.join(os.path.dirname(__file__), '..', '..',
-                                     'tests', 'cpputest', 'testOptions.h5')
+                            'tests', 'cpputest', 'testOptions.h5')
 expected_results_file = os.path.join(os.path.dirname(__file__), '..', '..',
                                      'tests', 'cpputest', 'expectedResults.h5')
 expected_results = h5py.File(expected_results_file, 'r')

--- a/src/rdata.cpp
+++ b/src/rdata.cpp
@@ -11,6 +11,7 @@
 #include "amici/symbolic_functions.h"
 
 #include <cstring>
+#include <cmath>
 
 namespace amici {
 
@@ -21,8 +22,9 @@ ReturnData::ReturnData(Solver const &solver, const Model &model)
                  solver.getNewtonMaxSteps(),
                  model.getParameterScale(), model.o2mode,
                  solver.getSensitivityOrder(), solver.getSensitivityMethod(),
-                 solver.getReturnDataReportingMode(), model.hasQuadraticLLH()) {
-}
+                 solver.getReturnDataReportingMode(), model.hasQuadraticLLH(),
+                 model.getAddSigmaResiduals(),
+                 model.getMinimumSigmaResiduals()) {}
 
 ReturnData::ReturnData(std::vector<realtype> ts,
                        ModelDimensions const& model_dimensions,
@@ -31,12 +33,14 @@ ReturnData::ReturnData(std::vector<realtype> ts,
                        std::vector<ParameterScaling> pscale,
                        SecondOrderMode o2mode, SensitivityOrder sensi,
                        SensitivityMethod sensi_meth, RDataReporting rdrm,
-                       bool quadratic_llh)
+                       bool quadratic_llh, bool sigma_res,
+                       realtype sigma_offset)
     : ModelDimensions(model_dimensions), ts(std::move(ts)), nx(nx_rdata),
       nxtrue(nxtrue_rdata), nplist(nplist),
       nmaxevent(nmaxevent), nt(nt), newton_maxsteps(newton_maxsteps),
       pscale(std::move(pscale)), o2mode(o2mode), sensi(sensi),
-      sensi_meth(sensi_meth), rdata_reporting(rdrm), x_solver_(nx_solver),
+      sensi_meth(sensi_meth), rdata_reporting(rdrm), sigma_res(sigma_res),
+      sigma_offset(sigma_offset), x_solver_(nx_solver),
       sx_solver_(nx_solver, nplist), x_rdata_(nx), sx_rdata_(nx, nplist),
       nroots_(ne) {
     switch (rdata_reporting) {
@@ -72,7 +76,8 @@ void ReturnData::initializeResidualReporting(bool enable_res) {
     y.resize(nt * ny, 0.0);
     sigmay.resize(nt * ny, 0.0);
     if (enable_res)
-        res.resize(nt * nytrue, 0.0);
+        res.resize((sigma_res ? 2 : 1) * nt * nytrue, 0.0);
+
     if ((sensi_meth == SensitivityMethod::forward &&
          sensi >= SensitivityOrder::first)
         || sensi >= SensitivityOrder::second) {
@@ -80,7 +85,7 @@ void ReturnData::initializeResidualReporting(bool enable_res) {
         sy.resize(nt * ny * nplist, 0.0);
         ssigmay.resize(nt * ny * nplist, 0.0);
         if (enable_res)
-            sres.resize(nt * nytrue * nplist, 0.0);
+            sres.resize((sigma_res ? 2 : 1) * nt * nytrue * nplist, 0.0);
     }
 }
 
@@ -293,7 +298,7 @@ void ReturnData::getDataOutput(int it, Model &model, ExpData const *edata) {
         if (!isNaN(llh))
             model.addObservableObjective(llh, it, x_solver_, *edata);
         fres(it, model, *edata);
-        fchi2(it);
+        fchi2(it, *edata);
     }
 
     if (sensi >= SensitivityOrder::first && nplist > 0) {
@@ -664,9 +669,10 @@ void ReturnData::applyChainRuleFactorToSimulationResults(const Model &model) {
 
 
         if (!sres.empty())
-            for (int iyt = 0; iyt < nytrue * nt; ++iyt)
+            for (int ires = 0; ires < static_cast<int>(res.size()); ++ires)
                 for (int ip = 0; ip < nplist; ++ip)
-                    sres.at((iyt * nplist + ip)) *= pcoefficient.at(ip);
+                    sres.at((ires * nplist + ip)) *= pcoefficient.at(ip);
+
 
         if(!FIM.empty())
             for (int ip = 0; ip < nplist; ++ip)
@@ -797,16 +803,21 @@ void ReturnData::fres(const int it, Model &model, const ExpData &edata) {
             continue;
         res.at(iyt) = amici::fres(y_it.at(iy), observedData[iy],
                                   sigmay_it.at(iy));
+        if (sigma_res)
+            res.at(iyt + nt * nytrue) = sqrt(
+                amici::fres(log(sigmay_it.at(iy)), -sigma_offset, 1.0));
     }
 }
 
-void ReturnData::fchi2(const int it) {
+void ReturnData::fchi2(const int it, const ExpData &edata) {
     if (res.empty() || isNaN(chi2))
         return;
 
     for (int iy = 0; iy < nytrue; ++iy) {
         int iyt_true = iy + it * nytrue;
         chi2 += pow(res.at(iyt_true), 2);
+        if (sigma_res && edata.isSetObservedData(it, iy))
+            chi2 += pow(res.at(iyt_true + nt * nytrue), 2) - sigma_offset;
     }
 }
 
@@ -833,6 +844,15 @@ void ReturnData::fsres(const int it, Model &model, const ExpData &edata) {
             sres.at(idx) = amici::fsres(y_it.at(iy), sy_it.at(iy + ny * ip),
                                         observedData[iy], sigmay_it.at(iy),
                                         ssigmay_it.at(iy + ny * ip));
+            if (sigma_res) {
+                int idx_res =
+                    (iy + it * edata.nytrue() + edata.nytrue() * edata.nt()) *
+                        nplist + ip;
+                sres.at(idx_res) =
+                    amici::fsres(log(sigmay_it.at(iy)),
+                                 ssigmay_it.at(iy + ny * ip) / sigmay_it.at(iy),
+                                 sigma_offset, 1.0, 0.0);
+            }
         }
     }
 }
@@ -917,11 +937,19 @@ void ReturnData::fFIM(int it, Model &model, const ExpData &edata) {
             auto dy_i = sy_it.at(iy + ny * ip);
             auto ds_i = ssigmay_it.at(iy + ny * ip);
             auto sr_i = amici::fsres(y, dy_i, m, s, ds_i);
+            realtype sre_i;
+            if (sigma_res)
+                sre_i = amici::fsres(log(s), ds_i/s, -sigma_offset, 1.0, 0.0);
             for (int jp = 0; jp < nplist; ++jp) {
                 auto dy_j = sy_it.at(iy + ny * jp);
                 auto ds_j = ssigmay_it.at(iy + ny * jp);
                 auto sr_j = amici::fsres(y, dy_j, m, s, ds_j);
                 FIM.at(ip + nplist * jp) += sr_i*sr_j;
+                if (sigma_res) {
+                    auto sre_j = amici::fsres(log(s), ds_j / s,
+                                              -sigma_offset, 1.0, 0.0);
+                    FIM.at(ip + nplist * jp) += sre_i * sre_j;
+                }
                 /*+ ds_i*ds_j*(2*pow(r/pow(s,2.0), 2.0) - 1/pow(s,2.0));*/
             }
         }

--- a/src/rdata.cpp
+++ b/src/rdata.cpp
@@ -782,7 +782,7 @@ static realtype fres(realtype y, realtype my, realtype sigma_y) {
 }
 
 static realtype fres_error(realtype sigma_y, realtype sigma_offset) {
-    return sqrt(log(sigma_y) + sigma_offset);
+    return sqrt(2*log(sigma_y) + sigma_offset);
 }
 
 void ReturnData::fres(const int it, Model &model, const ExpData &edata) {
@@ -827,7 +827,7 @@ static realtype fsres(realtype y, realtype sy, realtype my,
 
 static realtype fsres_error(realtype sigma_y, realtype ssigma_y,
                             realtype sigma_offset) {
-    return 0.5 * ssigma_y / ( fres_error(sigma_y, sigma_offset) * sigma_y);
+    return ssigma_y / ( fres_error(sigma_y, sigma_offset) * sigma_y);
 }
 
 


### PR DESCRIPTION
default `min_sigma_ = 50` corresponds to d2d default. This enables optimization of respective objective functions using least squares optimizers, but also allows changing the FIM accordingly, which is then used in trust region optimizers.