### PR TITLE
Doc: Update OpenBLAS Windows installation instructions

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -231,14 +231,14 @@ This will download openBLAS and compile it, creating
 You will also need to define two environment variables:
 
     BLAS_LIBS="/LIBPATH:C:/BLAS/lib openblas.lib"
-    BLAS_CFLAGS="/IC:/BLAS/OpenBLAS-v0.3.12/OpenBLAS-0.3.12"
+    BLAS_CFLAGS="/IC:/BLAS/OpenBLAS-0.3.12/OpenBLAS-0.3.12"
     
 One way to do that is to run a PowerShell script with the following commands:
 
-    [System.Environment]::SetEnvironmentVariable("BLAS_LIBS", "/LIBPATH:C:\BLAS\lib openblas.lib", [System.EnvironmentVariableTarget]::User)
-    [System.Environment]::SetEnvironmentVariable("BLAS_LIBS", "/LIBPATH:C:\BLAS\lib openblas.lib", [System.EnvironmentVariableTarget]::Process)
-    [System.Environment]::SetEnvironmentVariable("BLAS_CFLAGS", "-IC:\BLAS\OpenBLAS-v0.3.12\OpenBLAS-0.3.12", [System.EnvironmentVariableTarget]::User)
-    [System.Environment]::SetEnvironmentVariable("BLAS_CFLAGS", "-IC:\BLAS\OpenBLAS-v0.3.12\OpenBLAS-0.3.12", [System.EnvironmentVariableTarget]::Process)
+    [System.Environment]::SetEnvironmentVariable("BLAS_LIBS", "/LIBPATH:C:/BLAS/lib openblas.lib", [System.EnvironmentVariableTarget]::User)
+    [System.Environment]::SetEnvironmentVariable("BLAS_LIBS", "/LIBPATH:C:/BLAS/lib openblas.lib", [System.EnvironmentVariableTarget]::Process)
+    [System.Environment]::SetEnvironmentVariable("BLAS_CFLAGS", "-IC:/BLAS/OpenBLAS-0.3.12/OpenBLAS-0.3.12", [System.EnvironmentVariableTarget]::User)
+    [System.Environment]::SetEnvironmentVariable("BLAS_CFLAGS", "-IC:/BLAS/OpenBLAS-0.3.12/OpenBLAS-0.3.12", [System.EnvironmentVariableTarget]::Process)
 
 The call ending in `Process` sets the environment variable in the current process, and it is no longer in effect in the next process. The call ending in `User` is permanent, and takes effect the next time the user logs on.
 


### PR DESCRIPTION
The current version of compileBLAS.cmd / installOpenBLAS.ps1 does not use a "v" in the top-level OpenBLAS-0.3.12 folder. 

Backward slashes got removed during installation of amici. Switching to forward slashes worked.