### PR TITLE
avoid w in root and stau headers (refactor)

### DIFF
--- a/python/amici/ode_export.py
+++ b/python/amici/ode_export.py
@@ -1649,6 +1649,11 @@ class ODEModel:
         for expr in self._expressions:
             expr.set_val(self._process_heavisides(expr.get_val(), roots))
 
+        # remove all possible Heavisides from roots, which may arise from
+        # the substitution of `'w'` in `_collect_heaviside_roots`
+        for root in roots:
+            root.set_val(self._process_heavisides(root.get_val(), roots))
+
         # Now add the found roots to the model components
         for root in roots:
             # skip roots of SBML events, as these have already been added


### PR DESCRIPTION
closes #1501 

`from_sbml` is passed through as there might be an issue for PySB symbols (haven't used PySB, so not really sure -- was just looking at `_generate_symbol`).

Could alternatively make `from_sbml` a class attribute, and/or add e.g. a `get_symbol_id` class method.