### PR TITLE
CI: Fix swig version conflict on Windows

### DIFF
--- a/.github/workflows/test_windows.yml
+++ b/.github/workflows/test_windows.yml
@@ -33,7 +33,7 @@ jobs:
         python -m pip install --upgrade pip \
           && pip install pytest petab \
           && choco install -y ninja \
-          && choco install -y swig --version=4.0.1
+          && choco install -y swig --version=4.0.2
 
     - name: Install OpenBLAS
       shell: powershell

--- a/.github/workflows/test_windows.yml
+++ b/.github/workflows/test_windows.yml
@@ -33,7 +33,7 @@ jobs:
         python -m pip install --upgrade pip \
           && pip install pytest petab \
           && choco install -y ninja \
-          && choco install -y swig --version=4.0.2
+          && choco install -y swig
 
     - name: Install OpenBLAS
       shell: powershell


### PR DESCRIPTION
It seems that SWIG4 is meanwhile preinstalled in the GHA Windows images. 
Remove specific version requirement to avoid conflicts or reinstallation.