### PR TITLE
Py: Proper typehints for SWIG interface

### DIFF
--- a/include/amici/model_dimensions.h
+++ b/include/amici/model_dimensions.h
@@ -148,12 +148,12 @@ struct ModelDimensions {
      */
     int ndwdw {0};
 
-    /** Number of nonzero elements in the \f$w\f$ derivative of \f$xdot\f$ */
+    /** Number of nonzero elements in the \f$ w \f$ derivative of \f$ xdot \f$ */
     int ndxdotdw {0};
 
     /**
-     * Number of nonzero elements in the \f$y\f$ derivative of
-     * \f$dJy\f$ (dimension `nytrue`)
+     * Number of nonzero elements in the \f$ y \f$ derivative of
+     * \f$ dJy \f$ (dimension `nytrue`)
      */
     std::vector<int> ndJydy;
 

--- a/python/amici/custom_commands.py
+++ b/python/amici/custom_commands.py
@@ -1,6 +1,5 @@
 """Custom setuptools commands for AMICI installation"""
 
-import contextlib
 import glob
 import os
 import subprocess
@@ -8,6 +7,7 @@ import sys
 from shutil import copyfile
 from typing import Dict, List, Tuple
 
+from amici.swig import fix_typehints
 from amici.setuptools import generate_swig_interface_files
 from setuptools.command.build_clib import build_clib
 from setuptools.command.build_ext import build_ext
@@ -142,9 +142,11 @@ class AmiciDevelop(develop):
         log.debug("running AmiciDevelop")
 
         if not self.no_clibs:
+            swig_outdir = os.path.join(os.path.abspath(os.getcwd()), "amici")
             generate_swig_interface_files(
-                swig_outdir=os.path.join(os.path.abspath(os.getcwd()),
-                                         "amici"))
+                swig_outdir=swig_outdir)
+            swig_py_module_path = os.path.join(swig_outdir, 'amici.py')
+            fix_typehints(swig_py_module_path, swig_py_module_path)
             self.get_finalized_command('build_clib').run()
 
         develop.run(self)
@@ -326,3 +328,4 @@ def set_compiler_specific_extension_options(
         except AttributeError:
             # No compiler-specific options set
             pass
+

--- a/python/amici/custom_commands.py
+++ b/python/amici/custom_commands.py
@@ -142,11 +142,6 @@ class AmiciDevelop(develop):
         log.debug("running AmiciDevelop")
 
         if not self.no_clibs:
-            swig_outdir = os.path.join(os.path.abspath(os.getcwd()), "amici")
-            generate_swig_interface_files(
-                swig_outdir=swig_outdir)
-            swig_py_module_path = os.path.join(swig_outdir, 'amici.py')
-            fix_typehints(swig_py_module_path, swig_py_module_path)
             self.get_finalized_command('build_clib').run()
 
         develop.run(self)
@@ -228,8 +223,11 @@ class AmiciBuildExt(build_ext):
                 log.info(f"copying {src} -> {dest}")
                 copyfile(src, dest)
 
-            generate_swig_interface_files(
-                swig_outdir=os.path.join(build_dir, 'amici'))
+            swig_outdir = os.path.join(os.path.abspath(build_dir), "amici")
+            generate_swig_interface_files(swig_outdir=swig_outdir)
+            swig_py_module_path = os.path.join(swig_outdir, 'amici.py')
+            log.debug("updating typehints")
+            fix_typehints(swig_py_module_path, swig_py_module_path)
 
         # Always force recompilation. The way setuptools/distutils check for
         # whether sources require recompilation is not reliable and may lead

--- a/python/amici/swig.py
+++ b/python/amici/swig.py
@@ -127,6 +127,9 @@ class TypeHintFixer(ast.NodeTransformer):
 
 def fix_typehints(infilename, outfilename):
     """Change SWIG-generated C++ typehints to Python typehints"""
+    # Only available from Python3.9
+    if not getattr(ast, 'unparse', None):
+        return
 
     # file -> AST
     with open(infilename, 'r') as f:


### PR DESCRIPTION
SWIG created typehint based on C++ types which are mostly useless for type checking.
This PR replaces (some) C++ types by their corresponding Python types.

Also fixes redundant swig invocation and some swig warnings.

Closes #1078