### PR TITLE
Fixup doc: build script order for C++ build

### DIFF
--- a/documentation/cpp_installation.rst
+++ b/documentation/cpp_installation.rst
@@ -24,7 +24,7 @@ To use AMICI from C++, run the
 
 .. code-block:: bash
 
-    ./scripts/buildSuitesparse.sh
+    ./scripts/buildSuiteSparse.sh
     ./scripts/buildSundials.sh
     ./scripts/buildAmici.sh
 

--- a/documentation/cpp_installation.rst
+++ b/documentation/cpp_installation.rst
@@ -24,8 +24,8 @@ To use AMICI from C++, run the
 
 .. code-block:: bash
 
-    ./scripts/buildSundials.sh
     ./scripts/buildSuitesparse.sh
+    ./scripts/buildSundials.sh
     ./scripts/buildAmici.sh
 
 script to build the AMICI library.


### PR DESCRIPTION
First SuiteSparse, then SUNDIALS. Not vice versa.