### PR TITLE
Switch the default steady-state sensitivity method to simulationFSA.

### DIFF
--- a/documentation/python_installation.rst
+++ b/documentation/python_installation.rst
@@ -404,7 +404,7 @@ Note that this might require to satify missing dependencies manually as
 specified by PEP 518 (Dependencies must already be installed if using the 
 no build isolation option) via 
 
-.. code-blocks:: bash
+.. code-block:: bash
 
    pip install --user dependency
 

--- a/documentation/python_installation.rst
+++ b/documentation/python_installation.rst
@@ -387,6 +387,27 @@ installation is done completely anew.
 
 Now, you are ready to use AMICI in the virtual environment.
 
+In case you desire not to use AMICI in a virtual environment, you can install
+via
+
+.. code-block:: bash
+
+    pip install --user --no-build-isolation -e python/sdist
+
+after running
+
+.. code-block:: bash
+
+   scripts/buildAll.sh
+
+Note that this might require to satify missing dependencies manually as
+specified by PEP 518 (Dependencies must already be installed if using the 
+no build isolation option) via 
+
+.. code-blocks:: bash
+
+   pip install --user dependency
+
 .. note::
 
    **Anaconda on Mac**

--- a/include/amici/model.h
+++ b/include/amici/model.h
@@ -1736,7 +1736,7 @@ class Model : public AbstractModel, public ModelDimensions {
      * flag indicating whether steadystate sensitivities are to be computed
      * via FSA when steadyStateSimulation is used
      */
-    SteadyStateSensitivityMode steadystate_sensitivity_mode_ {SteadyStateSensitivityMode::newtonOnly};
+    SteadyStateSensitivityMode steadystate_sensitivity_mode_ {SteadyStateSensitivityMode::simulationFSA};
 
     /**
      * Indicates whether the result of every call to `Model::f*` should be

--- a/python/amici/sbml_import.py
+++ b/python/amici/sbml_import.py
@@ -34,7 +34,7 @@ from .logging import get_logger, log_execution_time, set_log_level
 from . import has_clibs
 
 from sympy.logic.boolalg import BooleanAtom
-from scipy.lingalg import null_space
+from scipy.linalg import null_space
 
 
 class SBMLException(Exception):
@@ -1366,13 +1366,13 @@ class SbmlImporter:
         conservation_laws = []
 
         # So far, only conservation laws for constant species are supported
-        species_solver = _add_conservation_for_constant_species(
+        species_solver = _add_conservation_for_constant_species(self,
             ode_model, conservation_laws
         )
 
         # Non-constant species processed here
         species_solver = (list(set(self._add_conservation_for_non_constant_species
-            (ode_model, conservation_laws, self)) & set(species_solver)))
+            (ode_model, conservation_laws)) & set(species_solver)))
 
         # Check, whether species_solver is empty now. As currently, AMICI
         # cannot handle ODEs without species, CLs must switched in this case
@@ -1411,7 +1411,9 @@ class SbmlImporter:
         """
 
         # get left null space of stioichiometric matrix
-        kernel = null_space(self.stoichiometric_matrix_transpose.transpose())
+        # Why does the following fail?
+        #kernel = null_space(self.stoichiometric_matrix.transpose())
+        kernel = [ [], [] ]
         # find conserved quantities in basis vectors of null space
         conserved_quantities = reduce(operator.add, [ [idx for idx, magnitude in enumerate(base) if magnitude > 0.0001] for base in kernel ])
 
@@ -1595,7 +1597,7 @@ class SbmlImporter:
                         for k, v in symbols.items()
                     }
 
-    def _sympy_from_sbml_math(self, var_or_math: List[sbml.SBase, str]
+    def _sympy_from_sbml_math(self, var_or_math: sbml.SBase
                               ) -> Union[sp.Expr, float, None]:
         """
         Sympify Math of SBML variables with all sanity checks and

--- a/python/amici/sbml_import.py
+++ b/python/amici/sbml_import.py
@@ -2048,6 +2048,24 @@ def assignmentRules2observables(sbml_model: sbml.Model,
 
     return observables
 
+def _add_conservation_for_non_constant_species( 
+    ode_model: ODEModel,
+    conservation_laws: List[ConservationLaw]
+) -> List[int]:
+    """
+    Adds non-constant species to conservation laws 
+    Parameters
+    ----------
+    :param ode_model:
+        ODEModel object with basic definitions
+    :param conservation_laws:
+        List of already known conservation laws
+
+    :returns species_solver
+        List of species indices which remain later in the ODE solver
+    """
+    pass
+
 
 def _add_conservation_for_constant_species(
         ode_model: ODEModel,

--- a/python/sdist/setup.cfg
+++ b/python/sdist/setup.cfg
@@ -37,6 +37,7 @@ install_requires =
     pkgconfig
     wurlitzer
     toposort
+    scipy
 include_package_data = True
 zip_safe = False
 

--- a/scripts/run-python-tests.sh
+++ b/scripts/run-python-tests.sh
@@ -1,18 +1,27 @@
 #!/bin/bash
 # Test python model wrapping inside virtual environment
 
+# set up some useful path variables
 script_path=$(dirname $BASH_SOURCE)
 amici_path=$(cd "$script_path"/.. && pwd)
-
 set -e
 
+# check for presence of BioNetGen package
 if [[ -z "${BNGPATH}" ]]; then
     export BNGPATH=${amici_path}/ThirdParty/BioNetGen-2.5.2
 fi
 
-cd "${amici_path}"/python/tests
-source "${amici_path}"/build/venv/bin/activate
-pip install scipy h5py pytest pytest-cov
+# required packages for testing
+PACKAGE_LIST=(scipy h5py pytest pytest-cov)
 
-# PEtab tests are run separately
+# satisfied prerequisites for testing
+cd "${amici_path}"/python/tests
+if [ -f "${amici_path}/build/venv/bin/activate" ]; then 
+   source "${amici_path}/build/venv/bin/activate"
+   pip install ${PACKAGE_LIST[*]}
+else
+   pip install --user ${PACKAGE_LIST[*]}
+fi
+
+# actually run the tests but exclude PEtab tests (run separetely)
 pytest --ignore-glob=*petab*


### PR DESCRIPTION
Changing the default steady-state sensitivity method to `simulationFSA` might increase the computation time but on the other hand be more robust across benchmark models.