### PR TITLE
Fixes steadystate

### DIFF
--- a/src/steadystateproblem.cpp
+++ b/src/steadystateproblem.cpp
@@ -488,6 +488,7 @@ void SteadystateProblem::applyNewtonsMethod(Model *model,
     int ix = 0;
     double gamma = 1.0;
     bool compNewStep = true;
+    bool converged = false;
 
     if (model->nx_solver == 0)
         return;
@@ -503,9 +504,11 @@ void SteadystateProblem::applyNewtonsMethod(Model *model,
     x_old_ = x_;
     xdot_old_ = xdot_;
 
-    wrms_ = getWrmsNorm(x_newton_, xdot_, newtonSolver->atol_,
-                       newtonSolver->rtol_, ewt_);
-    bool converged = wrms_ < RCONST(1.0);
+    if (!newton_retry) {
+        wrms_ = getWrmsNorm(x_newton_, xdot_, newtonSolver->atol_,
+                            newtonSolver->rtol_, ewt_);
+        converged = wrms_ < RCONST(1.0);
+    }
     while (!converged && i_newtonstep < newtonSolver->max_steps) {
 
         /* If Newton steps are necessary, compute the initial search direction */

--- a/src/steadystateproblem.cpp
+++ b/src/steadystateproblem.cpp
@@ -462,7 +462,7 @@ bool SteadystateProblem::checkConvergence(const Solver *solver,
             sx_ = solver->getStateSensitivity(t_);
             model->fsxdot(t_, x_, dx_, ip, sx_[ip], dx_, xdot_);
             wrms_ = getWrmsNorm(
-                x_, xdot_, solver->getAbsoluteToleranceSteadyStateSensi(),
+                sx_[ip], xdot_, solver->getAbsoluteToleranceSteadyStateSensi(),
                 solver->getRelativeToleranceSteadyStateSensi(), ewt_);
             converged = wrms_ < RCONST(1.0);
         }


### PR DESCRIPTION
- small fix to the sensitivity convergence check
- fixes a bug when newton sensitivity computation is activated despite specifying `newton_steps == 0`. The error ocurs when simulation converges to a steadystate but simulation sensis are not converged according to convergence criteria. In that case simulation returns failure, but the newton rootfinding "finds" a steadystate even before the iteration check, leading to the erroneous computation of sensis via newton/IFT. For singular jacobians this means the overall simulation still fails, but a different, more informative error message is displayed. For non-singular jacobians it does not make too much sense to specify `newton_steps = 0`.