### PR TITLE
Fix: Argument "outdir" in ODEExporter.__init__ only stored but never …

### DIFF
--- a/python/amici/ode_export.py
+++ b/python/amici/ode_export.py
@@ -2702,8 +2702,11 @@ class ODEExporter:
 
     def _prepare_model_folder(self) -> None:
         """
-        Remove all files from the model folder.
+        Create model directory or remove all files if the output directory
+        already exists.
         """
+        os.makedirs(self.model_path, exist_ok=True)
+
         for file in os.listdir(self.model_path):
             file_path = os.path.join(self.model_path, file)
             if os.path.isfile(file_path):
@@ -3489,10 +3492,6 @@ class ODEExporter:
 
         self.model_path = os.path.abspath(output_dir)
         self.model_swig_path = os.path.join(self.model_path, 'swig')
-
-        for directory in [self.model_path, self.model_swig_path]:
-            if not os.path.exists(directory):
-                os.makedirs(directory)
 
     def set_name(self, model_name: str) -> None:
         """

--- a/python/amici/ode_export.py
+++ b/python/amici/ode_export.py
@@ -2575,9 +2575,6 @@ class ODEExporter:
     :ivar model:
         ODE definition
 
-    :ivar outdir:
-        see :meth:`amici.ode_export.ODEExporter.set_paths`
-
     :ivar verbose:
         more verbose output if True
 
@@ -2652,16 +2649,15 @@ class ODEExporter:
         """
         set_log_level(logger, verbose)
 
-        self.outdir: str = outdir
         self.verbose: bool = logger.getEffectiveLevel() <= logging.DEBUG
         self.assume_pow_positivity: bool = assume_pow_positivity
         self.compiler: str = compiler
 
         self.model_name: str = 'model'
-        output_dir = os.path.join(os.getcwd(),
-                                  f'amici-{self.model_name}')
-        self.model_path: str = os.path.abspath(output_dir)
-        self.model_swig_path: str = os.path.join(self.model_path, 'swig')
+        self.model_path: str = ''
+        self.model_swig_path: str = ''
+
+        self.set_paths(outdir)
 
         # Signatures and properties of generated model functions (see
         # include/amici/model.h for details)
@@ -3472,15 +3468,21 @@ class ODEExporter:
             template_data
         )
 
-    def set_paths(self, output_dir: str) -> None:
+    def set_paths(self, output_dir: Optional[str] = None) -> None:
         """
         Set output paths for the model and create if necessary
 
         :param output_dir:
             relative or absolute path where the generated model
-            code is to be placed. will be created if does not exists.
+            code is to be placed. If ``None``, this will default to
+            `amici-{self.model_name}` in the current working directory.
+            will be created if does not exists.
 
         """
+        if output_dir is None:
+            output_dir = os.path.join(os.getcwd(),
+                                      f'amici-{self.model_name}')
+
         self.model_path = os.path.abspath(output_dir)
         self.model_swig_path = os.path.join(self.model_path, 'swig')
 

--- a/python/amici/ode_export.py
+++ b/python/amici/ode_export.py
@@ -2618,7 +2618,8 @@ class ODEExporter:
             assume_pow_positivity: Optional[bool] = False,
             compiler: Optional[str] = None,
             allow_reinit_fixpar_initcond: Optional[bool] = True,
-            generate_sensitivity_code: Optional[bool] = True
+            generate_sensitivity_code: Optional[bool] = True,
+            model_name: Optional[str] = 'model'
     ):
         """
         Generate AMICI C++ files for the ODE provided to the constructor.
@@ -2646,6 +2647,9 @@ class ODEExporter:
 
         :param generate_sensitivity_code specifies whether code required for
             sensitivity computation will be generated
+
+        :param model_name:
+            name of the model to be used during code generation
         """
         set_log_level(logger, verbose)
 
@@ -2653,10 +2657,10 @@ class ODEExporter:
         self.assume_pow_positivity: bool = assume_pow_positivity
         self.compiler: str = compiler
 
-        self.model_name: str = 'model'
         self.model_path: str = ''
         self.model_swig_path: str = ''
 
+        self.set_name(model_name)
         self.set_paths(outdir)
 
         # Signatures and properties of generated model functions (see

--- a/python/amici/pysb_import.py
+++ b/python/amici/pysb_import.py
@@ -139,13 +139,12 @@ def pysb2amici(
     exporter = ODEExporter(
         ode_model,
         outdir=output_dir,
+        model_name=model.name,
         verbose=verbose,
         assume_pow_positivity=assume_pow_positivity,
         compiler=compiler,
         generate_sensitivity_code=generate_sensitivity_code
     )
-    exporter.set_name(model.name)
-    exporter.set_paths(output_dir)
     exporter.generate_model_code()
 
     if compile:

--- a/python/amici/sbml_import.py
+++ b/python/amici/sbml_import.py
@@ -364,7 +364,6 @@ class SbmlImporter:
             self, compute_cls=compute_conservation_laws)
         exporter = ODEExporter(
             ode_model,
-            outdir=output_dir,
             verbose=verbose,
             assume_pow_positivity=assume_pow_positivity,
             compiler=compiler,
@@ -372,6 +371,7 @@ class SbmlImporter:
             generate_sensitivity_code=generate_sensitivity_code
         )
         exporter.set_name(model_name)
+        exporter.set_paths(output_dir)
         exporter.generate_model_code()
 
         if compile:

--- a/python/amici/sbml_import.py
+++ b/python/amici/sbml_import.py
@@ -372,7 +372,6 @@ class SbmlImporter:
             generate_sensitivity_code=generate_sensitivity_code
         )
         exporter.set_name(model_name)
-        exporter.set_paths(output_dir)
         exporter.generate_model_code()
 
         if compile:

--- a/python/amici/sbml_import.py
+++ b/python/amici/sbml_import.py
@@ -364,14 +364,14 @@ class SbmlImporter:
             self, compute_cls=compute_conservation_laws)
         exporter = ODEExporter(
             ode_model,
+            model_name=model_name,
+            outdir=output_dir,
             verbose=verbose,
             assume_pow_positivity=assume_pow_positivity,
             compiler=compiler,
             allow_reinit_fixpar_initcond=allow_reinit_fixpar_initcond,
             generate_sensitivity_code=generate_sensitivity_code
         )
-        exporter.set_name(model_name)
-        exporter.set_paths(output_dir)
         exporter.generate_model_code()
 
         if compile:


### PR DESCRIPTION
…used

* Honor user-provided output directory (Fixes #1542)
* Remove unused instance variable ODEExporter.output_dir
* Remove redundant logic for setting model_path and model_swig path
* Handle default directory in ODEExporter.set_paths