### PR TITLE
SBML import: Use more descriptive IDs for flux expressions

### DIFF
--- a/python/amici/ode_export.py
+++ b/python/amici/ode_export.py
@@ -1050,10 +1050,9 @@ class ODEModel:
         nexpr = len(symbols[SymbolId.EXPRESSION])
 
         # assemble fluxes and add them as expressions to the model
-        fluxes = []
-        for ir, flux in enumerate(si.flux_vector):
-            flux_id = generate_flux_symbol(ir)
-            fluxes.append(flux_id)
+        assert len(si.flux_ids) == len(si.flux_vector)
+        fluxes = [generate_flux_symbol(ir, name=flux_id)
+                  for ir, flux_id in enumerate(si.flux_ids)]
         nr = len(fluxes)
 
         # correct time derivatives for compartment changes
@@ -3873,7 +3872,10 @@ def generate_measurement_symbol(observable_id: Union[str, sp.Symbol]):
     return symbol_with_assumptions(f'm{observable_id}')
 
 
-def generate_flux_symbol(reaction_index: int) -> sp.Symbol:
+def generate_flux_symbol(
+        reaction_index: int,
+        name: Optional[str] = None
+) -> sp.Symbol:
     """
     Generate identifier symbol for a reaction flux.
     This function will always return the same unique python object for a
@@ -3881,9 +3883,14 @@ def generate_flux_symbol(reaction_index: int) -> sp.Symbol:
 
     :param reaction_index:
         index of the reaction to which the flux corresponds
+    :param name:
+        an optional identifier of the reaction to which the flux corresponds
     :return:
         identifier symbol
     """
+    if name is not None:
+        return symbol_with_assumptions(name)
+
     return symbol_with_assumptions(f'flux_r{reaction_index}')
 
 

--- a/python/amici/sbml_import.py
+++ b/python/amici/sbml_import.py
@@ -859,7 +859,7 @@ class SbmlImporter:
             f"flux_{reaction.getId()}" if reaction.isSetId()
             else f"flux_r{reaction_idx}"
             for reaction_idx, reaction in enumerate(reactions)
-        ]
+        ] or ['flux_r0']
 
         reaction_ids = [
             reaction.getId() for reaction in reactions

--- a/python/amici/sbml_import.py
+++ b/python/amici/sbml_import.py
@@ -852,7 +852,7 @@ class SbmlImporter:
         # stoichiometric matrix
         self.stoichiometric_matrix = sp.SparseMatrix(sp.zeros(nx, nr))
         self.flux_vector = sp.zeros(nr, 1)
-        # Use reaction IDs as IDs for flux expressions (not that prior to SBML
+        # Use reaction IDs as IDs for flux expressions (note that prior to SBML
         #  level 3 version 2 the ID attribute was not mandatory and may be
         #  unset)
         self.flux_ids = [

--- a/python/amici/sbml_import.py
+++ b/python/amici/sbml_import.py
@@ -87,6 +87,9 @@ class SbmlImporter:
     :ivar flux_vector:
         reaction kinetic laws
 
+    :ivar flux_ids:
+        identifiers for elements of flux_vector
+
     :ivar _local_symbols:
         model symbols for sympy to consider during sympification
         see `locals`argument in `sympy.sympify`
@@ -849,6 +852,14 @@ class SbmlImporter:
         # stoichiometric matrix
         self.stoichiometric_matrix = sp.SparseMatrix(sp.zeros(nx, nr))
         self.flux_vector = sp.zeros(nr, 1)
+        # Use reaction IDs as IDs for flux expressions (not that prior to SBML
+        #  level 3 version 2 the ID attribute was not mandatory and may be
+        #  unset)
+        self.flux_ids = [
+            f"flux_{reaction.getId()}" if reaction.isSetId()
+            else f"flux_r{reaction_idx}"
+            for reaction_idx, reaction in enumerate(reactions)
+        ]
 
         reaction_ids = [
             reaction.getId() for reaction in reactions


### PR DESCRIPTION
Previously, those were flux_r0, flux_r1, ...; now they include the reaction ID if it was set in the imported SBML model.