### PR TITLE
fix nan-gradient values due to nan-propagation from unmapped parameters

### DIFF
--- a/python/amici/parameter_mapping.py
+++ b/python/amici/parameter_mapping.py
@@ -202,6 +202,9 @@ def fill_in_parameters_for_condition(
         if model_par in problem_parameters:
             # user-provided
             return problem_parameters[model_par]
+        # prevent nan-propagation in derivative
+        if np.isnan(value):
+            return 0.0
         # constant value
         return value
 


### PR DESCRIPTION
Unmapped parameters in PEtab problems are currently assigned to NaN values. This may lead to erroneous propagation of NaN values from dydp to sllh due to use of dgemm to compute dJydp = dJydy*dydp (http://icl.cs.utk.edu/lapack-forum/archives/lapack/msg01536.html), i.e., even if there are no measurements for observable iy and the respective row in dJydy is completely 0, NaN values in dydp will end up in dJydp.

Fixing to 0.0 is definitely not ideal, but works in more situations than current implementation (for example, this fixes gradient computation for the Isensee benchmark problem).