### PR TITLE
GHA: Update matlab actions to v1

### DIFF
--- a/.github/workflows/test_matlab.yml
+++ b/.github/workflows/test_matlab.yml
@@ -14,8 +14,8 @@ jobs:
     - run: echo "AMICI_DIR=$(pwd)" >> $GITHUB_ENV
 
     - name: Install MATLAB
-      uses: matlab-actions/setup-matlab@v0
+      uses: matlab-actions/setup-matlab@v1
     - name: Run script
-      uses: matlab-actions/run-command@v0
+      uses: matlab-actions/run-command@v1
       with:
         command: cd matlab; installAMICI; addpath tests; testModels


### PR DESCRIPTION
Matlab action failure was only temporary and unrelated to this. Nevertheless good to update.