### PR TITLE
Cleanup NVector math

### DIFF
--- a/include/amici/sundials_matrix_wrapper.h
+++ b/include/amici/sundials_matrix_wrapper.h
@@ -326,6 +326,17 @@ class SUNMatrixWrapper {
     void multiply(N_Vector c, const_N_Vector b, realtype alpha = 1.0) const;
 
     /**
+     * @brief AmiVector interface for multiply
+     * @param c output vector, may already contain values
+     * @param b multiplication vector
+     * @param alpha scalar coefficient for matrix
+     */
+    void multiply(AmiVector& c, AmiVector const& b, realtype alpha = 1.0) const {
+        multiply(c.getNVector(), b.getNVector(), alpha);
+    }
+
+
+    /**
      * @brief Perform matrix vector multiplication c += alpha * A*b
      * @param c output vector, may already contain values
      * @param b multiplication vector

--- a/include/amici/vector.h
+++ b/include/amici/vector.h
@@ -86,6 +86,13 @@ class AmiVector {
      */
     AmiVector &operator=(AmiVector const &other);
 
+    AmiVector &operator/=(AmiVector const& divisor) {
+        N_VDiv(getNVector(),
+               const_cast<N_Vector>(divisor.getNVector()),
+               getNVector());
+        return *this;
+    }
+
     /**
      * @brief Returns an iterator that points to the first element of the
      * vector.

--- a/include/amici/vector.h
+++ b/include/amici/vector.h
@@ -88,7 +88,7 @@ class AmiVector {
 
     /**
      * @brief operator *= (element-wise multiplication)
-     * @param divisor
+     * @param multiplier
      * @return result
      */
     AmiVector &operator*=(AmiVector const& multiplier) {

--- a/include/amici/vector.h
+++ b/include/amici/vector.h
@@ -87,6 +87,18 @@ class AmiVector {
     AmiVector &operator=(AmiVector const &other);
 
     /**
+     * @brief Returns an iterator that points to the first element of the
+     * vector.
+     */
+    auto begin() { return vec_.begin(); }
+
+    /**
+     * @brief Returns an iterator that points to one after the last element of
+     * the vector.
+     */
+    auto end() { return vec_.end(); }
+
+    /**
      * @brief data accessor
      * @return pointer to data array
      */
@@ -314,6 +326,29 @@ class AmiVectorArray {
      */
     std::vector<N_Vector> nvec_array_;
 };
+
+/**
+ * @brief Computes z = a*x + b*y
+ * @param a coefficient for x
+ * @param x a vector
+ * @param b coefficient for y
+ * @param y another vector with same size as x
+ * @param z result vector of same size as x and y
+ */
+inline void linearSum(realtype a, AmiVector const& x, realtype b,
+               AmiVector const& y, AmiVector& z) {
+    N_VLinearSum(a, const_cast<N_Vector>(x.getNVector()),
+                 b, const_cast<N_Vector>(y.getNVector()),
+                 z.getNVector());
+}
+
+/**
+ * @brief Negates all vector elements (in-place)
+ * @param x Vector to operate on
+ */
+inline void negate(AmiVector& x) {
+    std::transform(x.begin(), x.end(), x.begin(), std::negate<realtype>());
+}
 
 } // namespace amici
 

--- a/include/amici/vector.h
+++ b/include/amici/vector.h
@@ -88,7 +88,7 @@ class AmiVector {
 
     /**
      * @brief operator *= (element-wise multiplication)
-     * @param multiplier
+     * @param multiplier multiplier
      * @return result
      */
     AmiVector &operator*=(AmiVector const& multiplier) {
@@ -100,7 +100,7 @@ class AmiVector {
 
     /**
      * @brief operator /= (element-wise division)
-     * @param divisor
+     * @param divisor divisor
      * @return result
      */
     AmiVector &operator/=(AmiVector const& divisor) {

--- a/include/amici/vector.h
+++ b/include/amici/vector.h
@@ -343,11 +343,14 @@ inline void linearSum(realtype a, AmiVector const& x, realtype b,
 }
 
 /**
- * @brief Negates all vector elements (in-place)
- * @param x Vector to operate on
+ * @brief Compute dot product of x and y
+ * @param x vector
+ * @param y vector
+ * @return dot product of x and y
  */
-inline void negate(AmiVector& x) {
-    std::transform(x.begin(), x.end(), x.begin(), std::negate<realtype>());
+inline realtype dotProd(AmiVector const& x, AmiVector const& y) {
+    return N_VDotProd(const_cast<N_Vector>(x.getNVector()),
+                      const_cast<N_Vector>(y.getNVector()));
 }
 
 } // namespace amici

--- a/include/amici/vector.h
+++ b/include/amici/vector.h
@@ -113,12 +113,14 @@ class AmiVector {
     /**
      * @brief Returns an iterator that points to the first element of the
      * vector.
+     * @return iterator that points to the first element
      */
     auto begin() { return vec_.begin(); }
 
     /**
-     * @brief Returns an iterator that points to one after the last element of
-     * the vector.
+     * @brief Returns an iterator that points to one element after the last
+     * element of the vector.
+     * @return iterator that points to one element after the last element
      */
     auto end() { return vec_.end(); }
 

--- a/include/amici/vector.h
+++ b/include/amici/vector.h
@@ -183,6 +183,13 @@ class AmiVector {
      */
     void copy(const AmiVector &other);
 
+    /**
+     * @brief Take absolute value (in-place)
+     */
+    void abs() {
+        N_VAbs(getNVector(), getNVector());
+    };
+
   private:
     /** main data storage */
     std::vector<realtype> vec_;

--- a/include/amici/vector.h
+++ b/include/amici/vector.h
@@ -86,6 +86,23 @@ class AmiVector {
      */
     AmiVector &operator=(AmiVector const &other);
 
+    /**
+     * @brief operator *= (element-wise multiplication)
+     * @param divisor
+     * @return result
+     */
+    AmiVector &operator*=(AmiVector const& multiplier) {
+        N_VProd(getNVector(),
+               const_cast<N_Vector>(multiplier.getNVector()),
+               getNVector());
+        return *this;
+    }
+
+    /**
+     * @brief operator /= (element-wise division)
+     * @param divisor
+     * @return result
+     */
     AmiVector &operator/=(AmiVector const& divisor) {
         N_VDiv(getNVector(),
                const_cast<N_Vector>(divisor.getNVector()),

--- a/python/examples/example_petab/petab.ipynb
+++ b/python/examples/example_petab/petab.ipynb
@@ -4,7 +4,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "# Using PEtab\n",
+    " Using PEtab\n",
     "\n",
     "This notebook illustrates how to use [PEtab](https://github.com/petab-dev/petab) with AMICI."
    ]

--- a/python/examples/example_petab/petab.ipynb
+++ b/python/examples/example_petab/petab.ipynb
@@ -4,7 +4,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    " Using PEtab\n",
+    "# Using PEtab\n",
     "\n",
     "This notebook illustrates how to use [PEtab](https://github.com/petab-dev/petab) with AMICI."
    ]

--- a/src/newton_solver.cpp
+++ b/src/newton_solver.cpp
@@ -255,7 +255,7 @@ void NewtonSolverIterative::prepareLinearSystem(int ntry, int nnewt) {
     ns_Jdiag_.abs();
     N_VCompare(1e-15, ns_Jdiag_.getNVector(), ns_tmp_.getNVector());
     linearSum(-1.0, ns_tmp_, 1.0, ns_p_, ns_tmp_);
-    linearSum(1.0, ns_Jdiag_, 1.0, ns_tmp_, ns_Jdiag_);
+    ns_Jdiag_ *= ns_tmp_;
 }
 
 /* ------------------------------------------------------------------------- */
@@ -278,7 +278,7 @@ void NewtonSolverIterative::prepareLinearSystemB(int ntry, int nnewt) {
     ns_Jdiag_.abs();
     N_VCompare(1e-15, ns_Jdiag_.getNVector(), ns_tmp_.getNVector());
     linearSum(-1.0, ns_tmp_, 1.0, ns_p_, ns_tmp_);
-    linearSum(1.0, ns_Jdiag_, 1.0, ns_tmp_, ns_Jdiag_);
+    ns_Jdiag_ *= ns_tmp_;
     ns_Jdiag_.minus();
 }
 

--- a/src/newton_solver.cpp
+++ b/src/newton_solver.cpp
@@ -2,9 +2,6 @@
 
 #include "amici/model.h"
 #include "amici/solver.h"
-#include "amici/steadystateproblem.h"
-#include "amici/forwardproblem.h"
-#include "amici/edata.h"
 
 #include "sunlinsol/sunlinsol_klu.h" // sparse solver
 #include "sunlinsol/sunlinsol_dense.h" // dense solver

--- a/src/newton_solver.cpp
+++ b/src/newton_solver.cpp
@@ -255,7 +255,7 @@ void NewtonSolverIterative::prepareLinearSystem(int ntry, int nnewt) {
     ns_Jdiag_.abs();
     N_VCompare(1e-15, ns_Jdiag_.getNVector(), ns_tmp_.getNVector());
     linearSum(-1.0, ns_tmp_, 1.0, ns_p_, ns_tmp_);
-    ns_Jdiag_ *= ns_tmp_;
+    linearSum(1.0, ns_Jdiag_, 1.0, ns_tmp_, ns_Jdiag_);
 }
 
 /* ------------------------------------------------------------------------- */
@@ -278,7 +278,7 @@ void NewtonSolverIterative::prepareLinearSystemB(int ntry, int nnewt) {
     ns_Jdiag_.abs();
     N_VCompare(1e-15, ns_Jdiag_.getNVector(), ns_tmp_.getNVector());
     linearSum(-1.0, ns_tmp_, 1.0, ns_p_, ns_tmp_);
-    ns_Jdiag_ *= ns_tmp_;
+    linearSum(1.0, ns_Jdiag_, 1.0, ns_tmp_, ns_Jdiag_);
     ns_Jdiag_.minus();
 }
 

--- a/src/newton_solver.cpp
+++ b/src/newton_solver.cpp
@@ -282,7 +282,7 @@ void NewtonSolverIterative::prepareLinearSystemB(int ntry, int nnewt) {
     N_VCompare(1e-15, ns_Jdiag_.getNVector(), ns_tmp_.getNVector());
     linearSum(-1.0, ns_tmp_, 1.0, ns_p_, ns_tmp_);
     linearSum(1.0, ns_Jdiag_, 1.0, ns_tmp_, ns_Jdiag_);
-    negate(ns_Jdiag_);
+    ns_Jdiag_.minus();
 }
 
 /* ------------------------------------------------------------------------- */
@@ -315,11 +315,10 @@ void NewtonSolverIterative::linsolveSPBCG(int /*ntry*/, int nnewt,
     N_VDiv(ns_r_.getNVector(), ns_Jdiag_.getNVector(), ns_r_.getNVector());
     ns_rt_ = ns_r_;
 
-    for (int i_linstep = 0; i_linstep < max_lin_steps_;
-         i_linstep++) {
+    for (int i_linstep = 0; i_linstep < max_lin_steps_; i_linstep++) {
         // Compute factors
         double rho1 = rho;
-        rho = N_VDotProd(ns_rt_.getNVector(), ns_r_.getNVector());
+        rho = dotProd(ns_rt_, ns_r_);
         double beta = rho * alpha / (rho1 * omega);
 
         // ns_p = ns_r + beta * (ns_p - omega * ns_v);
@@ -332,7 +331,7 @@ void NewtonSolverIterative::linsolveSPBCG(int /*ntry*/, int nnewt,
         N_VDiv(ns_v_.getNVector(), ns_Jdiag_.getNVector(), ns_v_.getNVector());
 
         // Compute factor
-        alpha = rho / N_VDotProd(ns_rt_.getNVector(), ns_v_.getNVector());
+        alpha = rho / dotProd(ns_rt_, ns_v_);
 
         // ns_h = ns_delta + alpha * ns_p;
         linearSum(1.0, ns_delta, alpha, ns_p_, ns_h_);
@@ -345,7 +344,7 @@ void NewtonSolverIterative::linsolveSPBCG(int /*ntry*/, int nnewt,
         N_VDiv(ns_t_.getNVector(), ns_Jdiag_.getNVector(), ns_t_.getNVector());
 
         // Compute factor
-        omega = N_VDotProd(ns_t_.getNVector(), ns_s_.getNVector()) / N_VDotProd(ns_t_.getNVector(), ns_t_.getNVector());
+        omega = dotProd(ns_t_, ns_s_) / dotProd(ns_t_, ns_t_);
 
         // ns_delta = ns_h + omega * ns_s;
         linearSum(1.0, ns_h_, omega, ns_s_, ns_delta);
@@ -354,7 +353,7 @@ void NewtonSolverIterative::linsolveSPBCG(int /*ntry*/, int nnewt,
 
         // Compute the (unscaled) residual
         N_VProd(ns_r_.getNVector(), ns_Jdiag_.getNVector(), ns_r_.getNVector());
-        double res = sqrt(N_VDotProd(ns_r_.getNVector(), ns_r_.getNVector()));
+        double res = sqrt(dotProd(ns_r_, ns_r_));
 
         // Test convergence
         if (res < atol_) {

--- a/src/newton_solver.cpp
+++ b/src/newton_solver.cpp
@@ -255,7 +255,7 @@ void NewtonSolverIterative::prepareLinearSystem(int ntry, int nnewt) {
 
     // Ensure positivity of entries in ns_Jdiag
     ns_p_.set(1.0);
-    N_VAbs(ns_Jdiag_.getNVector(), ns_Jdiag_.getNVector());
+    ns_Jdiag_.abs();
     N_VCompare(1e-15, ns_Jdiag_.getNVector(), ns_tmp_.getNVector());
     linearSum(-1.0, ns_tmp_, 1.0, ns_p_, ns_tmp_);
     linearSum(1.0, ns_Jdiag_, 1.0, ns_tmp_, ns_Jdiag_);
@@ -278,7 +278,7 @@ void NewtonSolverIterative::prepareLinearSystemB(int ntry, int nnewt) {
     model_->fJDiag(*t_, ns_Jdiag_, 0.0, *x_, dx_);
 
     ns_p_.set(1.0);
-    N_VAbs(ns_Jdiag_.getNVector(), ns_Jdiag_.getNVector());
+    ns_Jdiag_.abs();
     N_VCompare(1e-15, ns_Jdiag_.getNVector(), ns_tmp_.getNVector());
     linearSum(-1.0, ns_tmp_, 1.0, ns_p_, ns_tmp_);
     linearSum(1.0, ns_Jdiag_, 1.0, ns_tmp_, ns_Jdiag_);

--- a/src/newton_solver.cpp
+++ b/src/newton_solver.cpp
@@ -305,7 +305,7 @@ void NewtonSolverIterative::linsolveSPBCG(int /*ntry*/, int nnewt,
     double omega = 1.0;
     double alpha = 1.0;
 
-    ns_J_.multiply(ns_Jv_.getNVector(), ns_delta.getNVector());
+    ns_J_.multiply(ns_Jv_, ns_delta);
 
     // ns_r = xdot - ns_Jv;
     linearSum(-1.0, ns_Jv_, 1.0, xdot_, ns_r_);
@@ -324,7 +324,7 @@ void NewtonSolverIterative::linsolveSPBCG(int /*ntry*/, int nnewt,
 
         // ns_v = J * ns_p
         ns_v_.zero();
-        ns_J_.multiply(ns_v_.getNVector(), ns_p_.getNVector());
+        ns_J_.multiply(ns_v_, ns_p_);
         ns_v_ /= ns_Jdiag_;
 
         // Compute factor
@@ -337,7 +337,7 @@ void NewtonSolverIterative::linsolveSPBCG(int /*ntry*/, int nnewt,
 
         // ns_t = J * ns_s
         ns_t_.zero();
-        ns_J_.multiply(ns_t_.getNVector(), ns_s_.getNVector());
+        ns_J_.multiply(ns_t_, ns_s_);
         ns_t_ /= ns_Jdiag_;
 
         // Compute factor
@@ -349,7 +349,7 @@ void NewtonSolverIterative::linsolveSPBCG(int /*ntry*/, int nnewt,
         linearSum(1.0, ns_s_, -omega, ns_t_, ns_r_);
 
         // Compute the (unscaled) residual
-        N_VProd(ns_r_.getNVector(), ns_Jdiag_.getNVector(), ns_r_.getNVector());
+        ns_r_ *= ns_Jdiag_;
         double res = sqrt(dotProd(ns_r_, ns_r_));
 
         // Test convergence

--- a/src/newton_solver.cpp
+++ b/src/newton_solver.cpp
@@ -312,7 +312,7 @@ void NewtonSolverIterative::linsolveSPBCG(int /*ntry*/, int nnewt,
 
     // ns_r = xdot - ns_Jv;
     linearSum(-1.0, ns_Jv_, 1.0, xdot_, ns_r_);
-    N_VDiv(ns_r_.getNVector(), ns_Jdiag_.getNVector(), ns_r_.getNVector());
+    ns_r_ /= ns_Jdiag_;
     ns_rt_ = ns_r_;
 
     for (int i_linstep = 0; i_linstep < max_lin_steps_; i_linstep++) {
@@ -328,7 +328,7 @@ void NewtonSolverIterative::linsolveSPBCG(int /*ntry*/, int nnewt,
         // ns_v = J * ns_p
         ns_v_.zero();
         ns_J_.multiply(ns_v_.getNVector(), ns_p_.getNVector());
-        N_VDiv(ns_v_.getNVector(), ns_Jdiag_.getNVector(), ns_v_.getNVector());
+        ns_v_ /= ns_Jdiag_;
 
         // Compute factor
         alpha = rho / dotProd(ns_rt_, ns_v_);
@@ -341,7 +341,7 @@ void NewtonSolverIterative::linsolveSPBCG(int /*ntry*/, int nnewt,
         // ns_t = J * ns_s
         ns_t_.zero();
         ns_J_.multiply(ns_t_.getNVector(), ns_s_.getNVector());
-        N_VDiv(ns_t_.getNVector(), ns_Jdiag_.getNVector(), ns_t_.getNVector());
+        ns_t_ /= ns_Jdiag_;
 
         // Compute factor
         omega = dotProd(ns_t_, ns_s_) / dotProd(ns_t_, ns_t_);
@@ -365,7 +365,7 @@ void NewtonSolverIterative::linsolveSPBCG(int /*ntry*/, int nnewt,
         }
 
         // Scale back
-        N_VDiv(ns_r_.getNVector(), ns_Jdiag_.getNVector(), ns_r_.getNVector());
+        ns_r_ /= ns_Jdiag_;
     }
     throw NewtonFailure(AMICI_CONV_FAILURE, "linsolveSPBCG");
 }

--- a/src/steadystateproblem.cpp
+++ b/src/steadystateproblem.cpp
@@ -288,7 +288,7 @@ void SteadystateProblem::getQuadratureByLinSolve(NewtonSolver *newtonSolver,
         computeQBfromQ(model, xQ_, xQB_);
         /* set flag that quadratures is available (for processing in rdata) */
         hasQuadrature_ = true;
-        
+
         /* Finalize by setting adjoint state to zero (its steady state) */
         xB_.zero();
     } catch (NewtonFailure const &) {
@@ -526,8 +526,7 @@ void SteadystateProblem::applyNewtonsMethod(Model *model,
         }
 
         /* Try a full, undamped Newton step */
-        N_VLinearSum(1.0, x_old_.getNVector(), gamma, delta_.getNVector(),
-                     x_.getNVector());
+        linearSum(1.0, x_old_, gamma, delta_, x_);
 
         /* Compute new xdot and residuals */
         model->fxdot(t_, x_, dx_, xdot_);

--- a/src/steadystateproblem.cpp
+++ b/src/steadystateproblem.cpp
@@ -708,9 +708,7 @@ void SteadystateProblem::computeQBfromQ(Model *model, const AmiVector &yQ,
                                            plist, true);
     } else {
         for (int ip=0; ip<model->nplist(); ++ip)
-            yQB[ip] = N_VDotProd(
-                const_cast<N_Vector>(yQ.getNVector()),
-                const_cast<N_Vector>(model->get_dxdotdp().getNVector(ip)));
+            yQB[ip] = dotProd(yQ, model->get_dxdotdp()[ip]);
     }
 }
 


### PR DESCRIPTION
Adds more math operations to `AmiVector`, avoiding having `.getNVector()` all over the place.