### PR TITLE
Require sympy>=1.9,pysb>=1.13.1 / update Heaviside

### DIFF
--- a/include/amici/symbolic_functions.h
+++ b/include/amici/symbolic_functions.h
@@ -5,7 +5,7 @@ namespace amici {
 
 double log(double x);
 double dirac(double x);
-double heaviside(double x);
+double heaviside(double x, double x);
 
 double min(double a, double b, double c);
 double Dmin(int id, double a, double b, double c);

--- a/include/amici/symbolic_functions.h
+++ b/include/amici/symbolic_functions.h
@@ -5,7 +5,7 @@ namespace amici {
 
 double log(double x);
 double dirac(double x);
-double heaviside(double x, double x);
+double heaviside(double x, double x0);
 
 double min(double a, double b, double c);
 double Dmin(int id, double a, double b, double c);

--- a/python/amici/ode_export.py
+++ b/python/amici/ode_export.py
@@ -2036,7 +2036,6 @@ class ODEModel:
                         raise RuntimeError(
                             'dwdw is not nilpotent. Something, somewhere went '
                             'terribly wrong. Please file a bug report at '
-                            'terribly wrong. Please file a bug report at '
                             'https://github.com/AMICI-dev/AMICI/issues and '
                             'attach this model.'
                         )

--- a/python/amici/ode_export.py
+++ b/python/amici/ode_export.py
@@ -1626,7 +1626,7 @@ class ODEModel:
             expr.set_val(self._process_heavisides(expr.get_val(), roots))
 
         # remove all possible Heavisides from roots, which may arise from
-        # the substitution of `'w'` in `_collect_heaviside_roots`
+        # the substitution of `'w'` in `_get_unique_root`
         for root in roots:
             root.set_val(self._process_heavisides(root.get_val(), roots))
 
@@ -2036,6 +2036,7 @@ class ODEModel:
                         raise RuntimeError(
                             'dwdw is not nilpotent. Something, somewhere went '
                             'terribly wrong. Please file a bug report at '
+                            'terribly wrong. Please file a bug report at '
                             'https://github.com/AMICI-dev/AMICI/issues and '
                             'attach this model.'
                         )
@@ -2354,6 +2355,14 @@ class ODEModel:
             unique identifier for root, or `None` if the root is not
             time-dependent
         """
+        # substitute 'w' expressions into root expressions now, to avoid
+        # rewriting '{model_name}_root.cpp' and '{model_name}_stau.cpp' headers
+        # to include 'w.h'
+        w_sorted = toposort_symbols(dict(zip(
+            [expr.get_id() for expr in self._expressions],
+            [expr.get_val() for expr in self._expressions],
+        )))
+        root_found = root_found.subs(w_sorted)
 
         if not self._expr_is_time_dependent(root_found):
             return None
@@ -2394,18 +2403,6 @@ class ODEModel:
                 root_funs.append(arg.args[0])
             elif arg.has(sp.Heaviside):
                 root_funs.extend(self._collect_heaviside_roots(arg.args))
-
-        # substitute 'w' expressions into root expressions now, to avoid
-        # rewriting '{model_name}_root.cpp' and '{model_name}_stau.cpp' headers
-        # to include 'w.h'
-        w_sorted = toposort_symbols(dict(zip(
-            [expr.get_id()  for expr in self._expressions],
-            [expr.get_val() for expr in self._expressions],
-        )))
-        root_funs = [
-            r.subs(w_sorted)
-            for r in root_funs
-        ]
 
         return root_funs
 

--- a/python/sdist/setup.cfg
+++ b/python/sdist/setup.cfg
@@ -44,7 +44,7 @@ zip_safe = False
 
 [options.extras_require]
 petab = petab>=0.1.17
-pysb = pysb>=1.11.0
+pysb = pysb>=1.13.1
 
 [options.package_data]
 amici =

--- a/python/sdist/setup.cfg
+++ b/python/sdist/setup.cfg
@@ -27,7 +27,7 @@ package_dir =
     amici = amici
 python_requires = >=3.7
 install_requires =
-    sympy>=1.7.1,<1.9
+    sympy>=1.7.1
     numpy>=1.14.5; python_version=='3.7'
     numpy>=1.17.5; python_version=='3.8'
     numpy>=1.19.3; python_version=='3.9'

--- a/python/sdist/setup.cfg
+++ b/python/sdist/setup.cfg
@@ -27,7 +27,7 @@ package_dir =
     amici = amici
 python_requires = >=3.7
 install_requires =
-    sympy>=1.7.1
+    sympy>=1.9
     numpy>=1.14.5; python_version=='3.7'
     numpy>=1.17.5; python_version=='3.8'
     numpy>=1.19.3; python_version=='3.9'

--- a/src/symbolic_functions.cpp
+++ b/src/symbolic_functions.cpp
@@ -84,13 +84,15 @@ double dirac(double x) {
  * c implementation of matlab function heaviside
  *
  * @param x argument
- * @return if(x>0) then 1 else 0
+ * @param x0 value at x==0
+ * @return if(x>0) then 1 else if (x==0) then x0 else 0
  *
  */
-double heaviside(double x) {
-    if (x < 0.0) {
+double heaviside(double x, double x0) {
+    if (x < 0.0)
         return 0.0;
-    }
+    if (x == 0.0)
+        return x0
     return 1.0;
 }
 

--- a/src/symbolic_functions.cpp
+++ b/src/symbolic_functions.cpp
@@ -92,7 +92,7 @@ double heaviside(double x, double x0) {
     if (x < 0.0)
         return 0.0;
     if (x == 0.0)
-        return x0
+        return x0;
     return 1.0;
 }
 

--- a/tests/cpp/unittests/testMisc.cpp
+++ b/tests/cpp/unittests/testMisc.cpp
@@ -183,9 +183,9 @@ TEST(SymbolicFunctionsTest, Sign)
 
 TEST(SymbolicFunctionsTest, Heaviside)
 {
-    ASSERT_EQ(0, heaviside(-1));
-    ASSERT_EQ(1, heaviside(0));
-    ASSERT_EQ(1, heaviside(1));
+    ASSERT_EQ(0, heaviside(-1, 0.5));
+    ASSERT_EQ(0.5, heaviside(0, 0.5));
+    ASSERT_EQ(1, heaviside(1, 0.5));
 }
 
 TEST(SymbolicFunctionsTest, Min)


### PR DESCRIPTION
Require sympy>=1.9, and pysb>=1.13.1 to be compatible with the newer sympy.

Adapt to changes in sympy's Heaviside signature