### PR TITLE
Fix sympy deprecation warning

### DIFF
--- a/python/amici/ode_export.py
+++ b/python/amici/ode_export.py
@@ -845,11 +845,9 @@ def smart_is_zero_matrix(x: Union[sp.MutableDenseMatrix,
     """
 
     if isinstance(x, sp.MutableDenseMatrix):
-        nonzero = any(xx.is_zero is not True for xx in x._mat)
-    else:
-        nonzero = x.nnz() > 0
+        return all(xx.is_zero is True for xx in x.flat())
 
-    return not nonzero
+    return x.nnz() == 0
 
 
 class ODEModel:


### PR DESCRIPTION
```
sympy/matrices/dense.py:41: SymPyDeprecationWarning:

  The private _mat attribute of Matrix has been deprecated since SymPy
  1.9. Use the .flat() method instead. See
  https://github.com/sympy/sympy/issues/21715 for more info.

    SymPyDeprecationWarning(
```

Closes #1562