### PR TITLE
Fix SUNMatrixWrapper ctor for size 0 matrices

### DIFF
--- a/src/sundials_matrix_wrapper.cpp
+++ b/src/sundials_matrix_wrapper.cpp
@@ -34,8 +34,8 @@ SUNMatrixWrapper::SUNMatrixWrapper(sunindextype M, sunindextype N)
         throw std::bad_alloc();
 
     finish_init();
-    assert(M == rows());
-    assert(N == columns());
+    assert(M == rows() || !matrix_);
+    assert(N == columns() || !matrix_);
 }
 
 SUNMatrixWrapper::SUNMatrixWrapper(sunindextype M, sunindextype ubw,


### PR DESCRIPTION
Fixes a bug where the program would terminate if a SUNMatrixWrapper was used to construct a matrix with zero rows or zero columns if compiled with -DNDEBUG.