### PR TITLE
Remove assert_fun argument from gradient checking, improve output

### DIFF
--- a/python/amici/gradient_check.py
+++ b/python/amici/gradient_check.py
@@ -14,15 +14,17 @@ import copy
 from typing import Callable, Optional, List, Sequence
 
 
-def check_finite_difference(x0: Sequence[float],
-                            model: Model,
-                            solver: Solver,
-                            edata: ExpData,
-                            ip: int,
-                            fields: List[str],
-                            atol: Optional[float] = 1e-4,
-                            rtol: Optional[float] = 1e-4,
-                            epsilon: Optional[float] = 1e-3) -> None:
+def check_finite_difference(
+        x0: Sequence[float],
+        model: Model,
+        solver: Solver,
+        edata: ExpData,
+        ip: int,
+        fields: List[str],
+        atol: Optional[float] = 1e-4,
+        rtol: Optional[float] = 1e-4,
+        epsilon: Optional[float] = 1e-3
+        ) -> None:
     """
     Checks the computed sensitivity based derivatives against a finite
     difference approximation.
@@ -104,7 +106,7 @@ def check_finite_difference(x0: Sequence[float],
 
     for field in fields:
         sensi_raw = rdata[f's{field}']
-        fd = (rdataf[field]-rdatab[field])/(pf[ip] - pb[ip])
+        fd = (rdataf[field] - rdatab[field]) / (pf[ip] - pb[ip])
         if len(sensi_raw.shape) == 1:
             sensi = sensi_raw[0]
         elif len(sensi_raw.shape) == 2:
@@ -114,7 +116,7 @@ def check_finite_difference(x0: Sequence[float],
         else:
             raise NotImplementedError()
 
-        check_close(sensi, fd, atol=atol, rtol=rtol, field=field, ip=ip)
+        _check_close(sensi, fd, atol=atol, rtol=rtol, field=field, ip=ip)
 
     solver.setSensitivityOrder(og_sensitivity_order)
     model.setParameters(og_parameters)
@@ -123,14 +125,16 @@ def check_finite_difference(x0: Sequence[float],
         edata.plist = og_eplist
 
 
-def check_derivatives(model: Model,
-                      solver: Solver,
-                      edata: Optional[ExpData] = None,
-                      atol: Optional[float] = 1e-4,
-                      rtol: Optional[float] = 1e-4,
-                      epsilon: Optional[float] = 1e-3,
-                      check_least_squares: bool = True,
-                      skip_zero_pars: bool = False) -> None:
+def check_derivatives(
+        model: Model,
+        solver: Solver,
+        edata: Optional[ExpData] = None,
+        atol: Optional[float] = 1e-4,
+        rtol: Optional[float] = 1e-4,
+        epsilon: Optional[float] = 1e-3,
+        check_least_squares: bool = True,
+        skip_zero_pars: bool = False
+) -> None:
     """
     Finite differences check for likelihood gradient.
 
@@ -204,7 +208,7 @@ def check_derivatives(model: Model,
                                 atol=atol, rtol=rtol, epsilon=epsilon)
 
 
-def check_close(
+def _check_close(
         result: np.array,
         expected: np.array,
         atol: float,
@@ -257,17 +261,19 @@ def check_close(
             lines.append(
                 f"\tat {idx}: Expected {expected[idx]}, got {result[idx]}")
     adev = np.abs(result - expected)
-    rdev = np.abs((result - expected)/(expected + atol))
+    rdev = np.abs((result - expected) / (expected + atol))
     lines.append(f'max(adev): {adev.max()}, max(rdev): {rdev.max()}')
 
     raise AssertionError("\n".join(lines))
 
 
-def check_results(rdata: ReturnData,
-                  field: str,
-                  expected: np.array,
-                  atol: float,
-                  rtol: float) -> None:
+def check_results(
+        rdata: ReturnData,
+        field: str,
+        expected: np.array,
+        atol: float,
+        rtol: float
+        ) -> None:
     """
     Checks whether rdata[field] agrees with expected according to provided
     tolerances.
@@ -293,5 +299,5 @@ def check_results(rdata: ReturnData,
     if type(result) is float:
         result = np.array(result)
 
-    check_close(result=result, expected=expected,
+    _check_close(result=result, expected=expected,
                 atol=atol, rtol=rtol, field=field)

--- a/python/amici/gradient_check.py
+++ b/python/amici/gradient_check.py
@@ -193,10 +193,10 @@ def check_derivatives(
     if check_least_squares and leastsquares_applicable:
         fields += ['res', 'y']
 
-        check_results(rdata, 'FIM', np.dot(rdata['sres'].T, rdata['sres']),
-                      atol=1e-8, rtol=1e-4)
-        check_results(rdata, 'sllh', -np.dot(rdata['res'].T, rdata['sres']),
-                      atol=1e-8, rtol=1e-4)
+        _check_results(rdata, 'FIM', np.dot(rdata['sres'].T, rdata['sres']),
+                       atol=1e-8, rtol=1e-4)
+        _check_results(rdata, 'sllh', -np.dot(rdata['res'].T, rdata['sres']),
+                       atol=1e-8, rtol=1e-4)
 
     if edata is not None:
         fields.append('llh')
@@ -237,7 +237,7 @@ def _check_close(
         relative tolerance for comparison
 
     :param ip:
-        parameter index
+        parameter index, for more informative output
 
     :param verbose:
         produce a more verbose error message in case of unmatched expectations
@@ -267,7 +267,7 @@ def _check_close(
     raise AssertionError("\n".join(lines))
 
 
-def check_results(
+def _check_results(
         rdata: ReturnData,
         field: str,
         expected: np.array,
@@ -300,4 +300,4 @@ def check_results(
         result = np.array(result)
 
     _check_close(result=result, expected=expected,
-                atol=atol, rtol=rtol, field=field)
+                 atol=atol, rtol=rtol, field=field)

--- a/python/amici/gradient_check.py
+++ b/python/amici/gradient_check.py
@@ -24,7 +24,7 @@ def check_finite_difference(
         atol: Optional[float] = 1e-4,
         rtol: Optional[float] = 1e-4,
         epsilon: Optional[float] = 1e-3
-        ) -> None:
+) -> None:
     """
     Checks the computed sensitivity based derivatives against a finite
     difference approximation.

--- a/python/tests/test_pregenerated_models.py
+++ b/python/tests/test_pregenerated_models.py
@@ -10,7 +10,7 @@ import amici
 import h5py
 import numpy as np
 import pytest
-from amici.gradient_check import check_derivatives, check_results
+from amici.gradient_check import check_derivatives, _check_results
 
 cpp_test_dir = Path(__file__).parents[2] / 'tests' / 'cpp'
 options_file = str(cpp_test_dir / 'testOptions.h5')
@@ -219,20 +219,20 @@ def verify_simulation_results(rdata, expected_results, fields=None,
                 if subfield not in subfields:
                     assert rdata[subfield] is None, field
                     continue
-                check_results(rdata, subfield,
-                              expected_results[field][subfield][()],
-                              atol=1e-8, rtol=1e-8)
+                _check_results(rdata, subfield,
+                               expected_results[field][subfield][()],
+                               atol=1e-8, rtol=1e-8)
         else:
             if field not in fields:
                 assert rdata[field] is None, field
                 continue
             if field == 's2llh':
-                check_results(rdata, field, expected_results[field][()],
-                              atol=1e-4, rtol=1e-3)
+                _check_results(rdata, field, expected_results[field][()],
+                               atol=1e-4, rtol=1e-3)
             else:
-                check_results(rdata, field, expected_results[field][()],
-                              atol=atol, rtol=rtol)
+                _check_results(rdata, field, expected_results[field][()],
+                               atol=atol, rtol=rtol)
 
     for attr in attrs:
-        check_results(rdata, attr, expected_results.attrs[attr],
-                      atol=atol, rtol=rtol)
+        _check_results(rdata, attr, expected_results.attrs[attr],
+                       atol=atol, rtol=rtol)

--- a/python/tests/test_pregenerated_models.py
+++ b/python/tests/test_pregenerated_models.py
@@ -22,10 +22,6 @@ model_cases = [(sub_test, case)
                for case in list(expected_results[sub_test].keys())]
 
 
-def assert_fun(x):
-    assert x
-
-
 @pytest.mark.skipif(os.environ.get('AMICI_SKIP_CMAKE_TESTS', '') == 'TRUE',
                     reason='skipping cmake based test')
 @pytest.mark.parametrize("sub_test,case", model_cases)
@@ -81,8 +77,7 @@ def test_pregenerated_model(sub_test, case):
             and len(model.getParameterList()) \
             and not model_name.startswith('model_neuron') \
             and not case.endswith('byhandpreeq'):
-        check_derivatives(model, solver, edata, assert_fun,
-                          **check_derivative_opts)
+        check_derivatives(model, solver, edata, **check_derivative_opts)
 
     verify_simulation_opts = dict()
 
@@ -165,8 +160,7 @@ def test_pregenerated_model(sub_test, case):
 
         if edata and solver.getSensitivityMethod() and \
                 solver.getSensitivityOrder() and len(model.getParameterList()):
-            check_derivatives(model, solver, edata, assert_fun,
-                              **check_derivative_opts)
+            check_derivatives(model, solver, edata, **check_derivative_opts)
 
         chi2_ref = rdata.chi2
         res_ref = rdata.res
@@ -227,18 +221,18 @@ def verify_simulation_results(rdata, expected_results, fields=None,
                     continue
                 check_results(rdata, subfield,
                               expected_results[field][subfield][()],
-                              assert_fun, 1e-8, 1e-8)
+                              atol=1e-8, rtol=1e-8)
         else:
             if field not in fields:
                 assert rdata[field] is None, field
                 continue
             if field == 's2llh':
                 check_results(rdata, field, expected_results[field][()],
-                              assert_fun, 1e-4, 1e-3)
+                              atol=1e-4, rtol=1e-3)
             else:
                 check_results(rdata, field, expected_results[field][()],
-                              assert_fun, atol, rtol)
+                              atol=atol, rtol=rtol)
 
     for attr in attrs:
-        check_results(rdata, attr, expected_results.attrs[attr], assert_fun,
-                      atol, rtol)
+        check_results(rdata, attr, expected_results.attrs[attr],
+                      atol=atol, rtol=rtol)

--- a/python/tests/test_sbml_import.py
+++ b/python/tests/test_sbml_import.py
@@ -77,10 +77,6 @@ def test_nosensi(simple_sbml_model):
         assert rdata.status == amici.AMICI_ERROR
 
 
-def assert_fun(x):
-    assert x
-
-
 @pytest.fixture
 def model_steadystate_module():
     sbml_file = os.path.join(os.path.dirname(__file__), '..',
@@ -153,7 +149,7 @@ def test_presimulation(sbml_example_presimulation_module):
 
     solver.setRelativeTolerance(1e-12)
     solver.setAbsoluteTolerance(1e-12)
-    check_derivatives(model, solver, edata, assert_fun, epsilon=1e-4)
+    check_derivatives(model, solver, edata, epsilon=1e-4)
 
 
 def test_steadystate_simulation(model_steadystate_module):
@@ -199,7 +195,7 @@ def test_steadystate_simulation(model_steadystate_module):
 
     solver.setRelativeTolerance(1e-12)
     solver.setAbsoluteTolerance(1e-12)
-    check_derivatives(model, solver, edata[0], assert_fun, atol=1e-3,
+    check_derivatives(model, solver, edata[0], atol=1e-3,
                       rtol=1e-3, epsilon=1e-4)
 
     # Run some additional tests which need a working Model,
@@ -301,7 +297,7 @@ def test_likelihoods(model_test_likelihoods):
         solver.setRelativeTolerance(1e-12)
         solver.setAbsoluteTolerance(1e-12)
         check_derivatives(
-            model, solver, edata, assert_fun, atol=1e-2, rtol=1e-2,
+            model, solver, edata, atol=1e-2, rtol=1e-2,
             epsilon=1e-5, check_least_squares=False
         )
 
@@ -381,7 +377,7 @@ def test_sympy_exp_monkeypatch():
 
         # print sensitivity-related results
         assert rdata['status'] == amici.AMICI_SUCCESS
-        check_derivatives(model, solver, None, assert_fun, atol=1e-2, rtol=1e-2,
+        check_derivatives(model, solver, None, atol=1e-2, rtol=1e-2,
                           epsilon=1e-3)
 
 

--- a/python/tests/test_sbml_import_special_functions.py
+++ b/python/tests/test_sbml_import_special_functions.py
@@ -14,10 +14,6 @@ import pytest
 from amici.gradient_check import check_derivatives
 
 
-def assert_fun(x):
-    assert x
-
-
 @pytest.fixture
 def model_special_likelihoods():
     """Test model for special likelihood functions."""
@@ -104,7 +100,7 @@ def test_special_likelihoods(model_special_likelihoods):
         solver.setSensitivityMethod(sensi_method)
         solver.setSensitivityOrder(amici.SensitivityOrder.first)
         check_derivatives(
-            model, solver, edata, assert_fun, atol=1e-1, rtol=1e-1,
+            model, solver, edata, atol=1e-1, rtol=1e-1,
             check_least_squares=False)
 
     # Test for m > y, i.e. in region with 0 density

--- a/tests/petab_test_suite/test_petab_suite.py
+++ b/tests/petab_test_suite/test_petab_suite.py
@@ -136,9 +136,6 @@ def check_derivatives(problem: petab.Problem, model: amici.Model) -> None:
     model.setSteadyStateSensitivityMode(
         SteadyStateSensitivityMode_simulationFSA)
 
-    def assert_true(x):
-        assert x
-
     for edata in create_parameterized_edatas(
             amici_model=model, petab_problem=problem,
             problem_parameters=problem_parameters):
@@ -147,7 +144,7 @@ def check_derivatives(problem: petab.Problem, model: amici.Model) -> None:
         model.setParameterScale(edata.pscale)
         edata.parameters = []
         edata.pscale = amici.parameterScalingFromIntVector([])
-        amici_check_derivatives(model, solver, edata, assert_true)
+        amici_check_derivatives(model, solver, edata)
 
 
 def run():


### PR DESCRIPTION
Breaking change:
* previously required argument `assert_fun` is removed from amici.gradient_check.*
* `check_result` and `check_close` are now private (but were anyways not very useful by themselves)

`assert_fun` was probably always used to pass `assert`, and stood in the way of providing proper error messages and meaningful stack traces.