### PR TITLE
Refactor ODE export

### DIFF
--- a/python/amici/ode_export.py
+++ b/python/amici/ode_export.py
@@ -83,7 +83,7 @@ class _FunctionInfo:
     assume_pow_positivity: bool = False
     sparse: bool = False
     dont_generate_body: bool = False
-    body: Union[None, str] = None
+    body: str = ''
 
 
 # Information on a model-specific generated C++ function
@@ -1508,7 +1508,6 @@ class ODEModel:
 
         :return:
             list of names
-
         """
         if name not in self._names:
             self._generate_name(name)
@@ -2598,7 +2597,7 @@ class ODEExporter:
             if not func_info.dont_generate_body:
                 dec = log_execution_time(f'writing {func_name}.cpp', logger)
                 dec(self._write_function_file)(func_name)
-            if func_name in sparse_functions and func_info.body is not None:
+            if func_name in sparse_functions and func_info.body:
                 self._write_function_index(func_name, 'colptrs')
                 self._write_function_index(func_name, 'rowvals')
 
@@ -2607,10 +2606,10 @@ class ODEExporter:
             # check for both basic variables (not in functions) and function
             # computed values
             if (name in self.functions
-                and self.functions[name].body is None
-                and name not in nobody_functions) or \
-                    (name not in self.functions and
-                     len(self.model.sym(name)) == 0):
+                and not self.functions[name].body
+                and name not in nobody_functions) \
+                    or (name not in self.functions and
+                        len(self.model.sym(name)) == 0):
                 continue
             self._write_index_files(name)
 
@@ -3208,7 +3207,7 @@ class ODEExporter:
             if func_name in nobody_functions:
                 continue
 
-            if func_info.body is None:
+            if not func_info.body:
                 tpl_data[f'{func_name.upper()}_DEF'] = ''
 
                 if func_name in sensi_functions + sparse_sensi_functions and \

--- a/python/amici/ode_export.py
+++ b/python/amici/ode_export.py
@@ -73,8 +73,8 @@ class _FunctionInfo:
         specifies whether the result of this function will be stored in sparse
         format. sparse format means that the function will only return an
         array of nonzero values and not a full matrix.
-    :ivar dont_generate_body:
-        indicates that no model-specific implementation is to be generated
+    :ivar generate_body:
+        indicates whether a model-specific implementation is to be generated
     :ivar body:
         the actual function body. will be filled later
     """
@@ -82,7 +82,7 @@ class _FunctionInfo:
     return_type: str = 'void'
     assume_pow_positivity: bool = False
     sparse: bool = False
-    dont_generate_body: bool = False
+    generate_body: bool = True
     body: str = ''
 
 
@@ -182,16 +182,16 @@ functions = {
             'realtype *stau, const realtype t, const realtype *x, '
             'const realtype *p, const realtype *k, const realtype *h, '
             'const realtype *sx, const int ip, const int ie',
-            dont_generate_body=True
+            generate_body=False
         ),
     'drootdt':
-        _FunctionInfo(dont_generate_body=True),
+        _FunctionInfo(generate_body=False),
     'drootdt_total':
-        _FunctionInfo(dont_generate_body=True),
+        _FunctionInfo(generate_body=False),
     'drootdp':
-        _FunctionInfo(dont_generate_body=True),
+        _FunctionInfo(generate_body=False),
     'drootdx':
-        _FunctionInfo(dont_generate_body=True),
+        _FunctionInfo(generate_body=False),
     'stau':
         _FunctionInfo(
             'realtype *stau, const realtype t, const realtype *x, '
@@ -205,11 +205,11 @@ functions = {
             'const int ie, const realtype *xdot, const realtype *xdot_old'
         ),
     'ddeltaxdx':
-        _FunctionInfo(dont_generate_body=True),
+        _FunctionInfo(generate_body=False),
     'ddeltaxdt':
-        _FunctionInfo(dont_generate_body=True),
+        _FunctionInfo(generate_body=False),
     'ddeltaxdp':
-        _FunctionInfo(dont_generate_body=True),
+        _FunctionInfo(generate_body=False),
     'deltasx':
         _FunctionInfo(
             'realtype *deltasx, const realtype t, const realtype *x, '
@@ -255,7 +255,7 @@ functions = {
             assume_pow_positivity=True
         ),
     'xdot_old':
-        _FunctionInfo(dont_generate_body=True),
+        _FunctionInfo(generate_body=False),
     'y':
         _FunctionInfo(
             'realtype *y, const realtype t, const realtype *x, '
@@ -281,7 +281,7 @@ sparse_functions = [
 # list of nobody functions
 nobody_functions = [
     func_name for func_name, func_info in functions.items()
-    if func_info.dont_generate_body
+    if not func_info.generate_body
 ]
 # list of sensitivity functions
 sensi_functions = [
@@ -2594,7 +2594,7 @@ class ODEExporter:
                     not self.generate_sensitivity_code:
                 continue
 
-            if not func_info.dont_generate_body:
+            if func_info.generate_body:
                 dec = log_execution_time(f'writing {func_name}.cpp', logger)
                 dec(self._write_function_file)(func_name)
             if func_name in sparse_functions and func_info.body:

--- a/python/amici/ode_export.py
+++ b/python/amici/ode_export.py
@@ -2721,10 +2721,9 @@ class ODEExporter:
         if name not in self.model.sym_names():
             raise ValueError(f'Unknown symbolic array: {name}')
 
-        if name in sparse_functions:
-            symbols = self.model.sparsesym(name)
-        else:
-            symbols = self.model.sym(name).T
+        symbols = self.model.sparsesym(name) if name in sparse_functions \
+            else self.model.sym(name).T
+
         # flatten multiobs
         if isinstance(next(iter(symbols), None), list):
             symbols = [symbol for obs in symbols for symbol in obs]

--- a/python/amici/ode_export.py
+++ b/python/amici/ode_export.py
@@ -2780,11 +2780,10 @@ class ODEExporter:
         # don't add includes for files that won't be generated.
         # Unfortunately we cannot check for `self.functions[sym].body`
         # here since it may not have been generated yet.
-        for match in re.findall(
-                r'const (realtype|double) \*([\w]+)[0]*(,|$)+',
+        for sym in re.findall(
+                r'const (?:realtype|double) \*([\w]+)[0]*(?:,|$)',
                 func_info.arguments
         ):
-            sym = match[1]
             if sym not in self.model.sym_names():
                 continue
 

--- a/python/amici/ode_export.py
+++ b/python/amici/ode_export.py
@@ -73,6 +73,10 @@ class _FunctionInfo:
         specifies whether the result of this function will be stored in sparse
         format. sparse format means that the function will only return an
         array of nonzero values and not a full matrix.
+    :ivar dont_generate_body:
+        indicates that no model-specific implementation is to be generated
+    :ivar body:
+        the actual function body. will be filled later
     """
     arguments: str = ''
     return_type: str = 'void'

--- a/python/amici/ode_export.py
+++ b/python/amici/ode_export.py
@@ -2824,10 +2824,11 @@ class ODEExporter:
             body = [re.sub(r'(^|\W)std::pow\(', r'\1amici::pos_pow(', line)
                     for line in body]
 
-        if body:
-            func_info.body = body
-        else:
+        if not body:
             return
+
+        self.functions[function].body = body
+
         lines += body
         lines.extend([
             '}',
@@ -2844,9 +2845,9 @@ class ODEExporter:
                 lines.insert(0, fun['include'])
 
         # if not body is None:
-        with open(os.path.join(
-                self.model_path, f'{self.model_name}_{function}.cpp'), 'w'
-        ) as fileout:
+        filename = os.path.join(self.model_path,
+                                f'{self.model_name}_{function}.cpp')
+        with open(filename, 'w') as fileout:
             fileout.write('\n'.join(lines))
 
     def _write_function_index(self, function: str, indextype: str) -> None:

--- a/python/amici/ode_export.py
+++ b/python/amici/ode_export.py
@@ -348,7 +348,7 @@ def var_in_function_signature(name: str, varname: str) -> bool:
     """
     return name in functions \
         and re.search(
-            rf'const (realtype|double) \*{varname}[0]*[,)]+',
+            rf'const (realtype|double) \*{varname}[0]*(,|$)+',
             functions[name].arguments
         )
 

--- a/python/tests/test_sbml_import.py
+++ b/python/tests/test_sbml_import.py
@@ -50,7 +50,6 @@ def test_sbml2amici_no_observables(simple_sbml_model):
                                  observables=None,
                                  compute_conservation_laws=False)
 
-
 @pytest.mark.skipif(sys.platform in ['win32', 'cygwin'],
                     reason="windows stinks")
 def test_nosensi(simple_sbml_model):

--- a/python/tests/test_sbml_import.py
+++ b/python/tests/test_sbml_import.py
@@ -50,6 +50,7 @@ def test_sbml2amici_no_observables(simple_sbml_model):
                                  observables=None,
                                  compute_conservation_laws=False)
 
+
 @pytest.mark.skipif(sys.platform in ['win32', 'cygwin'],
                     reason="windows stinks")
 def test_nosensi(simple_sbml_model):


### PR DESCRIPTION
* Use class instead of dict for function info, to simplify default argument handling and to find more easily where the respective values are used.

* Allow specifying non-void return type.

* Remove redundant virtual with override

* Cleanup.

Will simplify some changes in #1515