### PR TITLE
Handle TemporaryDirectory cleanup failures on Windows

### DIFF
--- a/python/amici/testing.py
+++ b/python/amici/testing.py
@@ -1,0 +1,19 @@
+"""Test support functions"""
+
+import sys
+from tempfile import TemporaryDirectory
+
+
+class TemporaryDirectoryWinSafe(TemporaryDirectory):
+    """TemporaryDirectory that will not raise if cleanup fails.
+
+    If any extension was loaded from the temporary directory, cleanup would
+    otherwise fail on Windows with a ``PermissionError``. This class ignores
+    such failures.
+    """
+    def cleanup(self):
+        try:
+            super().cleanup()
+        except PermissionError as e:
+            if sys.platform not in {'win32', 'cygwin'}:
+                raise e

--- a/python/sdist/amici/testing.py
+++ b/python/sdist/amici/testing.py
@@ -1,0 +1,1 @@
+../../amici/testing.py

--- a/python/tests/test_sbml_import.py
+++ b/python/tests/test_sbml_import.py
@@ -1,18 +1,17 @@
 """Tests related to amici.sbml_import"""
-
 import os
-import sys
 import re
-from urllib.request import urlopen
 import shutil
-from tempfile import TemporaryDirectory
+from urllib.request import urlopen
 
-import amici
 import libsbml
 import numpy as np
 import pytest
+
+import amici
 from amici.gradient_check import check_derivatives
 from amici.sbml_import import SbmlImporter
+from amici.testing import TemporaryDirectoryWinSafe as TemporaryDirectory
 
 
 @pytest.fixture
@@ -50,9 +49,11 @@ def test_sbml2amici_no_observables(simple_sbml_model):
                                  observables=None,
                                  compute_conservation_laws=False)
 
+        # Ensure import succeeds (no missing symbols)
+        module_module = amici.import_model_module("test", tmpdir)
+        assert hasattr(module_module, 'getModel')
 
-@pytest.mark.skipif(sys.platform in ['win32', 'cygwin'],
-                    reason="windows stinks")
+
 def test_nosensi(simple_sbml_model):
     sbml_doc, sbml_model = simple_sbml_model
     sbml_importer = SbmlImporter(sbml_source=sbml_model,


### PR DESCRIPTION
If any extension was loaded from a temporary directory, cleanup would fail on Windows with a ``PermissionError``. Ignore such failures.