### PR TITLE
Allowing all integer parameter vector.

### DIFF
--- a/python/amici/parameter_mapping.py
+++ b/python/amici/parameter_mapping.py
@@ -246,7 +246,7 @@ def fill_in_parameters_for_condition(
     ]
 
     if parameters:
-        edata.parameters = parameters
+        edata.parameters = np.asarray(parameters, dtype=float)
 
     if scales:
         edata.pscale = amici.parameterScalingFromIntVector(scales)


### PR DESCRIPTION
Evaluating an objective function with an all integer parameter vector throws the following error:

`TypeError: in method 'SimulationParameters_parameters_set', argument 2 of type 'std::vector< amici::realtype,std::allocator< amici::realtype > > const &'`

This PR mitigates the requirement for manual creation of a float vector of parameters.