### PR TITLE
Add environment variable AMICI_DLL_DIRS to control DLL directories on Windows

### DIFF
--- a/.github/workflows/test_windows.yml
+++ b/.github/workflows/test_windows.yml
@@ -9,9 +9,19 @@ jobs:
 
     env:
       AMICI_SKIP_CMAKE_TESTS: "TRUE"
-      openBLAS_version: "0.3.12"
+      openBLAS_version: "0.3.19"
+      AMICI_DLL_DIRS: "C:\\BLAS\\bin"
+
+    strategy:
+      matrix:
+        python-version: [ "3.8" ]
 
     steps:
+    - name: Set up Python ${{ matrix.python-version }}
+      uses: actions/setup-python@v2
+      with:
+        python-version: ${{ matrix.python-version }}
+
     - uses: actions/checkout@master
     - run: git fetch --prune --unshallow
 
@@ -47,6 +57,8 @@ jobs:
       working-directory: python/sdist
       shell: bash
       run: pip install -v $(ls -t dist/amici-*.tar.gz | head -1)
+
+    - run: python -m amici
 
     - name: Run Python tests
       run: python -m pytest --ignore-glob=*petab* --ignore-glob=*special* python/tests

--- a/documentation/python_installation.rst
+++ b/documentation/python_installation.rst
@@ -268,7 +268,7 @@ by MSVC (see Visual Studio above). ``KERNEL32.dll`` is part of Windows and in
 
 .. note::
 
-    Since Python 3.8, the library directory needs to be set as follows:
+    Since Python 3.8, the library directory needs to be set either from Python:
 
     .. code-block:: python
 
@@ -277,7 +277,7 @@ by MSVC (see Visual Studio above). ``KERNEL32.dll`` is part of Windows and in
         os.add_dll_directory("C:\\BLAS\\bin")
         import amici
 
-    Adding it to ``PATH`` will not work.
+    or via the environment variable ``AMICI_DLL_DIRS``.
 
 Further topics
 ++++++++++++++

--- a/scripts/installOpenBLAS.ps1
+++ b/scripts/installOpenBLAS.ps1
@@ -1,5 +1,5 @@
 Write-Host 'script installOpenBLAS.ps1 started'
-$version = '0.3.12'
+$version = '0.3.19'
 New-Item -Path 'C:\BLAS' -ItemType Directory -Force # create directory
 # Enforce stronger cryptography
 [System.Net.ServicePointManager]::SecurityProtocol = [System.Net.SecurityProtocolType]::Tls12

--- a/swig/amici.i
+++ b/swig/amici.i
@@ -189,6 +189,17 @@ RDataReporting = enum('RDataReporting')
 
 %template(SteadyStateStatusVector) std::vector<amici::SteadyStateStatus>;
 
+%pythonbegin %{
+import sys
+import os
+
+if sys.platform == 'win32':
+    for dll_dir in os.environ.get("AMICI_DLL_DIRS", "").split(os.pathsep):
+        os.add_dll_directory(dll_dir)
+
+%}
+
+
 // add module docstring and import additional types for typehints
 %pythonbegin %{
 """


### PR DESCRIPTION
Since Python3.8, external DLL directories need to be added via os.add_dll_directory.

This change provides the AMICI_DLL_DIRS environment variable as an alternative way to specify these directories.

Also, upgrades OpenBLAS to 0.3.19 and runs Windows tests on Python 3.8.