### PR TITLE
More informative NaN/Inf warnings

### DIFF
--- a/include/amici/misc.h
+++ b/include/amici/misc.h
@@ -187,6 +187,17 @@ class ContextManager{
     ContextManager(ContextManager &&other) = delete;
 };
 
+
+/**
+ * @brief Convert a flat index to a pair of row/column indices,
+ * assuming row-major order.
+ * @param flat_idx flat index
+ * @param num_cols number of columns of referred to matrix
+ * @return row index, column index
+ */
+auto unravel_index(size_t flat_idx, size_t num_cols)
+    -> std::pair<size_t, size_t>;
+
 } // namespace amici
 
 #endif // AMICI_MISC_H

--- a/include/amici/model.h
+++ b/include/amici/model.h
@@ -35,6 +35,34 @@ void serialize(Archive &ar, amici::Model &m, unsigned int version);
 namespace amici {
 
 /**
+ * @brief Describes the various model quantities
+ */
+enum class ModelQuantity {
+    J,
+    JB,
+    Jv,
+    JvB,
+    sx,
+    sy,
+    xdot,
+    xBdot,
+    x0_rdata,
+    x0,
+    x_rdata,
+    x,
+    dwdw,
+    dwdx,
+    dwdp,
+    y,
+    dydp,
+    dydx,
+    w,
+};
+
+extern std::map<ModelQuantity, std::string> model_quantity_to_str;
+
+
+/**
  * @brief The Model class represents an AMICI ODE/DAE model.
  *
  * The model can compute various model related quantities based on symbolically
@@ -1206,6 +1234,8 @@ class Model : public AbstractModel, public ModelDimensions {
      *
      * If not, try to give hints by which other fields this could be caused.
      *
+     * For (1D) spans.
+     *
      * @param array Array to check
      * @param fun Name of the function that generated the values (for more
      * informative messages).
@@ -1213,6 +1243,43 @@ class Model : public AbstractModel, public ModelDimensions {
      * `amici::AMICI_SUCCESS` otherwise
      */
     int checkFinite(gsl::span<const realtype> array, const char *fun) const;
+
+    /**
+     * @brief Check if the given array has only finite elements.
+     *
+     * For (1D) spans.
+     *
+     * @param array
+     * @param model_quantity The model quantity `array` corresponds to
+     * @return
+     */
+    int checkFinite(gsl::span<const realtype> array,
+                           ModelQuantity model_quantity) const;
+    /**
+     * @brief Check if the given array has only finite elements.
+     *
+     * For flattened 2D arrays.
+     *
+     * @param array Flattened matrix
+     * @param model_quantity The model quantity `array` corresponds to
+     * @param num_cols Number of columns of the non-flattened matrix
+     * @return
+     */
+    int checkFinite(gsl::span<const realtype> array,
+                    ModelQuantity model_quantity,
+                    size_t num_cols) const;
+
+    /**
+     * @brief Check if the given array has only finite elements.
+     *
+     * For SUNMatrix.
+     *
+     * @param m Matrix to check
+     * @param model_quantity The model quantity `m` corresponds to
+     * @param t current timepoint
+     * @return
+     */
+    int checkFinite(SUNMatrix m, ModelQuantity model_quantity, realtype t) const;
 
     /**
      * @brief Set whether the result of every call to `Model::f*` should be

--- a/include/amici/model.h
+++ b/include/amici/model.h
@@ -44,6 +44,7 @@ enum class ModelQuantity {
     JvB,
     sx,
     sy,
+    ssigmay,
     xdot,
     xBdot,
     x0_rdata,

--- a/include/amici/model.h
+++ b/include/amici/model.h
@@ -67,7 +67,7 @@ enum class ModelQuantity {
     JSparseB_ss,
 };
 
-extern std::map<ModelQuantity, std::string> model_quantity_to_str;
+extern const std::map<ModelQuantity, std::string> model_quantity_to_str;
 
 
 /**

--- a/include/amici/model.h
+++ b/include/amici/model.h
@@ -42,6 +42,7 @@ enum class ModelQuantity {
     JB,
     Jv,
     JvB,
+    JDiag,
     sx,
     sy,
     ssigmay,

--- a/include/amici/model.h
+++ b/include/amici/model.h
@@ -47,6 +47,7 @@ enum class ModelQuantity {
     sy,
     ssigmay,
     xdot,
+    sxdot,
     xBdot,
     x0_rdata,
     x0,
@@ -59,6 +60,11 @@ enum class ModelQuantity {
     dydp,
     dydx,
     w,
+    root,
+    qBdot,
+    qBdot_ss,
+    xBdot_ss,
+    JSparseB_ss,
 };
 
 extern std::map<ModelQuantity, std::string> model_quantity_to_str;

--- a/include/amici/model.h
+++ b/include/amici/model.h
@@ -1237,20 +1237,6 @@ class Model : public AbstractModel, public ModelDimensions {
      */
     void updateHeavisideB(const int *rootsfound);
 
-    /**
-     * @brief Check if the given array has only finite elements.
-     *
-     * If not, try to give hints by which other fields this could be caused.
-     *
-     * For (1D) spans.
-     *
-     * @param array Array to check
-     * @param fun Name of the function that generated the values (for more
-     * informative messages).
-     * @return `amici::AMICI_RECOVERABLE_ERROR` if a NaN/Inf value was found,
-     * `amici::AMICI_SUCCESS` otherwise
-     */
-    int checkFinite(gsl::span<const realtype> array, const char *fun) const;
 
     /**
      * @brief Check if the given array has only finite elements.

--- a/include/amici/sundials_matrix_wrapper.h
+++ b/include/amici/sundials_matrix_wrapper.h
@@ -532,6 +532,16 @@ class SUNMatrixWrapper {
     bool ownmat = true;
 };
 
+
+/**
+ * @brief Convert a flat index to a pair of row/column indices.
+ * @param i flat index
+ * @param m referred to matrix
+ * @return row index, column index
+ */
+auto unravel_index(sunindextype i, SUNMatrix m)
+    -> std::pair<sunindextype, sunindextype>;
+
 } // namespace amici
 
 namespace gsl {

--- a/src/amici.cpp
+++ b/src/amici.cpp
@@ -179,7 +179,7 @@ AmiciApplication::runAmiciSimulation(Solver& solver,
                 throw;
             warningF("AMICI:simulation",
                      "AMICI forward simulation failed at t = %f: "
-                     "Maximum time exceeed.\n",
+                     "Maximum time exceeded.\n",
                      ex.time);
         } else {
             rdata->status = ex.error_code;
@@ -199,7 +199,7 @@ AmiciApplication::runAmiciSimulation(Solver& solver,
             warningF(
                 "AMICI:simulation",
                 "AMICI backward simulation failed when trying to solve until "
-                "t = %f: Maximum time exceeed.\n",
+                "t = %f: Maximum time exceeded.\n",
                 ex.time);
 
         } else {
@@ -305,6 +305,8 @@ AmiciApplication::errorF(const char* identifier, const char* format, ...) const
 int
 AmiciApplication::checkFinite(gsl::span<const realtype> array, const char* fun)
 {
+    Expects(array.size()
+            <= static_cast<unsigned>(std::numeric_limits<int>::max()));
 
     for (int idx = 0; idx < (int)array.size(); idx++) {
         if (isNaN(array[idx])) {

--- a/src/misc.cpp
+++ b/src/misc.cpp
@@ -178,4 +178,9 @@ std::string printfToString(const char *fmt, va_list ap) {
     return str;
 }
 
+std::pair<size_t, size_t> unravel_index(size_t flat_idx, size_t num_cols)
+{
+    return {flat_idx / num_cols, flat_idx % num_cols};
+}
+
 } // namespace amici

--- a/src/model.cpp
+++ b/src/model.cpp
@@ -1302,22 +1302,31 @@ int Model::checkFinite(gsl::span<const realtype> array,
         break;
     }
 
+    std::string model_quantity_str;
+    try {
+        model_quantity_str = model_quantity_to_str.at(model_quantity);
+    } catch (std::out_of_range&) {
+        // Missing model quantity string - terminate if this is a debug build,
+        // but show the quantity number if non-debug.
+        gsl_ExpectsDebug(false);
+        model_quantity_str = std::to_string(static_cast<int>(model_quantity));
+    }
     app->warningF(msg_id.c_str(),
                   "AMICI encountered a %s value for %s[%i] (%s)",
                   non_finite_type.c_str(),
-                  model_quantity_to_str[model_quantity].c_str(),
+                  model_quantity_str.c_str(),
                   static_cast<int>(flat_index),
                   element_id.c_str()
                   );
 
     // check upstream
-    if(!always_check_finite_) {
-        // don't check twice if always_check_finite_
-        app->checkFinite(derived_state_.w_, "w");
-    }
     app->checkFinite(state_.fixedParameters, "k");
     app->checkFinite(state_.unscaledParameters, "p");
     app->checkFinite(simulation_parameters_.ts_, "t");
+    if(!always_check_finite_) {
+        // don't check twice if always_check_finite_ is true
+        app->checkFinite(derived_state_.w_, "w");
+    }
 
     return AMICI_RECOVERABLE_ERROR;
 }
@@ -1362,20 +1371,30 @@ int Model::checkFinite(gsl::span<const realtype> array,
         break;
     }
 
+    std::string model_quantity_str;
+    try {
+        model_quantity_str = model_quantity_to_str.at(model_quantity);
+    } catch (std::out_of_range&) {
+        // Missing model quantity string - terminate if this is a debug build,
+        // but show the quantity number if non-debug.
+        gsl_ExpectsDebug(false);
+        model_quantity_str = std::to_string(static_cast<int>(model_quantity));
+    }
+
     app->warningF(msg_id.c_str(),
                   "AMICI encountered a %s value for %s[%i] (%s, %s)",
                   non_finite_type.c_str(),
-                  model_quantity_to_str[model_quantity].c_str(),
+                  model_quantity_str.c_str(),
                   static_cast<int>(flat_index),
                   row_id.c_str(),
                   col_id.c_str()
                   );
 
-       // check upstream
+    // check upstream
     app->checkFinite(state_.fixedParameters, "k");
     app->checkFinite(state_.unscaledParameters, "p");
-    app->checkFinite(derived_state_.w_, "w");
     app->checkFinite(simulation_parameters_.ts_, "t");
+    app->checkFinite(derived_state_.w_, "w");
 
     return AMICI_RECOVERABLE_ERROR;
 }
@@ -1443,21 +1462,30 @@ int Model::checkFinite(SUNMatrix m, ModelQuantity model_quantity, realtype t) co
         break;
     }
 
+    std::string model_quantity_str;
+    try {
+        model_quantity_str = model_quantity_to_str.at(model_quantity);
+    } catch (std::out_of_range&) {
+        // Missing model quantity string - terminate if this is a debug build,
+        // but show the quantity number if non-debug.
+        gsl_ExpectsDebug(false);
+        model_quantity_str = std::to_string(static_cast<int>(model_quantity));
+    }
     app->warningF(msg_id.c_str(),
                   "AMICI encountered a %s value for %s[%i] (%s, %s) at t=%g",
                   non_finite_type.c_str(),
-                  model_quantity_to_str[model_quantity].c_str(),
+                  model_quantity_str.c_str(),
                   static_cast<int>(flat_index),
                   row_id.c_str(),
                   col_id.c_str(),
                   t
                   );
 
-       // check upstream
+    // check upstream
     app->checkFinite(state_.fixedParameters, "k");
     app->checkFinite(state_.unscaledParameters, "p");
-    app->checkFinite(derived_state_.w_, "w");
     app->checkFinite(simulation_parameters_.ts_, "t");
+    app->checkFinite(derived_state_.w_, "w");
 
     return AMICI_RECOVERABLE_ERROR;
 }

--- a/src/model.cpp
+++ b/src/model.cpp
@@ -1439,7 +1439,6 @@ int Model::checkFinite(SUNMatrix m, ModelQuantity model_quantity, realtype t) co
         }
         break;
     case ModelQuantity::dwdx:
-        // FIXME: indices wrong?!
         if(hasExpressionIds())
             row_id += " " + getExpressionIds()[row];
         if(hasStateIds())

--- a/src/model.cpp
+++ b/src/model.cpp
@@ -1251,19 +1251,6 @@ void Model::updateHeavisideB(const int *rootsfound) {
     }
 }
 
-int Model::checkFinite(gsl::span<const realtype> array, const char *fun) const {
-    auto result = app->checkFinite(array, fun);
-
-    if (result != AMICI_SUCCESS) {
-        app->checkFinite(state_.fixedParameters, "k");
-        app->checkFinite(state_.unscaledParameters, "p");
-        app->checkFinite(derived_state_.w_, "w");
-        app->checkFinite(simulation_parameters_.ts_, "t");
-    }
-
-    return result;
-}
-
 int Model::checkFinite(gsl::span<const realtype> array,
                        ModelQuantity model_quantity) const
 {

--- a/src/model.cpp
+++ b/src/model.cpp
@@ -23,6 +23,7 @@ std::map<ModelQuantity, std::string> model_quantity_to_str {
     {ModelQuantity::JB, "JB"},
     {ModelQuantity::Jv, "Jv"},
     {ModelQuantity::JvB, "JvB"},
+    {ModelQuantity::JDiag, "JDiag"},
     {ModelQuantity::sx, "sx"},
     {ModelQuantity::sy, "sy"},
     {ModelQuantity::ssigmay, "ssigmay"},
@@ -1287,6 +1288,9 @@ int Model::checkFinite(gsl::span<const realtype> array,
     case ModelQuantity::x:
     case ModelQuantity::x_rdata:
     case ModelQuantity::x0_rdata:
+    case ModelQuantity::Jv:
+    case ModelQuantity::JvB:
+    case ModelQuantity::JDiag:
         if(hasStateIds()) {
             element_id = getStateIdsSolver()[flat_index];
         }
@@ -1416,8 +1420,6 @@ int Model::checkFinite(SUNMatrix m, ModelQuantity model_quantity, realtype t) co
     switch (model_quantity) {
     case ModelQuantity::J:
     case ModelQuantity::JB:
-    case ModelQuantity::Jv:
-    case ModelQuantity::JvB:
         if(hasStateIds()) {
             auto state_ids = getStateIdsSolver();
             row_id += " " + state_ids[row];

--- a/src/model.cpp
+++ b/src/model.cpp
@@ -18,7 +18,7 @@ namespace amici {
 /**
  * @brief Maps ModelQuantity items to their string value
  */
-std::map<ModelQuantity, std::string> model_quantity_to_str {
+const std::map<ModelQuantity, std::string> model_quantity_to_str {
     {ModelQuantity::J, "J"},
     {ModelQuantity::JB, "JB"},
     {ModelQuantity::Jv, "Jv"},
@@ -1305,7 +1305,7 @@ int Model::checkFinite(gsl::span<const realtype> array,
     std::string model_quantity_str;
     try {
         model_quantity_str = model_quantity_to_str.at(model_quantity);
-    } catch (std::out_of_range&) {
+    } catch (std::out_of_range const&) {
         // Missing model quantity string - terminate if this is a debug build,
         // but show the quantity number if non-debug.
         gsl_ExpectsDebug(false);
@@ -1374,7 +1374,7 @@ int Model::checkFinite(gsl::span<const realtype> array,
     std::string model_quantity_str;
     try {
         model_quantity_str = model_quantity_to_str.at(model_quantity);
-    } catch (std::out_of_range&) {
+    } catch (std::out_of_range const&) {
         // Missing model quantity string - terminate if this is a debug build,
         // but show the quantity number if non-debug.
         gsl_ExpectsDebug(false);
@@ -1464,7 +1464,7 @@ int Model::checkFinite(SUNMatrix m, ModelQuantity model_quantity, realtype t) co
     std::string model_quantity_str;
     try {
         model_quantity_str = model_quantity_to_str.at(model_quantity);
-    } catch (std::out_of_range&) {
+    } catch (std::out_of_range const&) {
         // Missing model quantity string - terminate if this is a debug build,
         // but show the quantity number if non-debug.
         gsl_ExpectsDebug(false);

--- a/src/model.cpp
+++ b/src/model.cpp
@@ -28,6 +28,7 @@ std::map<ModelQuantity, std::string> model_quantity_to_str {
     {ModelQuantity::sy, "sy"},
     {ModelQuantity::ssigmay, "ssigmay"},
     {ModelQuantity::xdot, "xdot"},
+    {ModelQuantity::sxdot, "sxdot"},
     {ModelQuantity::xBdot, "xBdot"},
     {ModelQuantity::x0, "x0"},
     {ModelQuantity::x0_rdata, "x0_rdata"},
@@ -40,6 +41,11 @@ std::map<ModelQuantity, std::string> model_quantity_to_str {
     {ModelQuantity::dydp, "dydp"},
     {ModelQuantity::dydx, "dydx"},
     {ModelQuantity::w, "w"},
+    {ModelQuantity::root, "root"},
+    {ModelQuantity::qBdot, "qBdot"},
+    {ModelQuantity::qBdot_ss, "qBdot_ss"},
+    {ModelQuantity::xBdot_ss, "xBdot_ss"},
+    {ModelQuantity::JSparseB_ss, "JSparseB_ss"},
 };
 
 /**

--- a/src/model.cpp
+++ b/src/model.cpp
@@ -25,6 +25,7 @@ std::map<ModelQuantity, std::string> model_quantity_to_str {
     {ModelQuantity::JvB, "JvB"},
     {ModelQuantity::sx, "sx"},
     {ModelQuantity::sy, "sy"},
+    {ModelQuantity::ssigmay, "ssigmay"},
     {ModelQuantity::xdot, "xdot"},
     {ModelQuantity::xBdot, "xBdot"},
     {ModelQuantity::x0, "x0"},
@@ -900,7 +901,7 @@ void Model::getObservableSigmaSensitivity(gsl::span<realtype> ssigmay,
     }
 
     if (always_check_finite_)
-        checkFinite(ssigmay, "ssigmay");
+        checkFinite(ssigmay, ModelQuantity::ssigmay, nplist());
 }
 
 void Model::addObservableObjective(realtype &Jy, const int it,
@@ -1314,6 +1315,7 @@ int Model::checkFinite(gsl::span<const realtype> array,
 
     // check upstream
     if(!always_check_finite_) {
+        // don't check twice if always_check_finite_
         app->checkFinite(derived_state_.w_, "w");
     }
     app->checkFinite(state_.fixedParameters, "k");
@@ -1350,6 +1352,7 @@ int Model::checkFinite(gsl::span<const realtype> array,
 
     switch (model_quantity) {
     case ModelQuantity::sy:
+    case ModelQuantity::ssigmay:
     case ModelQuantity::dydp:
         row_id += " " + getObservableIds()[row];
         col_id += " " + getParameterIds()[plist(col)];

--- a/src/model_dae.cpp
+++ b/src/model_dae.cpp
@@ -87,7 +87,7 @@ void Model_DAE::fJDiag(const realtype t, AmiVector &JDiag,
     fJSparse(t, 0.0, x.getNVector(), dx.getNVector(), derived_state_.J_.get());
     derived_state_.J_.refresh();
     derived_state_.J_.to_diag(JDiag.getNVector());
-    if (!checkFinite(JDiag.getVector(), "Jacobian"))
+    if (checkFinite(JDiag.getVector(), ModelQuantity::JDiag) != AMICI_SUCCESS)
         throw AmiException("Evaluation of fJDiag failed!");
 }
 

--- a/src/model_ode.cpp
+++ b/src/model_ode.cpp
@@ -105,7 +105,7 @@ void Model_ODE::fJDiag(const realtype t, AmiVector &JDiag,
                        const realtype /*cj*/, const AmiVector &x,
                        const AmiVector & /*dx*/) {
     fJDiag(t, JDiag.getNVector(), x.getNVector());
-    if (checkFinite(JDiag.getVector(), "Jacobian") != AMICI_SUCCESS)
+    if (checkFinite(JDiag.getVector(), ModelQuantity::JDiag) != AMICI_SUCCESS)
         throw AmiException("Evaluation of fJDiag failed!");
 }
 

--- a/src/solver_cvodes.cpp
+++ b/src/solver_cvodes.cpp
@@ -807,7 +807,6 @@ const Model *CVodeSolver::getModel() const {
 
 /**
  * @brief Jacobian of xdot with respect to states x
- * @param N number of state variables
  * @param t timepoint
  * @param x Vector with the states
  * @param xdot Vector with the right hand side
@@ -827,13 +826,12 @@ static int fJ(realtype t, N_Vector x, N_Vector xdot, SUNMatrix J,
     Expects(model);
 
     model->fJ(t, x, xdot, J);
-    return model->checkFinite(gsl::make_span(J), "Jacobian");
+    return model->checkFinite(J, ModelQuantity::J, t);
 }
 
 
 /**
  * @brief Jacobian of xBdot with respect to adjoint state xB
- * @param NeqBdot number of adjoint state variables
  * @param t timepoint
  * @param x Vector with the states
  * @param xB Vector with the adjoint states
@@ -854,7 +852,7 @@ static int fJB(realtype t, N_Vector x, N_Vector xB, N_Vector xBdot,
     Expects(model);
 
     model->fJB(t, x, xB, xBdot, JB);
-    return model->checkFinite(gsl::make_span(JB), "Jacobian");
+    return model->checkFinite(gsl::make_span(JB), ModelQuantity::JB);
 }
 
 
@@ -879,7 +877,7 @@ static int fJSparse(realtype t, N_Vector x, N_Vector /*xdot*/,
     Expects(model);
 
     model->fJSparse(t, x, J);
-    return model->checkFinite(gsl::make_span(J), "Jacobian");
+    return model->checkFinite(J, ModelQuantity::J, t);
 }
 
 
@@ -905,7 +903,7 @@ static int fJSparseB(realtype t, N_Vector x, N_Vector xB, N_Vector xBdot,
     Expects(model);
 
     model->fJSparseB(t, x, xB, xBdot, JB);
-    return model->checkFinite(gsl::make_span(JB), "Jacobian");
+    return model->checkFinite(gsl::make_span(JB), ModelQuantity::JB);
 }
 
 
@@ -967,7 +965,7 @@ static int fJv(N_Vector v, N_Vector Jv, realtype t, N_Vector x,
     Expects(model);
 
     model->fJv(v, Jv, t, x);
-    return model->checkFinite(gsl::make_span(Jv), "Jacobian");
+    return model->checkFinite(gsl::make_span(Jv), ModelQuantity::Jv);
 }
 
 
@@ -993,7 +991,7 @@ static int fJvB(N_Vector vB, N_Vector JvB, realtype t, N_Vector x,
     Expects(model);
 
     model->fJvB(vB, JvB, t, x, xB);
-    return model->checkFinite(gsl::make_span(JvB), "Jacobian");
+    return model->checkFinite(gsl::make_span(JvB), ModelQuantity::JvB);
 }
 
 
@@ -1038,7 +1036,8 @@ static int fxdot(realtype t, N_Vector x, N_Vector xdot, void *user_data) {
         return AMICI_MAX_TIME_EXCEEDED;
     }
 
-    if (t > 1e200 && !model->checkFinite(gsl::make_span(x), "fxdot")) {
+    if (t > 1e200
+        && !model->checkFinite(gsl::make_span(x), ModelQuantity::xdot)) {
         /* when t is large (typically ~1e300), CVODES may pass all NaN x
            to fxdot from which we typically cannot recover. To save time
            on normal execution, we do not always want to check finiteness
@@ -1047,7 +1046,7 @@ static int fxdot(realtype t, N_Vector x, N_Vector xdot, void *user_data) {
     }
 
     model->fxdot(t, x, xdot);
-    return model->checkFinite(gsl::make_span(xdot), "fxdot");
+    return model->checkFinite(gsl::make_span(xdot), ModelQuantity::xdot);
 }
 
 
@@ -1074,7 +1073,7 @@ static int fxBdot(realtype t, N_Vector x, N_Vector xB, N_Vector xBdot,
     }
 
     model->fxBdot(t, x, xB, xBdot);
-    return model->checkFinite(gsl::make_span(xBdot), "fxBdot");
+    return model->checkFinite(gsl::make_span(xBdot), ModelQuantity::xBdot);
 }
 
 

--- a/src/solver_cvodes.cpp
+++ b/src/solver_cvodes.cpp
@@ -1012,7 +1012,7 @@ static int froot(realtype t, N_Vector x, realtype *root,
 
     model->froot(t, x, gsl::make_span<realtype>(root, model->ne));
     return model->checkFinite(gsl::make_span<realtype>(root, model->ne),
-                              "root function");
+                              ModelQuantity::root);
 }
 
 
@@ -1094,7 +1094,7 @@ static int fqBdot(realtype t, N_Vector x, N_Vector xB, N_Vector qBdot,
     Expects(model);
 
     model->fqBdot(t, x, xB, qBdot);
-    return model->checkFinite(gsl::make_span(qBdot), "qBdot");
+    return model->checkFinite(gsl::make_span(qBdot), ModelQuantity::qBdot);
 }
 
 
@@ -1115,7 +1115,7 @@ static int fxBdot_ss(realtype t, N_Vector xB, N_Vector xBdot,
     Expects(model);
 
     model->fxBdot_ss(t, xB, xBdot);
-    return model->checkFinite(gsl::make_span(xBdot), "fxBdot_ss");
+    return model->checkFinite(gsl::make_span(xBdot), ModelQuantity::xBdot_ss);
 }
 
 
@@ -1136,7 +1136,7 @@ static int fqBdot_ss(realtype t, N_Vector xB, N_Vector qBdot,
     Expects(model);
 
     model->fqBdot_ss(t, xB, qBdot);
-    return model->checkFinite(gsl::make_span(qBdot), "qBdot_ss");
+    return model->checkFinite(gsl::make_span(qBdot), ModelQuantity::qBdot_ss);
 }
 
 /**
@@ -1160,7 +1160,8 @@ static int fJSparseB_ss(realtype /*t*/, N_Vector /*x*/, N_Vector xBdot,
     Expects(model);
 
     model->fJSparseB_ss(JB);
-    return model->checkFinite(gsl::make_span(xBdot), "JSparseB_ss");
+    return model->checkFinite(gsl::make_span(xBdot),
+                              ModelQuantity::JSparseB_ss);
 }
 
 
@@ -1188,7 +1189,7 @@ static int fsxdot(int /*Ns*/, realtype t, N_Vector x, N_Vector /*xdot*/,
     Expects(model);
 
     model->fsxdot(t, x, ip, sx, sxdot);
-    return model->checkFinite(gsl::make_span(sxdot), "sxdot");
+    return model->checkFinite(gsl::make_span(sxdot), ModelQuantity::sxdot);
 }
 
 bool operator==(const CVodeSolver &a, const CVodeSolver &b) {

--- a/src/solver_idas.cpp
+++ b/src/solver_idas.cpp
@@ -817,7 +817,7 @@ int fJ(realtype t, realtype cj, N_Vector x, N_Vector dx,
     auto model = dynamic_cast<Model_DAE *>(typed_udata->first);
     Expects(model);
     model->fJ(t, cj, x, dx, xdot, J);
-    return model->checkFinite(gsl::make_span(J), "Jacobian");
+    return model->checkFinite(J, ModelQuantity::J, t);
 }
 
 /**
@@ -846,7 +846,8 @@ int fJB(realtype t, realtype cj, N_Vector x, N_Vector dx,
     Expects(model);
 
     model->fJB(t, cj, x, dx, xB, dxB, JB);
-    return model->checkFinite(gsl::make_span(JB), "Jacobian");
+    return model->checkFinite(JB, ModelQuantity::JB, t);
+
 }
 
 /**
@@ -873,7 +874,7 @@ int fJSparse(realtype t, realtype cj, N_Vector x, N_Vector dx,
     Expects(model);
 
     model->fJSparse(t, cj, x, dx, J);
-    return model->checkFinite(gsl::make_span(J), "Jacobian");
+    return model->checkFinite(J, ModelQuantity::J, t);
 }
 
 /**
@@ -902,7 +903,7 @@ int fJSparseB(realtype t, realtype cj, N_Vector x, N_Vector dx,
     Expects(model);
 
     model->fJSparseB(t, cj, x, dx, xB, dxB, JB);
-    return model->checkFinite(gsl::make_span(JB), "Jacobian");
+    return model->checkFinite(JB, ModelQuantity::JB, t);
 }
 
 /**
@@ -973,7 +974,7 @@ int fJv(realtype t, N_Vector x, N_Vector dx, N_Vector /*xdot*/,
     Expects(model);
 
     model->fJv(t, x, dx, v, Jv, cj);
-    return model->checkFinite(gsl::make_span(Jv), "Jacobian");
+    return model->checkFinite(gsl::make_span(Jv), ModelQuantity::Jv);
 }
 
 /**
@@ -1003,7 +1004,7 @@ int fJvB(realtype t, N_Vector x, N_Vector dx, N_Vector xB,
     Expects(model);
 
     model->fJvB(t, x, dx, xB, dxB, vB, JvB, cj);
-    return model->checkFinite(gsl::make_span(JvB), "Jacobian");
+    return model->checkFinite(gsl::make_span(JvB), ModelQuantity::JvB);
 }
 
 /**

--- a/src/solver_idas.cpp
+++ b/src/solver_idas.cpp
@@ -1025,7 +1025,7 @@ int froot(realtype t, N_Vector x, N_Vector dx, realtype *root,
 
     model->froot(t, x, dx, gsl::make_span<realtype>(root, model->ne));
     return model->checkFinite(gsl::make_span<realtype>(root, model->ne),
-                              "root function");
+                              ModelQuantity::root);
 }
 
 /**
@@ -1059,7 +1059,7 @@ int fxdot(realtype t, N_Vector x, N_Vector dx, N_Vector xdot,
     }
 
     model->fxdot(t, x, dx, xdot);
-    return model->checkFinite(gsl::make_span(xdot), "fxdot");
+    return model->checkFinite(gsl::make_span(xdot), ModelQuantity::xdot);
 }
 
 /**
@@ -1087,7 +1087,7 @@ int fxBdot(realtype t, N_Vector x, N_Vector dx, N_Vector xB,
     }
 
     model->fxBdot(t, x, dx, xB, dxB, xBdot);
-    return model->checkFinite(gsl::make_span(xBdot), "xBdot");
+    return model->checkFinite(gsl::make_span(xBdot), ModelQuantity::xBdot);
 }
 
 /**
@@ -1110,7 +1110,7 @@ int fqBdot(realtype t, N_Vector x, N_Vector dx, N_Vector xB,
     Expects(model);
 
     model->fqBdot(t, x, dx, xB, dxB, qBdot);
-    return model->checkFinite(gsl::make_span(qBdot), "qBdot");
+    return model->checkFinite(gsl::make_span(qBdot), ModelQuantity::qBdot);
 
 }
 
@@ -1133,7 +1133,7 @@ static int fxBdot_ss(realtype t, N_Vector xB, N_Vector dxB, N_Vector xBdot,
     Expects(model);
 
     model->fxBdot_ss(t, xB, dxB, xBdot);
-    return model->checkFinite(gsl::make_span(xBdot), "xBdot_ss");
+    return model->checkFinite(gsl::make_span(xBdot), ModelQuantity::xBdot_ss);
 }
 
 
@@ -1155,7 +1155,7 @@ static int fqBdot_ss(realtype t, N_Vector xB, N_Vector dxB, N_Vector qBdot,
     Expects(model);
 
     model->fqBdot_ss(t, xB, dxB, qBdot);
-    return model->checkFinite(gsl::make_span(qBdot), "qBdot_ss");
+    return model->checkFinite(gsl::make_span(qBdot), ModelQuantity::qBdot_ss);
 }
 
 /**
@@ -1182,7 +1182,8 @@ static int fqBdot_ss(realtype t, N_Vector xB, N_Vector dxB, N_Vector qBdot,
     Expects(model);
 
     model->fJSparseB_ss(JB);
-    return model->checkFinite(gsl::make_span(xBdot), "JSparseB_ss");
+    return model->checkFinite(gsl::make_span(xBdot),
+                              ModelQuantity::JSparseB_ss);
 }
 
 /**
@@ -1213,7 +1214,7 @@ int fsxdot(int /*Ns*/, realtype t, N_Vector x, N_Vector dx,
 
     for (int ip = 0; ip < model->nplist(); ip++) {
         model->fsxdot(t, x, dx, ip, sx[ip], sdx[ip], sxdot[ip]);
-        if (model->checkFinite(gsl::make_span(sxdot[ip]), "sxdot")
+        if (model->checkFinite(gsl::make_span(sxdot[ip]), ModelQuantity::sxdot)
                 != AMICI_SUCCESS)
             return AMICI_RECOVERABLE_ERROR;
     }

--- a/swig/amici.i
+++ b/swig/amici.i
@@ -120,6 +120,7 @@ wrap_unique_ptr(ExpDataPtr, amici::ExpData)
 %ignore amici::ContextManager;
 %ignore amici::ModelState;
 %ignore amici::ModelStateDerived;
+%ignore amici::unravel_index;
 
 // Include before any other header which uses enums defined there
 %include "amici/defines.h"


### PR DESCRIPTION
Show more informative warnings when encountering `NaN` or `inf` in model quantities (include IDs where available and provide 2D indices instead of flat indices).

Closes #1375 