### PR TITLE
Fix special function parsing inside min() and max()

### DIFF
--- a/python/amici/import_utils.py
+++ b/python/amici/import_utils.py
@@ -335,12 +335,8 @@ def _parse_special_functions(sym: sp.Expr, toplevel: bool = True) -> sp.Expr:
         # c++ doesnt like mixing int and double for arguments of those
         # functions
         if sym.__class__.__name__ in ['min', 'max']:
-            args = tuple([
-                sp.Float(arg) if arg.is_number else arg
-                for arg in sym.args
-            ])
-        else:
-            args = sym.args
+            args = tuple(sp.Float(arg) if arg.is_number else arg
+                         for arg in args)
         return fun_mappings[sym.__class__.__name__](*args)
 
     elif sym.__class__.__name__ == 'piecewise' \


### PR DESCRIPTION
Fixes a bug where special functions occurring inside min() and max() would not be correctly parsed and import would fail.