### PR TITLE
Outsource numpy requirement

### DIFF
--- a/python/sdist/pyproject.toml
+++ b/python/sdist/pyproject.toml
@@ -2,18 +2,6 @@
 requires = [
     "setuptools>=40.6.3",
     "wheel",
-    # We pin numpy here to the lowest supported version to have
-    # ABI-compatibility with the numpy version in the runtime environment.
-    # There seems to be no easy way to require the numpy version from the
-    # runtime environment for the build requirement here. The only alternative
-    # would be pinning the setup.py numpy requirement to the same version as
-    # here, which we want to avoid.
-    # cf. discussion at https://github.com/numpy/numpy/issues/5888
-    # See also:
-    #  https://github.com/scipy/oldest-supported-numpy/blob/master/setup.cfg
-    #  https://github.com/h5py/h5py/blob/master/setup.py
-    "numpy==1.17.5; python_version=='3.8'",
-    "numpy==1.19.3; python_version=='3.9'",
-    "numpy==1.21.4; python_version>='3.10'",
+    "oldest-supported-numpy",
 ]
 build-backend = "setuptools.build_meta"

--- a/python/sdist/pyproject.toml
+++ b/python/sdist/pyproject.toml
@@ -2,6 +2,12 @@
 requires = [
     "setuptools>=40.6.3",
     "wheel",
+    # oldest-supported-numpy helps us to pin numpy here to the lowest supported
+    # version to have ABI-compatibility with the numpy version in the runtime
+    # environment. The undesirable alternative would be pinning the setup.py
+    # numpy requirement to the same version as here, which we want to avoid.
+    # cf. discussion at https://github.com/numpy/numpy/issues/5888
+    # (https://github.com/scipy/oldest-supported-numpy/)
     "oldest-supported-numpy",
 ]
 build-backend = "setuptools.build_meta"


### PR DESCRIPTION
Let's rely on https://github.com/scipy/oldest-supported-numpy instead of maintaining our own compatibility list.

Fixes #1656