### PR TITLE
Fix: 'sed: illegal option -- -' on OSX

### DIFF
--- a/cmake/version.cmake
+++ b/cmake/version.cmake
@@ -1,6 +1,6 @@
 find_package(Git)
 if(Git_FOUND)
-    execute_process(COMMAND sh -c "${GIT_EXECUTABLE} describe --abbrev=4 --dirty=-dirty --always --tags  | cut -c 2- | tr -d '\n' | sed --regexp-extended s/-/./"
+    execute_process(COMMAND sh -c "${GIT_EXECUTABLE} describe --abbrev=4 --dirty=-dirty --always --tags  | cut -c 2- | tr -d '\n' | sed s/-/./"
         WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
         OUTPUT_VARIABLE PROJECT_VERSION_GIT
         )


### PR DESCRIPTION
Not sure why `--regexp-extended` was in there in the first place... 