### PR TITLE
cmake: Add AMICI_CXX_OPTIONS

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -179,6 +179,8 @@ if(ENABLE_HDF5)
 endif()
 
 add_library(${PROJECT_NAME} ${AMICI_SRC_LIST})
+set(AMICI_CXX_OPTIONS "" CACHE STRING "C++ options for libamici (semicolon-separated)")
+target_compile_options(${PROJECT_NAME} PRIVATE "${AMICI_CXX_OPTIONS}")
 add_dependencies(${PROJECT_NAME} version)
 file(GLOB PUBLIC_HEADERS include/amici/*.h)
 set_target_properties(${PROJECT_NAME} PROPERTIES PUBLIC_HEADER "${PUBLIC_HEADERS}")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -26,7 +26,6 @@ if("${CMAKE_CXX_COMPILER_ID}" STREQUAL "GNU")
     endif()
 endif()
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
-set(ENABLE_SWIG ON)
 
 # Compiler flags
 include(CheckCXXCompilerFlag)

--- a/scripts/buildAmici.sh
+++ b/scripts/buildAmici.sh
@@ -23,7 +23,7 @@ else
 fi
 
 ${cmake} \
-  -DCMAKE_CXX_FLAGS="-Wall -Wextra -Werror" \
+  -DAMICI_CXX_OPTIONS="-Wall;-Wextra;-Werror" \
   -DCMAKE_BUILD_TYPE=$build_type \
   -DPython3_EXECUTABLE="$(command -v python3)" ..
 


### PR DESCRIPTION
to set libamici-specific compiler options.