### PR TITLE
Cached simplify in ODE export

### DIFF
--- a/python/amici/ode_export.py
+++ b/python/amici/ode_export.py
@@ -959,7 +959,8 @@ class ODEModel:
     """
 
     def __init__(self, verbose: Optional[Union[bool, int]] = False,
-                 simplify: Optional[Callable] = sp.powsimp):
+                 simplify: Optional[Callable] = sp.powsimp,
+                 cache_simplify: bool = True):
         """
         Create a new ODEModel instance.
 
@@ -969,6 +970,10 @@ class ODEModel:
 
         :param simplify:
             see :meth:`ODEModel._simplify`
+
+        :param cache_simplify:
+            Whether to cache calls to the simplify method. Can e.g. decrease
+            import times for models with events.
         """
         self._states: List[State] = []
         self._observables: List[Observable] = []
@@ -1036,8 +1041,8 @@ class ODEModel:
             }
 
         self._lock_total_derivative: List[str] = list()
-        self._simplify: Callable = None
-        if simplify is not None:
+        self._simplify: Callable = simplify
+        if cache_simplify and simplify is not None:
             def cached_simplify(
                 expr: sp.Expr,
                 _simplified: Dict[str, sp.Expr] = {},

--- a/python/amici/ode_export.py
+++ b/python/amici/ode_export.py
@@ -1051,7 +1051,7 @@ class ODEModel:
                 expr_str = repr(expr)
                 if expr_str not in _simplified:
                     _simplified[expr_str] = _simplify(expr)
-                return copy.deepcopy(_simplified[expr_str])
+                return _simplified[expr_str]
             self._simplify = cached_simplify
         self._x0_fixedParameters_idx: Union[None, Sequence[int]]
         self._w_recursion_depth: int = 0

--- a/python/amici/ode_export.py
+++ b/python/amici/ode_export.py
@@ -960,7 +960,7 @@ class ODEModel:
 
     def __init__(self, verbose: Optional[Union[bool, int]] = False,
                  simplify: Optional[Callable] = sp.powsimp,
-                 cache_simplify: bool = True):
+                 cache_simplify: bool = False):
         """
         Create a new ODEModel instance.
 

--- a/python/amici/ode_export.py
+++ b/python/amici/ode_export.py
@@ -1036,7 +1036,18 @@ class ODEModel:
             }
 
         self._lock_total_derivative: List[str] = list()
-        self._simplify: Callable = simplify
+        self._simplify: Callable = None
+        if simplify is not None:
+            def cached_simplify(
+                expr: sp.Expr,
+                _simplified: Dict[str, sp.Expr] = {},
+                _simplify: Callable = simplify,
+            ) -> sp.Expr:
+                expr_str = str(expr)
+                if expr_str not in _simplified:
+                    _simplified[expr_str] = _simplify(expr)
+                return copy.deepcopy(_simplified[expr_str])
+            self._simplify = cached_simplify
         self._x0_fixedParameters_idx: Union[None, Sequence[int]]
         self._w_recursion_depth: int = 0
         self._has_quadratic_nllh: bool = True

--- a/python/amici/ode_export.py
+++ b/python/amici/ode_export.py
@@ -1048,6 +1048,24 @@ class ODEModel:
                 _simplified: Dict[str, sp.Expr] = {},
                 _simplify: Callable = simplify,
             ) -> sp.Expr:
+                """Speed up expression simplification with caching.
+
+                NB: This can decrease model import times for models that have
+                    many repeated expressions during C++ file generation.
+                    For example, this can be useful for models with events.
+                    However, for other models, this may increase model import
+                    times.
+
+                :param expr:
+                    The SymPy expression.
+                :param _simplified:
+                    The cache.
+                :param _simplify:
+                    The simplification method.
+
+                :return:
+                    The simplified expression.
+                """
                 expr_str = repr(expr)
                 if expr_str not in _simplified:
                     _simplified[expr_str] = _simplify(expr)

--- a/python/amici/ode_export.py
+++ b/python/amici/ode_export.py
@@ -1043,7 +1043,7 @@ class ODEModel:
                 _simplified: Dict[str, sp.Expr] = {},
                 _simplify: Callable = simplify,
             ) -> sp.Expr:
-                expr_str = str(expr)
+                expr_str = repr(expr)
                 if expr_str not in _simplified:
                     _simplified[expr_str] = _simplify(expr)
                 return copy.deepcopy(_simplified[expr_str])

--- a/python/amici/pysb_import.py
+++ b/python/amici/pysb_import.py
@@ -49,6 +49,9 @@ def pysb2amici(
         compute_conservation_laws: bool = True,
         compile: bool = True,
         simplify: Callable = lambda x: sp.powsimp(x, deep=True),
+        # Do not enable by default without testing.
+        # See https://github.com/AMICI-dev/AMICI/pull/1672
+        cache_simplify: bool = False,
         generate_sensitivity_code: bool = True,
 ):
     r"""
@@ -115,6 +118,11 @@ def pysb2amici(
     :param simplify:
         see :attr:`amici.ODEModel._simplify`
 
+    :param cache_simplify:
+            see :func:`amici.ODEModel.__init__`
+            Note that there are possible issues with PySB models:
+            https://github.com/AMICI-dev/AMICI/pull/1672
+
     :param generate_sensitivity_code:
         if set to ``False``, code for sensitivity computation will not be
         generated
@@ -134,6 +142,7 @@ def pysb2amici(
         noise_distributions=noise_distributions,
         compute_conservation_laws=compute_conservation_laws,
         simplify=simplify,
+        cache_simplify=cache_simplify,
         verbose=verbose,
     )
     exporter = ODEExporter(
@@ -160,6 +169,9 @@ def ode_model_from_pysb_importer(
         noise_distributions: Optional[Dict[str, Union[str, Callable]]] = None,
         compute_conservation_laws: bool = True,
         simplify: Callable = sp.powsimp,
+        # Do not enable by default without testing.
+        # See https://github.com/AMICI-dev/AMICI/pull/1672
+        cache_simplify: bool = False,
         verbose: Union[int, bool] = False,
 ) -> ODEModel:
     """
@@ -188,6 +200,11 @@ def ode_model_from_pysb_importer(
     :param simplify:
             see :attr:`amici.ODEModel._simplify`
 
+    :param cache_simplify:
+            see :func:`amici.ODEModel.__init__`
+            Note that there are possible issues with PySB models:
+            https://github.com/AMICI-dev/AMICI/pull/1672
+
     :param verbose: verbosity level for logging, True/False default to
         :attr:`logging.DEBUG`/:attr:`logging.ERROR`
 
@@ -198,6 +215,7 @@ def ode_model_from_pysb_importer(
     ode = ODEModel(
         verbose=verbose,
         simplify=simplify,
+        cache_simplify=cache_simplify,
     )
 
     if constant_parameters is None:

--- a/python/amici/pysb_import.py
+++ b/python/amici/pysb_import.py
@@ -49,6 +49,7 @@ def pysb2amici(
         compute_conservation_laws: bool = True,
         compile: bool = True,
         simplify: Callable = lambda x: sp.powsimp(x, deep=True),
+        cache_simplify: bool = False,
         generate_sensitivity_code: bool = True,
 ):
     r"""
@@ -115,6 +116,9 @@ def pysb2amici(
     :param simplify:
         see :attr:`amici.ODEModel._simplify`
 
+    :param cache_simplify:
+            see :func:`amici.ODEModel.__init__`
+
     :param generate_sensitivity_code:
         if set to ``False``, code for sensitivity computation will not be
         generated
@@ -134,6 +138,7 @@ def pysb2amici(
         noise_distributions=noise_distributions,
         compute_conservation_laws=compute_conservation_laws,
         simplify=simplify,
+        cache_simplify=cache_simplify,
         verbose=verbose,
     )
     exporter = ODEExporter(
@@ -160,6 +165,7 @@ def ode_model_from_pysb_importer(
         noise_distributions: Optional[Dict[str, Union[str, Callable]]] = None,
         compute_conservation_laws: bool = True,
         simplify: Callable = sp.powsimp,
+        cache_simplify: bool = False,
         verbose: Union[int, bool] = False,
 ) -> ODEModel:
     """
@@ -188,6 +194,9 @@ def ode_model_from_pysb_importer(
     :param simplify:
             see :attr:`amici.ODEModel._simplify`
 
+    :param cache_simplify:
+            see :func:`amici.ODEModel.__init__`
+
     :param verbose: verbosity level for logging, True/False default to
         :attr:`logging.DEBUG`/:attr:`logging.ERROR`
 
@@ -195,7 +204,11 @@ def ode_model_from_pysb_importer(
         New ODEModel instance according to pysbModel
     """
 
-    ode = ODEModel(verbose=verbose, simplify=simplify)
+    ode = ODEModel(
+        verbose=verbose,
+        simplify=simplify,
+        cache_simplify=cache_simplify,
+    )
 
     if constant_parameters is None:
         constant_parameters = []

--- a/python/amici/pysb_import.py
+++ b/python/amici/pysb_import.py
@@ -49,7 +49,7 @@ def pysb2amici(
         compute_conservation_laws: bool = True,
         compile: bool = True,
         simplify: Callable = lambda x: sp.powsimp(x, deep=True),
-        cache_simplify: bool = False,
+        cache_simplify: bool = True,
         generate_sensitivity_code: bool = True,
 ):
     r"""
@@ -165,7 +165,7 @@ def ode_model_from_pysb_importer(
         noise_distributions: Optional[Dict[str, Union[str, Callable]]] = None,
         compute_conservation_laws: bool = True,
         simplify: Callable = sp.powsimp,
-        cache_simplify: bool = False,
+        cache_simplify: bool = True,
         verbose: Union[int, bool] = False,
 ) -> ODEModel:
     """

--- a/python/amici/pysb_import.py
+++ b/python/amici/pysb_import.py
@@ -49,7 +49,6 @@ def pysb2amici(
         compute_conservation_laws: bool = True,
         compile: bool = True,
         simplify: Callable = lambda x: sp.powsimp(x, deep=True),
-        cache_simplify: bool = True,
         generate_sensitivity_code: bool = True,
 ):
     r"""
@@ -116,9 +115,6 @@ def pysb2amici(
     :param simplify:
         see :attr:`amici.ODEModel._simplify`
 
-    :param cache_simplify:
-            see :func:`amici.ODEModel.__init__`
-
     :param generate_sensitivity_code:
         if set to ``False``, code for sensitivity computation will not be
         generated
@@ -138,7 +134,6 @@ def pysb2amici(
         noise_distributions=noise_distributions,
         compute_conservation_laws=compute_conservation_laws,
         simplify=simplify,
-        cache_simplify=cache_simplify,
         verbose=verbose,
     )
     exporter = ODEExporter(
@@ -165,7 +160,6 @@ def ode_model_from_pysb_importer(
         noise_distributions: Optional[Dict[str, Union[str, Callable]]] = None,
         compute_conservation_laws: bool = True,
         simplify: Callable = sp.powsimp,
-        cache_simplify: bool = True,
         verbose: Union[int, bool] = False,
 ) -> ODEModel:
     """
@@ -194,9 +188,6 @@ def ode_model_from_pysb_importer(
     :param simplify:
             see :attr:`amici.ODEModel._simplify`
 
-    :param cache_simplify:
-            see :func:`amici.ODEModel.__init__`
-
     :param verbose: verbosity level for logging, True/False default to
         :attr:`logging.DEBUG`/:attr:`logging.ERROR`
 
@@ -207,7 +198,6 @@ def ode_model_from_pysb_importer(
     ode = ODEModel(
         verbose=verbose,
         simplify=simplify,
-        cache_simplify=cache_simplify,
     )
 
     if constant_parameters is None:

--- a/python/amici/sbml_import.py
+++ b/python/amici/sbml_import.py
@@ -218,6 +218,7 @@ class SbmlImporter:
                    compile: bool = True,
                    compute_conservation_laws: bool = True,
                    simplify: Callable = lambda x: sp.powsimp(x, deep=True),
+                   cache_simplify: bool = True,
                    log_as_log10: bool = True,
                    generate_sensitivity_code: bool = True,
                    **kwargs) -> None:
@@ -287,6 +288,9 @@ class SbmlImporter:
 
         :param simplify:
             see :attr:`ODEModel._simplify`
+
+        :param cache_simplify:
+                see :func:`amici.ODEModel.__init__`
 
         :param log_as_log10:
             If ``True``, log in the SBML model will be parsed as ``log10``
@@ -361,7 +365,11 @@ class SbmlImporter:
         self._clean_reserved_symbols()
         self._process_time()
 
-        ode_model = ODEModel(verbose=verbose, simplify=simplify)
+        ode_model = ODEModel(
+            verbose=verbose,
+            simplify=simplify,
+            cache_simplify=cache_simplify,
+        )
         ode_model.import_from_sbml_importer(
             self, compute_cls=compute_conservation_laws)
         exporter = ODEExporter(

--- a/python/amici/sbml_import.py
+++ b/python/amici/sbml_import.py
@@ -218,7 +218,7 @@ class SbmlImporter:
                    compile: bool = True,
                    compute_conservation_laws: bool = True,
                    simplify: Callable = lambda x: sp.powsimp(x, deep=True),
-                   cache_simplify: bool = True,
+                   cache_simplify: bool = False,
                    log_as_log10: bool = True,
                    generate_sensitivity_code: bool = True,
                    **kwargs) -> None:


### PR DESCRIPTION
Decreases import time of a specific model with events by approximately 2.6x (n=1 ...).