### PR TITLE
Support for parameter-dependent conservation laws

### DIFF
--- a/include/amici/abstract_model.h
+++ b/include/amici/abstract_model.h
@@ -306,7 +306,7 @@ class AbstractModel {
                     const realtype *w);
 
     /**
-     * @brief Model-specific implementation of fdydp
+     * @brief Model-specific implementation of fdydp (MATLAB-only)
      * @param dydp partial derivative of observables y w.r.t. model parameters p
      * @param t current time
      * @param x current state
@@ -320,6 +320,24 @@ class AbstractModel {
     virtual void fdydp(realtype *dydp, const realtype t, const realtype *x,
                        const realtype *p, const realtype *k, const realtype *h,
                        int ip, const realtype *w, const realtype *dwdp);
+
+    /**
+     * @brief Model-specific implementation of fdydp (Python)
+     * @param dydp partial derivative of observables y w.r.t. model parameters p
+     * @param t current time
+     * @param x current state
+     * @param p parameter vector
+     * @param k constant vector
+     * @param h Heaviside vector
+     * @param ip parameter index w.r.t. which the derivative is requested
+     * @param w repeating elements vector
+     * @param tcl total abundances for conservation laws
+     * @param dtcldp Sensitivities of total abundances for conservation laws
+     */
+    virtual void fdydp(realtype *dydp, const realtype t, const realtype *x,
+                       const realtype *p, const realtype *k, const realtype *h,
+                       int ip, const realtype *w, const realtype *tcl,
+                       const realtype *dtcldp);
 
     /**
      * @brief Model-specific implementation of fdydx

--- a/include/amici/model.h
+++ b/include/amici/model.h
@@ -1265,8 +1265,11 @@ class Model : public AbstractModel, public ModelDimensions {
      * conservation laws expanded (stored in `amici::ReturnData`).
      * @param sx_solver State variables sensitivities with conservation laws
      * applied (solver returns this)
+     * @param x_solver State variables with conservation laws
+     * applied (solver returns this)
      */
-    void fsx_rdata(AmiVectorArray &sx_rdata, const AmiVectorArray &sx_solver);
+    void fsx_rdata(AmiVectorArray &sx_rdata, const AmiVectorArray &sx_solver,
+                   const AmiVector &x_solver);
 
     /**
      * @brief Set indices of states to be reinitialized based on provided
@@ -1644,9 +1647,12 @@ class Model : public AbstractModel, public ModelDimensions {
      * @param x_rdata State variables with conservation laws expanded
      * @param x_solver State variables with conservation laws applied
      * @param tcl Total abundances for conservation laws
+     * @param p parameter vector
+     * @param k constant vector
      */
     virtual void fx_rdata(realtype *x_rdata, const realtype *x_solver,
-                          const realtype *tcl);
+                          const realtype *tcl, const realtype *p,
+                          const realtype *k);
 
     /**
      * @brief Compute fsx_solver.
@@ -1658,10 +1664,17 @@ class Model : public AbstractModel, public ModelDimensions {
      * @param sx_solver State sensitivity variables with conservation laws
      * applied
      * @param stcl Sensitivities of total abundances for conservation laws
+     * @param p parameter vector
+     * @param k constant vector
+     * @param x_solver State variables with conservation laws applied
+     * @param tcl Total abundances for conservation laws
      * @param ip Sensitivity index
      */
     virtual void fsx_rdata(realtype *sx_rdata, const realtype *sx_solver,
-                           const realtype *stcl, int ip);
+                           const realtype *stcl, const realtype *p,
+                           const realtype *k, const realtype *x_solver,
+                           const realtype *tcl,
+                           const int ip);
 
     /**
      * @brief Compute fx_solver.
@@ -1692,8 +1705,11 @@ class Model : public AbstractModel, public ModelDimensions {
      *
      * @param total_cl Total abundances of conservation laws
      * @param x_rdata State variables with conservation laws expanded
+     * @param p parameter vector
+     * @param k constant vector
      */
-    virtual void ftotal_cl(realtype *total_cl, const realtype *x_rdata);
+    virtual void ftotal_cl(realtype *total_cl, const realtype *x_rdata,
+                           const realtype *p, const realtype *k);
 
     /**
      * @brief Compute fstotal_cl
@@ -1705,9 +1721,15 @@ class Model : public AbstractModel, public ModelDimensions {
      * @param sx_rdata State sensitivity variables with conservation laws
      * expanded
      * @param ip Sensitivity index
+     * @param x_rdata State variables with conservation laws expanded
+     * @param p parameter vector
+     * @param k constant vector
+     * @param tcl Total abundances for conservation laws
      */
     virtual void fstotal_cl(realtype *stotal_cl, const realtype *sx_rdata,
-                            int ip);
+                            const int ip, const realtype *x_rdata,
+                            const realtype *p, const realtype *k,
+                            const realtype *tcl);
 
     /**
      * @brief Compute non-negative state vector.
@@ -1723,7 +1745,7 @@ class Model : public AbstractModel, public ModelDimensions {
      * stateIsNonNegative
      */
     const_N_Vector computeX_pos(const_N_Vector x);
-    
+
     /**
      * @brief Compute non-negative state vector.
      *

--- a/python/amici/ode_export.py
+++ b/python/amici/ode_export.py
@@ -3120,7 +3120,8 @@ class ODEExporter:
                 outer_cases[ie] = copy.copy(inner_lines)
             lines.extend(get_switch_statement('ie', outer_cases, 1))
 
-        elif function in sensi_functions:
+        elif function in sensi_functions \
+                and equations.shape[1] == self.model.num_par():
             cases = {
                 ipar: self.model._code_printer._get_sym_lines_array(
                     equations[:, ipar], function, 0)
@@ -3128,7 +3129,6 @@ class ODEExporter:
                 if not smart_is_zero_matrix(equations[:, ipar])
             }
             lines.extend(get_switch_statement('ip', cases, 1))
-
         elif function in multiobs_functions:
             if function == 'dJydy':
                 cases = {

--- a/python/amici/sbml_import.py
+++ b/python/amici/sbml_import.py
@@ -1503,14 +1503,9 @@ class SbmlImporter:
                 else sp.Integer(1)
                 for state_id in state_ids
             ]
-            if any(x.free_symbols for x in compartment_sizes):
-                # https://github.com/AMICI-dev/AMICI/issues/1673
-                # see SBML semantic test suite, case 783 for an example
-                warnings.warn(
-                    "Conservation laws for non-constant species in "
-                    "compartments with parameter-dependent size are not "
-                    "currently supported and will be turned off.")
-                return species_solver
+            # prevent sympy from evaluating float operations in abundance
+            #  expression below
+            coefficients = list(map(sp.Rational, coefficients))
 
             total_abundance = symbol_with_assumptions(f'tcl_{target_state_id}')
             target_compartment = compartment_sizes[target_state_cl_idx]

--- a/src/abstract_model.cpp
+++ b/src/abstract_model.cpp
@@ -119,6 +119,17 @@ AbstractModel::fdydp(realtype* /*dydp*/,
                        __func__);
 }
 
+void AbstractModel::fdydp(realtype */*dydp*/, const realtype /*t*/,
+                          const realtype */*x*/, const realtype */*p*/,
+                          const realtype */*k*/, const realtype */*h*/,
+                          int /*ip*/, const realtype */*w*/,
+                          const realtype */*tcl*/, const realtype */*dtcldp*/)
+{
+    throw AmiException("Requested functionality is not supported as %s is "
+                       "not implemented for this model!",
+                       __func__);
+}
+
 void
 AbstractModel::fdydx(realtype* /*dydx*/,
                      const realtype /*t*/,

--- a/src/model_header.ODE_template.h
+++ b/src/model_header.ODE_template.h
@@ -69,6 +69,8 @@ TPL_DELTASX_DEF
 TPL_X_RDATA_DEF
 TPL_X_SOLVER_DEF
 TPL_TOTAL_CL_DEF
+TPL_STOTAL_CL_DEF
+TPL_SX_RDATA_DEF
 
 /**
  * @brief AMICI-generated model subclass.
@@ -463,6 +465,10 @@ class Model_TPL_MODELNAME : public amici::Model_ODE {
     TPL_X_SOLVER_IMPL
 
     TPL_TOTAL_CL_IMPL
+
+    TPL_STOTAL_CL_IMPL
+
+    TPL_SX_RDATA_IMPL
 
     std::string getName() const override {
         return "TPL_MODELNAME";

--- a/src/rdata.cpp
+++ b/src/rdata.cpp
@@ -193,7 +193,7 @@ void ReturnData::processPreEquilibration(SteadystateProblem const &preeq,
         writeSlice(x_rdata_, x_ss);
     }
     if (!sx_ss.empty() && sensi >= SensitivityOrder::first) {
-        model.fsx_rdata(sx_rdata_, sx_solver_);
+        model.fsx_rdata(sx_rdata_, sx_solver_, x_solver_);
         for (int ip = 0; ip < nplist; ip++)
             writeSlice(sx_rdata_[ip], slice(sx_ss, ip, nx));
     }
@@ -254,7 +254,7 @@ void ReturnData::processForwardProblem(ForwardProblem const &fwd, Model &model,
     }
 
     if (!sx0.empty()) {
-        model.fsx_rdata(sx_rdata_, sx_solver_);
+        model.fsx_rdata(sx_rdata_, sx_solver_, x_solver_);
         for (int ip = 0; ip < nplist; ip++)
             writeSlice(sx_rdata_[ip], slice(sx0, ip, nx));
     }
@@ -318,7 +318,7 @@ void ReturnData::getDataOutput(int it, Model &model, ExpData const *edata) {
 
 void ReturnData::getDataSensisFSA(int it, Model &model, ExpData const *edata) {
     if (!sx.empty()) {
-        model.fsx_rdata(sx_rdata_, sx_solver_);
+        model.fsx_rdata(sx_rdata_, sx_solver_, x_solver_);
         for (int ip = 0; ip < nplist; ip++) {
             writeSlice(sx_rdata_[ip],
                        slice(sx, it * nplist + ip, nx));


### PR DESCRIPTION
Adds support for parameter-dependent conservation laws. This allows applying conservation laws to models comprising species  in different compartments where model states correspond to concentrations. 

Closes #1673 