### PR TITLE
Model import: Get rid of multiplications with 1.0

### DIFF
--- a/python/amici/ode_export.py
+++ b/python/amici/ode_export.py
@@ -961,9 +961,12 @@ class ODEModel:
         Code printer to generate C++ code
     """
 
-    def __init__(self, verbose: Optional[Union[bool, int]] = False,
-                 simplify: Optional[Callable] = sp.powsimp,
-                 cache_simplify: bool = False):
+    def __init__(
+            self, verbose: Optional[Union[bool, int]] = False,
+            simplify: Optional[Callable]
+            = lambda x: sp.powsimp(x, deep=True).subs(1.0, 1),
+            cache_simplify: bool = False
+    ):
         """
         Create a new ODEModel instance.
 

--- a/python/amici/sbml_import.py
+++ b/python/amici/sbml_import.py
@@ -217,7 +217,8 @@ class SbmlImporter:
                    allow_reinit_fixpar_initcond: bool = True,
                    compile: bool = True,
                    compute_conservation_laws: bool = True,
-                   simplify: Callable = lambda x: sp.powsimp(x, deep=True),
+                   simplify: Callable = lambda x:
+                   sp.powsimp(x, deep=True).subs(1.0, 1),
                    cache_simplify: bool = False,
                    log_as_log10: bool = True,
                    generate_sensitivity_code: bool = True,


### PR DESCRIPTION
Gets rid of lots of multiplications with 1.0. 

Reduces code bloat, improves readability.

Closes #1671