### PR TITLE
Fix IndexError conserved_moieties._reduce

### DIFF
--- a/python/amici/conserved_moieties.py
+++ b/python/amici/conserved_moieties.py
@@ -695,10 +695,11 @@ def _relax(
         while i < len(matrix[k]):
             for i_species in range(k1 + 1, K):
                 j = order[i_species]
-                if not len(matrix[j]) or len(matrix[k]) <= i \
-                        or matrix[j][0] != matrix[k][i]:
+                if not len(matrix[j]) or matrix[j][0] != matrix[k][i]:
                     continue
 
+                # subtract rows
+                # matrix2[k] = matrix2[k] - matrix2[j] * matrix2[k][i]
                 row_k: List[float] = [0] * num_reactions
                 for a in range(len(matrix[k])):
                     row_k[matrix[k][a]] = matrix2[k][a]
@@ -708,6 +709,9 @@ def _relax(
                 matrix[k] = [row_idx for row_idx, row_val in enumerate(row_k)
                              if row_val != 0]
                 matrix2[k] = [row_val for row_val in row_k if row_val != 0]
+
+                if len(matrix[k]) <= i:
+                    break
             i += 1
 
     indip = [K + 1] * num_reactions

--- a/python/amici/conserved_moieties.py
+++ b/python/amici/conserved_moieties.py
@@ -695,7 +695,8 @@ def _relax(
         while i < len(matrix[k]):
             for i_species in range(k1 + 1, K):
                 j = order[i_species]
-                if not len(matrix[j]) or matrix[j][0] != matrix[k][i]:
+                if not len(matrix[j]) or len(matrix[k]) <= i \
+                        or matrix[j][0] != matrix[k][i]:
                     continue
 
                 row_k: List[float] = [0] * num_reactions


### PR DESCRIPTION
Fixes `IndexError` occurring under rare circumstances:

```
  File "/venv/src/amici/python/sdist/amici/conserved_moieties.py", line 698, in _relax
    if not len(matrix[j]) or matrix[j][0] != matrix[k][i]:
IndexError: list index out of range
```