### PR TITLE
Sympy 1.10 compatibility

### DIFF
--- a/documentation/conf.py
+++ b/documentation/conf.py
@@ -20,8 +20,9 @@ from sphinx.transforms.post_transforms import ReferencesResolver
 
 # need to import before setting typing.TYPE_CHECKING=True, fails otherwise
 import pandas as pd
+import sympy as sp
 
-exhale_multiproject_monkeypatch, pd  # to avoid removal of unused import
+exhale_multiproject_monkeypatch, pd, sp  # to avoid removal of unused import
 
 # BEGIN Monkeypatch exhale
 from exhale.deploy import _generate_doxygen as exhale_generate_doxygen

--- a/python/amici/cxxcodeprinter.py
+++ b/python/amici/cxxcodeprinter.py
@@ -20,9 +20,28 @@ class AmiciCxxCodePrinter(CXX11CodePrinter):
             return code
         except TypeError as e:
             raise ValueError(
-                f'Encountered unsupported function in expression "{expr}": '
-                f'{e}!'
-            )
+                f'Encountered unsupported function in expression "{expr}"'
+            ) from e
+
+    def _print_Max(self, expr):
+        from sympy.functions.elementary.miscellaneous import Max
+        # C++ doesn't like mixing int and double for arguments for min/max
+        arg0 = sp.Float(expr.args[0]) if expr.args[0].is_number \
+            else expr.args[0]
+        if len(expr.args) == 1:
+            return self._print(arg0)
+        return "%smax(%s, %s)" % (self._ns, self._print(arg0),
+                                  self._print(Max(*expr.args[1:])))
+
+    def _print_Min(self, expr):
+        from sympy.functions.elementary.miscellaneous import Min
+        # C++ doesn't like mixing int and double for arguments for min/max
+        arg0 = sp.Float(expr.args[0]) if expr.args[0].is_number \
+            else expr.args[0]
+        if len(expr.args) == 1:
+            return self._print(arg0)
+        return "%smin(%s, %s)" % (self._ns, self._print(arg0),
+                                  self._print(Min(*expr.args[1:])))
 
     def _get_sym_lines_array(
             self,

--- a/python/amici/cxxcodeprinter.py
+++ b/python/amici/cxxcodeprinter.py
@@ -23,25 +23,23 @@ class AmiciCxxCodePrinter(CXX11CodePrinter):
                 f'Encountered unsupported function in expression "{expr}"'
             ) from e
 
-    def _print_Max(self, expr):
-        from sympy.functions.elementary.miscellaneous import Max
-        # C++ doesn't like mixing int and double for arguments for min/max
+    def _print_min_max(self, expr, cpp_fun: str, sympy_fun):
+        # C++ doesn't like mixing int and double for arguments for min/max,
+        #  therefore, we just always convert to float
         arg0 = sp.Float(expr.args[0]) if expr.args[0].is_number \
             else expr.args[0]
         if len(expr.args) == 1:
             return self._print(arg0)
-        return "%smax(%s, %s)" % (self._ns, self._print(arg0),
-                                  self._print(Max(*expr.args[1:])))
+        return "%s%s(%s, %s)" % (self._ns, cpp_fun, self._print(arg0),
+                                 self._print(sympy_fun(*expr.args[1:])))
 
     def _print_Min(self, expr):
         from sympy.functions.elementary.miscellaneous import Min
-        # C++ doesn't like mixing int and double for arguments for min/max
-        arg0 = sp.Float(expr.args[0]) if expr.args[0].is_number \
-            else expr.args[0]
-        if len(expr.args) == 1:
-            return self._print(arg0)
-        return "%smin(%s, %s)" % (self._ns, self._print(arg0),
-                                  self._print(Min(*expr.args[1:])))
+        return self._print_min_max(expr, "min", Min)
+
+    def _print_Max(self, expr):
+        from sympy.functions.elementary.miscellaneous import Max
+        return self._print_min_max(expr, "max", Max)
 
     def _get_sym_lines_array(
             self,

--- a/python/amici/import_utils.py
+++ b/python/amici/import_utils.py
@@ -351,11 +351,6 @@ def _parse_special_functions(sym: sp.Expr, toplevel: bool = True) -> sp.Expr:
     }
 
     if sym.__class__.__name__ in fun_mappings:
-        # c++ doesnt like mixing int and double for arguments of those
-        # functions
-        if sym.__class__.__name__ in ['min', 'max']:
-            args = tuple(sp.Float(arg) if arg.is_number else arg
-                         for arg in args)
         return fun_mappings[sym.__class__.__name__](*args)
 
     elif sym.__class__.__name__ == 'piecewise' \


### PR DESCRIPTION
sympify now automatically parses min/max, thereby escaping our argument conversion for float.
Fixed here by moving the conversion from import to code generation.