### PR TITLE
Revert "Model import: Get rid of multiplications with 1.0 (#1681)"

### DIFF
--- a/python/amici/ode_export.py
+++ b/python/amici/ode_export.py
@@ -982,12 +982,9 @@ class ODEModel:
         Code printer to generate C++ code
     """
 
-    def __init__(
-            self, verbose: Optional[Union[bool, int]] = False,
-            simplify: Optional[Callable]
-            = lambda x: sp.powsimp(x, deep=True).subs(1.0, 1),
-            cache_simplify: bool = False
-    ):
+    def __init__(self, verbose: Optional[Union[bool, int]] = False,
+                 simplify: Optional[Callable] = sp.powsimp,
+                 cache_simplify: bool = False):
         """
         Create a new ODEModel instance.
 

--- a/python/amici/sbml_import.py
+++ b/python/amici/sbml_import.py
@@ -217,8 +217,7 @@ class SbmlImporter:
                    allow_reinit_fixpar_initcond: bool = True,
                    compile: bool = True,
                    compute_conservation_laws: bool = True,
-                   simplify: Callable = lambda x:
-                   sp.powsimp(x, deep=True).subs(1.0, 1),
+                   simplify: Callable = lambda x: sp.powsimp(x, deep=True),
                    cache_simplify: bool = False,
                    log_as_log10: bool = True,
                    generate_sensitivity_code: bool = True,


### PR DESCRIPTION
This reverts commit 5e750654c76c5f574d1bb4a0803bf17f9ef549ef.

For larger models, this just takes too long (~30min exta for
https://github.com/ICB-DCM/CS_Signalling_ERBB_RAS_AKT/tree/master/FroehlichKes2018/PEtab).