### PR TITLE
Remove python3.8 check for ModelModule

### DIFF
--- a/python/amici/__init__.py
+++ b/python/amici/__init__.py
@@ -114,18 +114,14 @@ if not _imported_from_setup():
     from .sbml_import import SbmlImporter, assignmentRules2observables
     from .ode_export import ODEModel, ODEExporter
 
-    try:
-        # Requires Python>=3.8
-        from typing import Protocol
+    from typing import Protocol
 
-        class ModelModule(Protocol):
-            """Enable Python static type checking for AMICI-generated model
-            modules"""
-            def getModel(self) -> amici.Model:
-                pass
-    except ImportError:
-        pass
 
+    class ModelModule(Protocol):
+        """Enable Python static type checking for AMICI-generated model
+        modules"""
+        def getModel(self) -> amici.Model:
+            pass
 
 
 class add_path:


### PR DESCRIPTION
As py3.8 is anyways required by now