### PR TITLE
CI: Fix C++ tests under valgrind

### DIFF
--- a/scripts/run-valgrind-cpp.sh
+++ b/scripts/run-valgrind-cpp.sh
@@ -8,12 +8,6 @@ AMICI_PATH=$(cd "$SCRIPT_PATH/.." && pwd)
 set -eou pipefail
 
 # run tests
-cd "${AMICI_PATH}/build/tests/cpp/"
-
+cd "${AMICI_PATH}/build/"
 VALGRIND_OPTS="--leak-check=full --error-exitcode=1 --trace-children=yes --show-leak-kinds=definite"
-set -x
-for MODEL in $(ctest -N | grep "Test[ ]*#" | grep -v unittests | sed --regexp-extended 's/ *Test[ ]*#[0-9]+: model_(.*)_test/\1/')
-    do cd "${AMICI_PATH}/build/tests/cpp/${MODEL}/" && valgrind ${VALGRIND_OPTS} "./model_${MODEL}_test"
-done
-cd "${AMICI_PATH}/build/tests/cpp/unittests/"
-valgrind ${VALGRIND_OPTS} ./unittests
+valgrind ${VALGRIND_OPTS} ctest


### PR DESCRIPTION
Previously, tests were not found and silently skipped. Probably since changing to gtest. Fixes #1715.