### PR TITLE
Fix default value for `amici_import_petab --no-sensitivities`

### DIFF
--- a/python/amici/ode_export.py
+++ b/python/amici/ode_export.py
@@ -1459,6 +1459,10 @@ class ODEModel:
             self._eqs[name] = \
                 sp.zeros(self.num_cons_law(), self.num_states_solver())
 
+        elif name == 'dtcldp':
+            # force symbols
+            self._eqs[name] = self.sym(name)
+
         elif name == 'dx_rdatadx_solver':
             if self.num_cons_law():
                 self._eqs[name] = smart_jacobian(self.eq('x_rdata'),

--- a/python/amici/petab_import.py
+++ b/python/amici/petab_import.py
@@ -715,7 +715,7 @@ def _parse_cli_args():
                         help='Flatten measurement specific overrides of '
                              'observable and noise parameters')
     parser.add_argument('--no-sensitivities', dest='generate_sensitivity_code',
-                        default=False, action='store_false',
+                        default=True, action='store_false',
                         help='Skip generation of sensitivity code')
 
     # Call with set of files


### PR DESCRIPTION
Fixup for a366a63404e3ea94339ce36f01a72619052504cc (#1688)

Due to wrong default value, sensitivity equations were never generated.