### PR TITLE
CI: Fix osx build (pin hdf5, boost dirs, omp dir)

### DIFF
--- a/.github/workflows/test_pypi.yml
+++ b/.github/workflows/test_pypi.yml
@@ -33,7 +33,7 @@ jobs:
           if [[ ${{ matrix.os }} == macos* ]] ; then \
             brew install hdf5@1.10 swig gcc libomp \
                && echo "/usr/local/opt/hdf5@1.10/bin" >> $GITHUB_PATH \
-               && echo LDFLAGS="-L/usr/local/opt/hdf5@1.10/lib" >> $GITHUB_ENV \
+               && echo LDFLAGS="-L /usr/local/lib/ -L/usr/local/opt/hdf5@1.10/lib" >> $GITHUB_ENV \
                && echo CPPFLAGS="-I/usr/local/opt/hdf5@1.10/include" >> $GITHUB_ENV
           fi
 

--- a/.github/workflows/test_pypi.yml
+++ b/.github/workflows/test_pypi.yml
@@ -33,7 +33,7 @@ jobs:
           if [[ ${{ matrix.os }} == macos* ]] ; then \
             brew install hdf5@1.10 swig gcc libomp \
                && echo "/usr/local/opt/hdf5@1.10/bin" >> $GITHUB_PATH \
-               && echo LDFLAGS="-L /usr/local/lib/ -L/usr/local/opt/hdf5@1.10/lib" >> $GITHUB_ENV \
+               && echo LDFLAGS="-L/usr/local/lib/ -L/usr/local/opt/hdf5@1.10/lib" >> $GITHUB_ENV \
                && echo CPPFLAGS="-I/usr/local/opt/hdf5@1.10/include" >> $GITHUB_ENV
           fi
 

--- a/.github/workflows/test_pypi.yml
+++ b/.github/workflows/test_pypi.yml
@@ -34,7 +34,8 @@ jobs:
             brew install hdf5@1.10 swig gcc libomp \
                && echo "/usr/local/opt/hdf5@1.10/bin" >> $GITHUB_PATH \
                && echo LDFLAGS="-L/usr/local/lib/ -L/usr/local/opt/hdf5@1.10/lib" >> $GITHUB_ENV \
-               && echo CPPFLAGS="-I/usr/local/opt/hdf5@1.10/include" >> $GITHUB_ENV
+               && echo CPPFLAGS="-I/usr/local/opt/hdf5@1.10/include" >> $GITHUB_ENV \
+               && echo HDF5_BASE="/usr/local/opt/hdf5@1.10/" >> $GITHUB_ENV
           fi
 
       - name: Set up Python ${{ matrix.python-version }}

--- a/.github/workflows/test_pypi.yml
+++ b/.github/workflows/test_pypi.yml
@@ -31,7 +31,10 @@ jobs:
       - name: homebrew
         run: |
           if [[ ${{ matrix.os }} == macos* ]] ; then \
-            brew install hdf5 swig gcc libomp
+            brew install hdf5@1.10 swig gcc libomp \
+               && echo "/usr/local/opt/hdf5@1.10/bin" >> $GITHUB_PATH \
+               && echo LDFLAGS="-L/usr/local/opt/hdf5@1.10/lib" >> $GITHUB_ENV \
+               && echo CPPFLAGS="-I/usr/local/opt/hdf5@1.10/include" >> $GITHUB_ENV
           fi
 
       - name: Set up Python ${{ matrix.python-version }}

--- a/.github/workflows/test_python_cplusplus.yml
+++ b/.github/workflows/test_python_cplusplus.yml
@@ -154,7 +154,7 @@ jobs:
       run: |
         brew install hdf5@1.10 swig gcc cppcheck libomp boost \
           && echo "/usr/local/opt/hdf5@1.10/bin" >> $GITHUB_PATH \
-          && echo LDFLAGS="-L /usr/local/lib/ -L/usr/local/opt/hdf5@1.10/lib" >> $GITHUB_ENV \
+          && echo LDFLAGS="-L/usr/local/lib/ -L/usr/local/opt/hdf5@1.10/lib" >> $GITHUB_ENV \
           && echo CPPFLAGS="-I/usr/local/opt/hdf5@1.10/include" >> $GITHUB_ENV
 
     - name: Build AMICI

--- a/.github/workflows/test_python_cplusplus.yml
+++ b/.github/workflows/test_python_cplusplus.yml
@@ -152,7 +152,10 @@ jobs:
     # install amici dependencies
     - name: homebrew
       run: |
-        brew install hdf5 swig gcc cppcheck libomp boost
+        brew install hdf5@1.10 swig gcc cppcheck libomp boost \
+          && echo "/usr/local/opt/hdf5@1.10/bin" >> $GITHUB_PATH \
+          && echo LDFLAGS="-L/usr/local/opt/hdf5@1.10/lib" >> $GITHUB_ENV \
+          && echo CPPFLAGS="-I/usr/local/opt/hdf5@1.10/include" >> $GITHUB_ENV
 
     - name: Build AMICI
       run: |

--- a/.github/workflows/test_python_cplusplus.yml
+++ b/.github/workflows/test_python_cplusplus.yml
@@ -155,7 +155,8 @@ jobs:
         brew install hdf5@1.10 swig gcc cppcheck libomp boost \
           && echo "/usr/local/opt/hdf5@1.10/bin" >> $GITHUB_PATH \
           && echo LDFLAGS="-L/usr/local/lib/ -L/usr/local/opt/hdf5@1.10/lib" >> $GITHUB_ENV \
-          && echo CPPFLAGS="-I/usr/local/opt/hdf5@1.10/include" >> $GITHUB_ENV
+          && echo CPPFLAGS="-I/usr/local/opt/hdf5@1.10/include" >> $GITHUB_ENV \
+          && echo HDF5_BASE="/usr/local/opt/hdf5@1.10/" >> $GITHUB_ENV
 
     - name: Build AMICI
       run: |

--- a/.github/workflows/test_python_cplusplus.yml
+++ b/.github/workflows/test_python_cplusplus.yml
@@ -154,7 +154,7 @@ jobs:
       run: |
         brew install hdf5@1.10 swig gcc cppcheck libomp boost \
           && echo "/usr/local/opt/hdf5@1.10/bin" >> $GITHUB_PATH \
-          && echo LDFLAGS="-L/usr/local/opt/hdf5@1.10/lib" >> $GITHUB_ENV \
+          && echo LDFLAGS="-L /usr/local/lib/ -L/usr/local/opt/hdf5@1.10/lib" >> $GITHUB_ENV \
           && echo CPPFLAGS="-I/usr/local/opt/hdf5@1.10/include" >> $GITHUB_ENV
 
     - name: Build AMICI

--- a/.github/workflows/test_python_cplusplus.yml
+++ b/.github/workflows/test_python_cplusplus.yml
@@ -153,6 +153,8 @@ jobs:
     - name: homebrew
       run: |
         brew install hdf5@1.10 swig gcc cppcheck libomp boost \
+          && brew ls -v boost \
+          && brew ls -v libomp \
           && echo "/usr/local/opt/hdf5@1.10/bin" >> $GITHUB_PATH \
           && echo LDFLAGS="-L/usr/local/lib/ -L/usr/local/opt/hdf5@1.10/lib" >> $GITHUB_ENV \
           && echo CPPFLAGS="-I/usr/local/opt/hdf5@1.10/include" >> $GITHUB_ENV \

--- a/.github/workflows/test_python_cplusplus.yml
+++ b/.github/workflows/test_python_cplusplus.yml
@@ -156,8 +156,8 @@ jobs:
           && brew ls -v boost \
           && brew ls -v libomp \
           && echo "/usr/local/opt/hdf5@1.10/bin" >> $GITHUB_PATH \
-          && echo LDFLAGS="-L/usr/local/lib/ -L/usr/local/opt/hdf5@1.10/lib" >> $GITHUB_ENV \
-          && echo CPPFLAGS="-I/usr/local/opt/hdf5@1.10/include" >> $GITHUB_ENV \
+          && echo LDFLAGS="-L/usr/local/lib/ -L/usr/local/opt/hdf5@1.10/lib -L/usr/local/Cellar/boost/1.78.0_1/lib/" >> $GITHUB_ENV \
+          && echo CPPFLAGS="-I/usr/local/opt/hdf5@1.10/include -I/usr/local/Cellar/boost/1.78.0_1/include/" >> $GITHUB_ENV \
           && echo HDF5_BASE="/usr/local/opt/hdf5@1.10/" >> $GITHUB_ENV
 
     - name: Build AMICI


### PR DESCRIPTION
Most recent HDF5 version (1.13) fails for unknown reasons:

```
__________________________ test_solver_hdf5_roundtrip __________________________

sbml_example_presimulation_module = <module 'test_model_presimulation' from '/Users/runner/work/AMICI/AMICI/python/tests/test_model_presimulation/test_model_presimulation/__init__.py'>

    @pytest.mark.skipif(not amici.hdf5_enabled,
                        reason='AMICI was compiled without HDF5')
    def test_solver_hdf5_roundtrip(sbml_example_presimulation_module):
        """TestCase class for AMICI HDF5 I/O"""

        model = sbml_example_presimulation_module.getModel()
        solver = model.getSolver()
        _modify_solver_attrs(solver)

        hdf5file = 'solverSettings.hdf5'

>       amici.writeSolverSettingsToHDF5(solver, hdf5file, 'ssettings')

test_hdf5.py:46:
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _
../sdist/amici/swig_wrappers.py:167: in writeSolverSettingsToHDF5
    amici_swig.writeSolverSettingsToHDF5(_get_ptr(solver), file, location)
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _

args = (<amici.amici.Solver; proxy of <Swig Object of type 'std::unique_ptr< amici::Solver >::pointer' at 0x12309bc90> >, 'solverSettings.hdf5', 'ssettings')

    def writeSolverSettingsToHDF5(*args) -> None:
        """
        *Overload 1:*

        Write solver options to HDF5 file.
        :type hdf5Filename: str
        :param hdf5Filename: Name of HDF5 file to write to
        :type solver: :py:class:`Solver`
        :param solver: Solver to write options from
        :type hdf5Location: str
        :param hdf5Location: Path inside the HDF5 file

        |

        *Overload 2:*

        Write solver options to HDF5 file.
        :type file: H5::H5File
        :param file: File to read from
        :type solver: :py:class:`Solver`
        :param solver: Solver to write options from
        :type hdf5Location: str
        :param hdf5Location: Path inside the HDF5 file
        """
>       return _amici.writeSolverSettingsToHDF5(*args)
E       RuntimeError: Failed to create group in hdf5CreateGroup: ssettings

../sdist/amici/amici.py:6150: RuntimeError
----------------------------- Captured stderr call -----------------------------
HDF5-DIAG: Error detected in HDF5 (1.13.0) thread 0:
  //000: H5Plcpl.c line 152 in H5Pset_create_intermediate_group(): can't find object for ID
    major: Object ID
    minor: Unable to find ID information (already closed?)
  //001: H5Pint.c line 4116 in H5P_object_verify(): property list is not a member of the class
    major: Property lists
    minor: Unable to register new ID
  //002: H5Pint.c line 4067 in H5P_isa_class(): not a property list
    major: Invalid arguments to routine
    minor: Inappropriate type
HDF5-DIAG: Error detected in HDF5 (1.13.0) thread 0:
  //000: H5G.c line 232 in H5Gcreate2(): unable to synchronously create group
    major: Symbol table
    minor: Unable to create file
  //001: H5G.c line 171 in H5G__create_api_common(): not a link creation property list
    major: Invalid arguments to routine
    minor: Inappropriate type
  //002: H5Pint.c line 4067 in H5P_isa_class(): not a property list
    major: Invalid arguments to routine
    minor: Inappropriate type
HDF5-DIAG: Error detected in HDF5 (1.13.0) thread 0:
  //000: H5P.c line 1487 in H5Pclose(): not a property list
    major: Invalid arguments to routine
    minor: Inappropriate type
```

Also, `libomp` as well as `boost` directories seems to have changed.