### PR TITLE
Fix Model::setStateIsNonNegative

### DIFF
--- a/python/tests/test_compare_conservation_laws_sbml.py
+++ b/python/tests/test_compare_conservation_laws_sbml.py
@@ -33,7 +33,8 @@ def edata_fixture():
     return edata_pre, edata_post, edata_full
 
 
-def generate_models():
+@pytest.fixture(scope="session")
+def models():
     # SBML model we want to import
     sbml_file = os.path.join(os.path.dirname(__file__), '..',
                              'examples', 'example_constant_species',
@@ -100,9 +101,9 @@ def get_results(model, edata=None, sensi_order=0,
     return amici.runAmiciSimulation(model, solver, edata)
 
 
-def test_compare_conservation_laws_sbml(edata_fixture):
+def test_compare_conservation_laws_sbml(models, edata_fixture):
     # first, create the model
-    model_with_cl, model_without_cl = generate_models()
+    model_with_cl, model_without_cl = models
 
     assert model_with_cl.ncl() > 0
     assert model_without_cl.nx_rdata == model_with_cl.nx_rdata
@@ -217,3 +218,11 @@ def test_adjoint_pre_and_post_equilibration(edata_fixture):
 
             # assert gradients are close (quadrature tolerances are laxer)
             assert np.isclose(raa_cl['sllh'], raa['sllh'], 1e-5, 1e-5).all()
+
+
+def test_get_set_model_settings(models):
+    """test amici.(get|set)_model_settings cycles for models with and without
+    conservation laws"""
+
+    for model in models:
+        amici.set_model_settings(model, amici.get_model_settings(model))

--- a/src/model.cpp
+++ b/src/model.cpp
@@ -622,7 +622,7 @@ void Model::setStateIsNonNegative(std::vector<bool> const &nonNegative) {
     if (nx_solver != nx_rdata) {
         if(any_state_non_negative)
             throw AmiException("Non-negative states are not supported with"
-                               " conservation laws enabled");
+                               " conservation laws enabled.");
         // nothing to do, as `state_is_non_negative_` will always be all-false
         // in case of conservation laws
         return;

--- a/src/model.cpp
+++ b/src/model.cpp
@@ -617,11 +617,15 @@ std::vector<bool> const &Model::getStateIsNonNegative() const {
 void Model::setStateIsNonNegative(std::vector<bool> const &nonNegative) {
     auto any_state_non_negative = std::any_of(nonNegative.begin(),
                                               nonNegative.end(),
-                                              [](bool x) { return x; });
-
-    if (any_state_non_negative && nx_solver != nx_rdata) {
-        throw AmiException("Non-negative states are not supported with"
-                           " conservation laws enabled");
+                                              [](bool x) {
+                                                  return x; });
+    if (nx_solver != nx_rdata) {
+        if(any_state_non_negative)
+            throw AmiException("Non-negative states are not supported with"
+                               " conservation laws enabled");
+        // nothing to do, as `state_is_non_negative_` will always be all-false
+        // in case of conservation laws
+        return;
     }
     if (state_is_non_negative_.size() != static_cast<unsigned long>(nx_rdata)) {
         throw AmiException("Dimension of input stateIsNonNegative (%u) does "


### PR DESCRIPTION
Fixes a logic error when handling all-false input for models with conservation laws.
And adds at test.