### PR TITLE
Fix HDF5 OSX intermediate group creation errors

### DIFF
--- a/.github/workflows/test_pypi.yml
+++ b/.github/workflows/test_pypi.yml
@@ -31,11 +31,8 @@ jobs:
       - name: homebrew
         run: |
           if [[ ${{ matrix.os }} == macos* ]] ; then \
-            brew install hdf5@1.10 swig gcc libomp \
-               && echo "/usr/local/opt/hdf5@1.10/bin" >> $GITHUB_PATH \
-               && echo LDFLAGS="-L/usr/local/lib/ -L/usr/local/opt/hdf5@1.10/lib" >> $GITHUB_ENV \
-               && echo CPPFLAGS="-I/usr/local/opt/hdf5@1.10/include" >> $GITHUB_ENV \
-               && echo HDF5_BASE="/usr/local/opt/hdf5@1.10/" >> $GITHUB_ENV
+            brew install hdf5 swig gcc libomp \
+               && echo LDFLAGS="-L/usr/local/lib/" >> $GITHUB_ENV
           fi
 
       - name: Set up Python ${{ matrix.python-version }}

--- a/.github/workflows/test_python_cplusplus.yml
+++ b/.github/workflows/test_python_cplusplus.yml
@@ -152,13 +152,11 @@ jobs:
     # install amici dependencies
     - name: homebrew
       run: |
-        brew install hdf5@1.10 swig gcc cppcheck libomp boost \
+        brew install hdf5 swig gcc cppcheck libomp boost \
           && brew ls -v boost \
           && brew ls -v libomp \
-          && echo "/usr/local/opt/hdf5@1.10/bin" >> $GITHUB_PATH \
-          && echo LDFLAGS="-L/usr/local/lib/ -L/usr/local/opt/hdf5@1.10/lib -L/usr/local/Cellar/boost/1.78.0_1/lib/" >> $GITHUB_ENV \
-          && echo CPPFLAGS="-I/usr/local/opt/hdf5@1.10/include -I/usr/local/Cellar/boost/1.78.0_1/include/" >> $GITHUB_ENV \
-          && echo HDF5_BASE="/usr/local/opt/hdf5@1.10/" >> $GITHUB_ENV
+          && echo LDFLAGS="-L/usr/local/lib/ -L/usr/local/Cellar/boost/1.78.0_1/lib/" >> $GITHUB_ENV \
+          && echo CPPFLAGS="-I/usr/local/Cellar/boost/1.78.0_1/include/" >> $GITHUB_ENV
 
     - name: Build AMICI
       run: |

--- a/src/hdf5.cpp
+++ b/src/hdf5.cpp
@@ -84,23 +84,9 @@ void checkEventDimensionsCompatible(hsize_t m, hsize_t n, Model const& model) {
 void createGroup(H5::H5File const& file,
                  std::string const& groupPath,
                  bool recursively) {
-
-    auto groupCreationPropertyList = H5P_DEFAULT;
-
-    if (recursively) {
-        groupCreationPropertyList = H5Pcreate(H5P_LINK_CREATE);
-        H5Pset_create_intermediate_group(groupCreationPropertyList, 1);
-    }
-
-    hid_t group = H5Gcreate(file.getId(), groupPath.c_str(),
-                            groupCreationPropertyList,
-                            H5P_DEFAULT, H5P_DEFAULT);
-    H5Pclose(groupCreationPropertyList);
-
-    if (group < 0)
-        throw(AmiException("Failed to create group in hdf5CreateGroup: %s",
-                           groupPath.c_str()));
-    H5Gclose(group);
+    H5::LinkCreatPropList lcpl;
+    lcpl.setCreateIntermediateGroup(recursively);
+    file.createGroup(groupPath.c_str(), lcpl);
 }
 
 std::unique_ptr<ExpData> readSimulationExpData(std::string const& hdf5Filename,


### PR DESCRIPTION
Still not sure what the original problem was, but going through the HDF5 C++ API seems to fix the following error occurring in `amici::hdf5::hdf5CreateGroup` with recent HDF5 versions on OSX: 
```
>       return _amici.writeSolverSettingsToHDF5(*args)
E       RuntimeError: Failed to create group in hdf5CreateGroup: ssettings

../sdist/amici/amici.py:6129: RuntimeError
----------------------------- Captured stderr call -----------------------------
HDF5-DIAG: Error detected in HDF5 (1.10.8) thread 0:
  #000: H5Plcpl.c line 152 in H5Pset_create_intermediate_group(): can't find object for ID
    major: Object atom
    minor: Unable to find atom information (already closed?)
  #001: H5Pint.c line 3805 in H5P_object_verify(): property list is not a member of the class
    major: Property lists
    minor: Unable to register new atom
  #002: H5Pint.c line 3756 in H5P_isa_class(): not a property list
    major: Invalid arguments to routine
    minor: Inappropriate type
HDF5-DIAG: Error detected in HDF5 (1.10.8) thread 0:
  #000: H5G.c line 288 in H5Gcreate2(): not link creation property list
    major: Invalid arguments to routine
    minor: Inappropriate type
  #001: H5Pint.c line 3756 in H5P_isa_class(): not a property list
    major: Invalid arguments to routine
    minor: Inappropriate type
HDF5-DIAG: Error detected in HDF5 (1.10.8) thread 0:
  #000: H5P.c line 1488 in H5Pclose(): not a property list
    major: Invalid arguments to routine
    minor: Inappropriate type
``` 

`H5::LinkCreatPropList::setCreateIntermediateGroup` was only added in HDF5 1.10.6, but current Ubuntu LTS still comes with HDF5 1.10.4. Therefore we still need to keep the C version.