### PR TITLE
Speedup conservation law computation

### DIFF
--- a/python/amici/pysb_import.py
+++ b/python/amici/pysb_import.py
@@ -1015,12 +1015,12 @@ def _construct_conservation_from_prototypes(
         # x_j = (T - sum_i≠j(a_i * x_i))/a_j
         # law: sum_i≠j(a_i * x_i))/a_j
         # state: x_j
-        target_expression = sum(
+        target_expression = sp.Add(*[
             sp.Symbol(f'__s{ix}')
             * extract_monomers(specie).count(monomer_name)
             for ix, specie in enumerate(pysb_model.species)
             if ix != target_index
-        ) / extract_monomers(pysb_model.species[
+        ]) / extract_monomers(pysb_model.species[
                                  target_index
                              ]).count(monomer_name)
         # normalize by the stoichiometry of the target species

--- a/python/amici/pysb_import.py
+++ b/python/amici/pysb_import.py
@@ -1015,12 +1015,12 @@ def _construct_conservation_from_prototypes(
         # x_j = (T - sum_i≠j(a_i * x_i))/a_j
         # law: sum_i≠j(a_i * x_i))/a_j
         # state: x_j
-        target_expression = sp.Add(*[
+        target_expression = sp.Add(*(
             sp.Symbol(f'__s{ix}')
             * extract_monomers(specie).count(monomer_name)
             for ix, specie in enumerate(pysb_model.species)
             if ix != target_index
-        ]) / extract_monomers(pysb_model.species[
+        )) / extract_monomers(pysb_model.species[
                                  target_index
                              ]).count(monomer_name)
         # normalize by the stoichiometry of the target species


### PR DESCRIPTION
So it turns out, using `sum` for symbolic variables is a really bad idea (see https://github.com/sympy/sympy/issues/13945).

Tested on a model with ~8k species.
Previous:
```
2022-04-02 20:52:20.502 - amici.pysb_import - INFO - Finished computing PySB conservation laws    + (3.17E+03s)
```

Now:
```
2022-04-03 09:30:18.220 - amici.pysb_import - INFO - Finished computing PySB conservation laws    + (1.90E+02s)
```