### PR TITLE
Use `amici.AmiciVersionError` to indicate version mismatch

### DIFF
--- a/python/amici/__init__.py
+++ b/python/amici/__init__.py
@@ -178,3 +178,9 @@ def import_model_module(module_name: str,
 
     with add_path(module_path):
         return importlib.import_module(module_name)
+
+
+class AmiciVersionError(RuntimeError):
+    """Error thrown if an AMICI model is loaded that is incompatible with
+    the installed AMICI base package"""
+    pass

--- a/python/amici/__init__.template.py
+++ b/python/amici/__init__.template.py
@@ -4,12 +4,13 @@ import amici
 
 # Ensure we are binary-compatible, see #556
 if 'TPL_AMICI_VERSION' != amici.__version__:
-    raise RuntimeError('Cannot use model TPL_MODELNAME, generated with AMICI '
-                       'version TPL_AMICI_VERSION, together with AMICI version'
-                       f' {amici.__version__} which is present in your '
-                       'PYTHONPATH. Install the AMICI package matching the '
-                       'model version or regenerate the model with the AMICI '
-                       'currently in your path.')
+    raise amici.AmiciVersionError(
+        'Cannot use model `TPL_MODELNAME`, generated with amici=='
+        f'TPL_AMICI_VERSION, together with amici=={amici.__version__} '
+        'which is currently installed. To use this model, install '
+        'amici==TPL_AMICI_VERSION or re-import the model with the amici '
+        'version currently installed.'
+    )
 
 from TPL_MODELNAME._TPL_MODELNAME import *
 


### PR DESCRIPTION
Using a more specific exception will allow downstream packages to handle version mismatches better, by e.g. automatically re-importing such models.