### PR TITLE
Speedup for models with conservation laws

### DIFF
--- a/python/amici/ode_export.py
+++ b/python/amici/ode_export.py
@@ -1617,6 +1617,16 @@ class ODEModel:
             # force symbols
             self._eqs[name] = self.sym(name)
 
+        elif name == 'dwdx':
+            x = self.sym('x')
+            self._eqs[name] = sp.Matrix([
+                [-cl.get_ncoeff(xs) for xs in x]
+                # the insert first in ode_model._add_conservation_law() means
+                # that we need to reverse the order here
+                for cl in reversed(self._conservationlaws)
+            ]) .col_join(smart_jacobian(self.eq('w')[self.num_cons_law():,:],
+                                        x))
+
         elif match_deriv:
             self._derivative(match_deriv.group(1), match_deriv.group(2), name)
 

--- a/python/amici/ode_export.py
+++ b/python/amici/ode_export.py
@@ -1994,22 +1994,6 @@ class ODEModel:
             ix_solver += 1
         return solver_index
 
-    def get_solver_indices(self) -> Dict[int, int]:
-        """
-        Returns a mapping that maps rdata species indices to solver indices
-
-        :return:
-            dictionary mapping rdata species indices to solver indices
-        """
-        solver_index = {}
-        ix_solver = 0
-        for ix in range(len(self._states)):
-            if self.state_has_conservation_law(ix):
-                continue
-            solver_index[ix] = ix_solver
-            ix_solver += 1
-        return solver_index
-
     def state_is_constant(self, ix: int) -> bool:
         """
         Checks whether the temporal derivative of the state is zero

--- a/python/amici/ode_model.py
+++ b/python/amici/ode_model.py
@@ -150,7 +150,7 @@ class ConservationLaw(ModelQuantity):
             unique identifier of the ConservationLaw
 
         :param name:
-            individual name of the ConservationLaw (does not need  to be
+            individual name of the ConservationLaw (does not need to be
             unique)
 
         :param value: formula (sum of states)
@@ -177,7 +177,7 @@ class ConservationLaw(ModelQuantity):
     def get_ncoeff(self, state_id) -> Union[sp.Expr, int, float]:
         """
         Computes the normalized coefficient a_i/a_j where i is the index of
-        the provided state_id and j is the index of the state that this
+        the provided state_id and j is the index of the state that is
         replaced by this conservation law. This can be used to compute both
         dtotal_cl/dx_rdata (=ncoeff) and dx_rdata/dx_solver (=-ncoeff).
 
@@ -307,10 +307,10 @@ class State(ModelQuantity):
 
     def get_dx_rdata_dx_solver(self, state_id):
         """
-        Returns the expression that allows computation of x_rdata for this
+        Returns the expression that allows computation of ``dx_rdata_dx_solver`` for this
         state, accounting for conservation laws.
 
-        :return: x_rdata expression
+        :return: dx_rdata_dx_solver expression
         """
         if self._conservation_law is None:
             return sp.Integer(self._identifier == state_id)

--- a/python/amici/ode_model.py
+++ b/python/amici/ode_model.py
@@ -131,6 +131,73 @@ class ModelQuantity:
         self._value = cast_to_sym(val, 'value')
 
 
+class ConservationLaw(ModelQuantity):
+    """
+    A conservation law defines the absolute the total amount of a
+    (weighted) sum of states
+
+    """
+    def __init__(self,
+                 identifier: sp.Symbol,
+                 name: str,
+                 value: sp.Expr,
+                 coefficients: Dict[sp.Symbol, sp.Expr],
+                 state_id: sp.Symbol):
+        """
+        Create a new ConservationLaw instance.
+
+        :param identifier:
+            unique identifier of the ConservationLaw
+
+        :param name:
+            individual name of the ConservationLaw (does not need  to be
+            unique)
+
+        :param value: formula (sum of states)
+
+        :param coefficients:
+            coefficients of the states in the sum
+
+        :param state_id:
+            identifier of the state that this conservation law replaces
+        """
+        self._state_expr: sp.Symbol = identifier - (value - state_id)
+        self._coefficients: Dict[sp.Symbol, sp.Expr] = coefficients
+        self._ncoeff: sp.Expr = coefficients[state_id]
+        super(ConservationLaw, self).__init__(identifier, name, value)
+
+    def get_state(self) -> sp.Symbol:
+        """
+        Get the identifier of the state that this conservation law replaces
+
+        :return: identifier of the state
+        """
+        return self._state_id
+
+    def get_ncoeff(self, state_id) -> Union[sp.Expr, int, float]:
+        """
+        Computes the normalized coefficient a_i/a_j where i is the index of
+        the provided state_id and j is the index of the state that this
+        replaced by this conservation law. This can be used to compute both
+        dtotal_cl/dx_rdata (=ncoeff) and dx_rdata/dx_solver (=-ncoeff).
+
+        :param state_id:
+            identifier of the state
+
+        :return: normalized coefficent of the state
+        """
+        return self._coefficients.get(state_id, 0.0) / self._ncoeff
+
+    def get_x_rdata(self):
+        """
+        Returns the expression that allows computation of x_rdata for the state
+        that this conservation law replaces.
+
+        :return: x_rdata expression
+        """
+        return self._state_expr
+
+
 class State(ModelQuantity):
     """
     A State variable defines an entity that evolves with time according to
@@ -171,10 +238,9 @@ class State(ModelQuantity):
         """
         super(State, self).__init__(identifier, name, init)
         self._dt = cast_to_sym(dt, 'dt')
-        self._conservation_law = None
+        self._conservation_law: Union[ConservationLaw, None] = None
 
-    def set_conservation_law(self,
-                             law: sp.Expr) -> None:
+    def set_conservation_law(self, law: ConservationLaw) -> None:
         """
         Sets the conservation law of a state.
 
@@ -185,9 +251,9 @@ class State(ModelQuantity):
             linear sum of states that if added to this state remain
             constant over time
         """
-        if not isinstance(law, sp.Expr):
-            raise TypeError(f'conservation law must have type sympy.Expr, '
-                            f'was {type(law)}')
+        if not isinstance(law, ConservationLaw):
+            raise TypeError(f'conservation law must have type ConservationLaw'
+                            f', was {type(law)}')
 
         self._conservation_law = law
 
@@ -219,30 +285,37 @@ class State(ModelQuantity):
         """
         return self._dt.free_symbols.union(self._value.free_symbols)
 
-
-class ConservationLaw(ModelQuantity):
-    """
-    A conservation law defines the absolute the total amount of a
-    (weighted) sum of states
-
-    """
-    def __init__(self,
-                 identifier: sp.Symbol,
-                 name: str,
-                 value: sp.Expr):
+    def has_conservation_law(self):
         """
-        Create a new ConservationLaw instance.
+        Checks whether this state has a conservation law assigned.
 
-        :param identifier:
-            unique identifier of the ConservationLaw
-
-        :param name:
-            individual name of the ConservationLaw (does not need  to be
-            unique)
-
-        :param value: formula (sum of states)
+        :return: True if assigned, False otherwise
         """
-        super(ConservationLaw, self).__init__(identifier, name, value)
+        return self._conservation_law is not None
+
+    def get_x_rdata(self):
+        """
+        Returns the expression that allows computation of x_rdata for this
+        state, accounting for conservation laws.
+
+        :return: x_rdata expression
+        """
+        if self._conservation_law is None:
+            return self.get_id()
+        else:
+            return self._conservation_law.get_x_rdata()
+
+    def get_dx_rdata_dx_solver(self, state_id):
+        """
+        Returns the expression that allows computation of x_rdata for this
+        state, accounting for conservation laws.
+
+        :return: x_rdata expression
+        """
+        if self._conservation_law is None:
+            return sp.Integer(self._identifier == state_id)
+        else:
+            return -self._conservation_law.get_ncoeff(state_id)
 
 
 class Observable(ModelQuantity):

--- a/python/amici/pysb_import.py
+++ b/python/amici/pysb_import.py
@@ -1110,36 +1110,18 @@ def _construct_conservation_from_prototypes(
     for monomer_name in cl_prototypes:
         target_index = cl_prototypes[monomer_name]['target_index']
 
-        # T = sum_i(a_i * x_i)
-        # x_j = (T - sum_i≠j(a_i * x_i))/a_j
-        # law: sum_i≠j(a_i * x_i))/a_j
-        # state: x_j
-        target_expression = sp.Add(*(
-            sp.Symbol(f'__s{ix}')
-            * extract_monomers(specie).count(monomer_name)
-            for ix, specie in enumerate(pysb_model.species)
-            if ix != target_index
-        )) / extract_monomers(pysb_model.species[
-                                 target_index
                              ]).count(monomer_name)
-        # normalize by the stoichiometry of the target species
-        target_state = sp.Symbol(f'__s{target_index}')
-        # = x_j
+        coefficients = dict()
 
-        total_abundance = sp.Symbol(f'tcl__s{target_index}')
-        # = T/a_j
-
-        state_expr = total_abundance - target_expression
-        # x_j = T/a_j - sum_i≠j(a_i * x_i)/a_j
-
-        abundance_expr = target_expression + target_state
-        # T/a_j = sum_i≠j(a_i * x_i)/a_j + x_j
+        for ix, specie in enumerate(pysb_model.species):
+            count = extract_monomers(specie).count(monomer_name)
+            if count > 0:
+                coefficients[sp.Symbol(f'__s{ix}')] = count
 
         conservation_laws.append({
-            'state': target_state,
-            'total_abundance': total_abundance,
-            'state_expr': state_expr,
-            'abundance_expr': abundance_expr,
+            'state': sp.Symbol(f'__s{target_index}'),
+            'total_abundance': sp.Symbol(f'tcl__s{target_index}'),
+            'coefficients': coefficients,
         })
 
     return conservation_laws
@@ -1163,14 +1145,10 @@ def _add_conservation_for_constant_species(
 
     for ix in range(ode_model.num_states_rdata()):
         if ode_model.state_is_constant(ix):
-            target_state = sp.Symbol(f'__s{ix}')
-            total_abundance = sp.Symbol(f'tcl__s{ix}')
-
             conservation_laws.append({
-                'state': target_state,
-                'total_abundance': total_abundance,
-                'state_expr': total_abundance,
-                'abundance_expr': target_state,
+                'state': sp.Symbol(f'__s{ix}'),
+                'total_abundance': sp.Symbol(f'tcl__s{ix}'),
+                'coefficients': {sp.Symbol(f'__s{ix}'): 1.0}
             })
 
 
@@ -1188,21 +1166,24 @@ def _flatten_conservation_laws(
 
     while len(conservation_law_subs):
         for cl in conservation_laws:
-            if _sub_matches_cl(
-                    conservation_law_subs,
-                    cl['state_expr'],
-                    cl['state']
-            ):
-                # this optimization is done by subs anyways, but we dont
-                # want to recompute the subs if we did not change anything
-                valid_subs = _select_valid_cls(
-                    conservation_law_subs,
-                    cl['state']
-                )
-                if len(valid_subs) > 0:
-                    cl['state_expr'] = cl['state_expr'].subs(valid_subs)
-                    conservation_law_subs = \
-                        _get_conservation_law_subs(conservation_laws)
+            matched_subs = [
+                s for s in conservation_law_subs
+                if s[0] in cl['coefficients'] and s[0] != cl['state']
+            ]
+            if matched_subs:
+                for s in matched_subs:
+                    coeff = cl['coefficients'][s[0]]
+                    del cl['coefficients'][s[0]]
+                    # x_j = T/a_j - sum_{i≠j}(x_i * a_i) / a_j
+                    # don't need to account for totals here as we can simply
+                    # absorb that into the new total
+                    for k, v in s[1].items():
+                        if k == s[0]:
+                            continue
+                        cl['coefficients'][k] = -coeff * v / s[1][s[0]]
+
+                conservation_law_subs = \
+                    _get_conservation_law_subs(conservation_laws)
 
 
 def _select_valid_cls(subs: Iterable[Tuple[sp.Symbol, sp.Basic]],
@@ -1226,43 +1207,11 @@ def _select_valid_cls(subs: Iterable[Tuple[sp.Symbol, sp.Basic]],
         if str(state) not in [str(symbol) for symbol in sub[1].free_symbols]
     ]
 
-
-def _sub_matches_cl(subs: Iterable[Tuple[sp.Symbol, sp.Basic]],
-                    state_expr: sp.Basic,
-                    state: sp.Basic) -> bool:
-    """
-    Checks whether any of the substitutions in subs will be applied to
-    state_expr
-
-    :param subs:
-        substitutions in tuple format
-
-    :param state_expr:
-        target symbolic expressions in which substitutions will be applied
-
-    :param state: target symbolic state to which substitutions will
-        be applied
-
-    :return:
-        boolean indicating positive match
-    """
-
-    sub_symbols = set(
-        sub[0]
-        for sub in subs
-        if str(state) not in [
-            str(symbol) for symbol in sub[1].free_symbols
-        ]
-    )
-
-    return len(sub_symbols.intersection(state_expr.free_symbols)) > 0
-
-
 def _get_conservation_law_subs(
         conservation_laws: List[ConservationLaw]
-) -> List[Tuple[sp.Symbol, sp.Basic]]:
+) -> List[Tuple[sp.Symbol, Dict[sp.Symbol, sp.Expr]]]:
     """
-    Computes a list of (state, law) tuples for conservation laws that still
+    Computes a list of (state, coeffs) tuples for conservation laws that still
     appear in other conservation laws
 
     :param conservation_laws:
@@ -1272,29 +1221,14 @@ def _get_conservation_law_subs(
         list of tuples containing substitution rules to be used with sympy
         subs
     """
-    free_symbols_cl = _conservation_law_variables(conservation_laws)
     return [
-        (cl['state'], cl['state_expr']) for cl in conservation_laws
-        if cl['state'] in free_symbols_cl
+        (cl['state'], cl['coefficients']) for cl in conservation_laws
+        if any(
+            cl['state'] in other_cl['coefficients']
+            for other_cl in conservation_laws
+            if other_cl != cl
+        )
     ]
-
-
-def _conservation_law_variables(
-        conservation_laws: List[ConservationLaw]) -> Set[sp.Symbol]:
-    """
-    Construct the set of all free variables from a list of conservation laws
-
-    :param conservation_laws:
-        list of conservation laws
-
-    :return:
-        free variables in conservation laws
-    """
-    variables = set()
-    for cl in conservation_laws:
-        variables |= cl['state_expr'].free_symbols
-    return variables
-
 
 def has_fixed_parameter_ic(specie: pysb.core.ComplexPattern,
                            pysb_model: pysb.Model,

--- a/python/amici/pysb_import.py
+++ b/python/amici/pysb_import.py
@@ -1109,8 +1109,6 @@ def _construct_conservation_from_prototypes(
     conservation_laws = []
     for monomer_name in cl_prototypes:
         target_index = cl_prototypes[monomer_name]['target_index']
-
-                             ]).count(monomer_name)
         coefficients = dict()
 
         for ix, specie in enumerate(pysb_model.species):
@@ -1174,13 +1172,18 @@ def _flatten_conservation_laws(
                 for s in matched_subs:
                     coeff = cl['coefficients'][s[0]]
                     del cl['coefficients'][s[0]]
-                    # x_j = T/a_j - sum_{i≠j}(x_i * a_i) / a_j
+                    # x_j = T/b_j - sum_{i≠j}(x_i * b_i) / b_j
                     # don't need to account for totals here as we can simply
                     # absorb that into the new total
                     for k, v in s[1].items():
                         if k == s[0]:
                             continue
-                        cl['coefficients'][k] = -coeff * v / s[1][s[0]]
+                        update = -coeff * v / s[1][s[0]]
+
+                        if k in cl['coefficients']:
+                            cl['coefficients'][k] += update
+                        else:
+                            cl['coefficients'][k] = update
 
                 conservation_law_subs = \
                     _get_conservation_law_subs(conservation_laws)

--- a/python/amici/sbml_import.py
+++ b/python/amici/sbml_import.py
@@ -1646,24 +1646,6 @@ class SbmlImporter:
             })
             species_to_be_removed.add(target_state_model_idx)
 
-        # replace eliminated states by their state expressions, taking care of
-        #  any (non-cyclic) dependencies
-        state_exprs = {
-            cl['state']: cl['state_expr']
-            for cl in itt.chain(conservation_laws, new_conservation_laws)
-        }
-        try:
-            sorted_state_exprs = toposort_symbols(state_exprs)
-        except CircularDependencyError as e:
-            raise AssertionError(
-                "Circular dependency detected in conservation laws. "
-                "This should not have happened."
-            ) from e
-
-        for cl in new_conservation_laws:
-            cl['state_expr'] = smart_subs_dict(cl['state_expr'],
-                                               sorted_state_exprs)
-
         conservation_laws.extend(new_conservation_laws)
 
         # list of species that are not determined by conservation laws

--- a/python/amici/sbml_import.py
+++ b/python/amici/sbml_import.py
@@ -1631,8 +1631,6 @@ class SbmlImporter:
             compartment_sizes = [all_compartment_sizes[i] for i in state_idxs]
 
             target_state_id = all_state_ids[target_state_model_idx]
-            target_compartment = all_compartment_sizes[target_state_model_idx]
-            target_state_coeff = coefficients[0]
             total_abundance = symbol_with_assumptions(f'tcl_{target_state_id}')
 
             new_conservation_laws.append({

--- a/python/amici/sbml_import.py
+++ b/python/amici/sbml_import.py
@@ -1635,22 +1635,14 @@ class SbmlImporter:
             target_state_coeff = coefficients[0]
             total_abundance = symbol_with_assumptions(f'tcl_{target_state_id}')
 
-            # \sum coeff * state * volume
-            abundance_expr = sp.Add(*[
-                state_id * coeff * compartment
-                for state_id, coeff, compartment
-                in zip(state_ids, coefficients, compartment_sizes)
-            ])
-
             new_conservation_laws.append({
                 'state': target_state_id,
                 'total_abundance': total_abundance,
-                'state_expr':
-                    (total_abundance - (abundance_expr
-                                        - target_state_id * target_compartment
-                                        * target_state_coeff))
-                    / target_state_coeff / target_compartment,
-                'abundance_expr': abundance_expr
+                'coefficients': {
+                     state_id: coeff * compartment
+                     for state_id, coeff, compartment
+                     in zip(state_ids, coefficients, compartment_sizes)
+                },
             })
             species_to_be_removed.add(target_state_model_idx)
 
@@ -2090,8 +2082,7 @@ def _add_conservation_for_constant_species(
             conservation_laws.append({
                 'state': target_state,
                 'total_abundance': total_abundance,
-                'state_expr': total_abundance,
-                'abundance_expr': target_state,
+                'coefficients': {target_state: 1.0},
             })
             # mark species to delete from stoichiometric matrix
             species_solver.pop(ix)

--- a/python/tests/test_pysb.py
+++ b/python/tests/test_pysb.py
@@ -165,8 +165,7 @@ def test_compare_to_pysb_simulation(example):
             solver.setRelativeTolerance(rtol)
             rdata = amici.runAmiciSimulation(model_pysb, solver)
 
-            # check agreement of species simulation
-
+            # check agreement of species simulations
             assert np.isclose(rdata['x'],
                               pysb_simres.species, 1e-4, 1e-4).all()
 


### PR DESCRIPTION
fixes #1762 

Explanation: By storing the coefficients for conservation laws we can compute super fast derivatives w.r.t. `x`, speeding up `dtotal_cldx_rdata`, `dx_rdata_dx_solver` and parts of `dwdx`.