### PR TITLE
Remove long deprecated sbml2amici arguments modelName and constantParameters

### DIFF
--- a/python/amici/sbml_import.py
+++ b/python/amici/sbml_import.py
@@ -205,24 +205,25 @@ class SbmlImporter:
         self.symbols = copy.deepcopy(default_symbols)
         self._local_symbols = {}
 
-    def sbml2amici(self,
-                   model_name: str = None,
-                   output_dir: Union[str, Path] = None,
-                   observables: Dict[str, Dict[str, str]] = None,
-                   constant_parameters: Iterable[str] = None,
-                   sigmas: Dict[str, Union[str, float]] = None,
-                   noise_distributions: Dict[str, Union[str, Callable]] = None,
-                   verbose: Union[int, bool] = logging.ERROR,
-                   assume_pow_positivity: bool = False,
-                   compiler: str = None,
-                   allow_reinit_fixpar_initcond: bool = True,
-                   compile: bool = True,
-                   compute_conservation_laws: bool = True,
-                   simplify: Callable = lambda x: sp.powsimp(x, deep=True),
-                   cache_simplify: bool = False,
-                   log_as_log10: bool = True,
-                   generate_sensitivity_code: bool = True,
-                   **kwargs) -> None:
+    def sbml2amici(
+            self,
+            model_name: str,
+            output_dir: Union[str, Path] = None,
+            observables: Dict[str, Dict[str, str]] = None,
+            constant_parameters: Iterable[str] = None,
+            sigmas: Dict[str, Union[str, float]] = None,
+            noise_distributions: Dict[str, Union[str, Callable]] = None,
+            verbose: Union[int, bool] = logging.ERROR,
+            assume_pow_positivity: bool = False,
+            compiler: str = None,
+            allow_reinit_fixpar_initcond: bool = True,
+            compile: bool = True,
+            compute_conservation_laws: bool = True,
+            simplify: Callable = lambda x: sp.powsimp(x, deep=True),
+            cache_simplify: bool = False,
+            log_as_log10: bool = True,
+            generate_sensitivity_code: bool = True,
+    ) -> None:
         """
         Generate and compile AMICI C++ files for the model provided to the
         constructor.
@@ -315,46 +316,14 @@ class SbmlImporter:
         """
         set_log_level(logger, verbose)
 
-        if 'constantParameters' in kwargs:
-            logger.warning('Use of `constantParameters` as argument name '
-                           'is deprecated and will be removed in a future '
-                           'version. Please use `constant_parameters` as '
-                           'argument name.')
-
-            if constant_parameters is not None:
-                raise ValueError('Cannot specify constant parameters using '
-                                 'both `constantParameters` and '
-                                 '`constant_parameters` as argument names.')
-
-            constant_parameters = kwargs.pop('constantParameters', [])
-
-        elif constant_parameters is None:
-            constant_parameters = []
-        constant_parameters = list(constant_parameters)
+        constant_parameters = list(constant_parameters) \
+            if constant_parameters else []
 
         if sigmas is None:
             sigmas = {}
 
         if noise_distributions is None:
             noise_distributions = {}
-
-        if model_name is None:
-            model_name = kwargs.pop('modelName', None)
-            if model_name is None:
-                raise ValueError('Missing argument: `model_name`')
-            else:
-                logger.warning('Use of `modelName` as argument name is '
-                               'deprecated and will be removed in a future'
-                               ' version. Please use `model_name` as '
-                               'argument name.')
-        else:
-            if 'modelName' in kwargs:
-                raise ValueError('Cannot specify model name using both '
-                                 '`modelName` and `model_name` as argument '
-                                 'names.')
-
-        if len(kwargs):
-            raise ValueError(f'Unknown arguments {kwargs.keys()}.')
 
         self._reset_symbols()
         self.sbml_parser_settings.setParseLog(


### PR DESCRIPTION
I think it's safe to remove them... 