### PR TITLE
Improve efficiency of newton step conv check

### DIFF
--- a/include/amici/solver.h
+++ b/include/amici/solver.h
@@ -897,7 +897,8 @@ class Solver {
     }
 
     /**
-     * @brief Returns how convergence checks for steadystate computation are performed.
+     * @brief Returns how convergence checks for steadystate computation are performed. If activated,
+     * convergence checks are limited to every 25 steps in the simulation solver to limit performance impact.
      * @return boolean flag indicating newton step (true) or the right hand side (false)
      */
     bool getNewtonStepSteadyStateCheck() const {

--- a/python/tests/test_preequilibration.py
+++ b/python/tests/test_preequilibration.py
@@ -338,6 +338,7 @@ def test_newton_solver_equilibration(preeq_fixture):
                 amici.SteadyStateSensitivityMode.newtonOnly]
 
     solver.setNewtonStepSteadyStateCheck(True)
+    solver.setRelativeToleranceSteadyState(1e-12)
 
     for equil_meth in settings:
         # set sensi method

--- a/src/steadystateproblem.cpp
+++ b/src/steadystateproblem.cpp
@@ -660,7 +660,7 @@ void SteadystateProblem::runSteadystateSimulation(const Solver &solver,
          system is prepared for newton type convergence check */
         if (wrms_ < conv_thresh && check_sensi_conv_ &&
             sensitivityFlag == SensitivityMethod::forward &&
-            convergence_check_frequency % sim_steps == 0) {
+            sim_steps % convergence_check_frequency == 0) {
             updateSensiSimulation(solver);
             wrms_ = getWrmsFSA(model);
         }

--- a/src/steadystateproblem.cpp
+++ b/src/steadystateproblem.cpp
@@ -630,7 +630,12 @@ void SteadystateProblem::runSteadystateSimulation(const Solver &solver,
     /* If run after Newton's method checks again if it converged */
     wrms_ = getWrms(model, sensitivityFlag);
     int sim_steps = 0;
-
+    
+    int convergence_check_frequency = 1;
+    
+    if (newton_step_conv_)
+        convergence_check_frequency = 25;
+        
     while (true) {
         /* One step of ODE integration
          reason for tout specification:
@@ -654,7 +659,8 @@ void SteadystateProblem::runSteadystateSimulation(const Solver &solver,
         /* getWrms needs to be called before getWrmsFSA such that the linear
          system is prepared for newton type convergence check */
         if (wrms_ < conv_thresh && check_sensi_conv_ &&
-            sensitivityFlag == SensitivityMethod::forward) {
+            sensitivityFlag == SensitivityMethod::forward &&
+            convergence_check_frequency % sim_steps == 0) {
             updateSensiSimulation(solver);
             wrms_ = getWrmsFSA(model);
         }


### PR DESCRIPTION
Some profiling suggests that one convergence check comes at the cost of about 10 simulation steps, so checking convergence in every step dominates computation time. Might be better to have some adaptive approach based on the value of `wrms_`, but this will hopefully work sufficiently well in most cases.