### PR TITLE
Specify initial timepoint with ExpData

### DIFF
--- a/include/amici/edata.h
+++ b/include/amici/edata.h
@@ -519,6 +519,7 @@ class ConditionContext : public ContextManager {
     std::vector<realtype> original_sx0_;
     std::vector<realtype> original_parameters_;
     std::vector<realtype> original_fixed_parameters_;
+    realtype original_tstart_;
     std::vector<realtype> original_timepoints_;
     std::vector<int> original_parameter_list_;
     std::vector<amici::ParameterScaling> original_scaling_;

--- a/src/edata.cpp
+++ b/src/edata.cpp
@@ -336,6 +336,7 @@ ConditionContext::ConditionContext(Model *model, const ExpData *edata,
     : model_(model),
       original_parameters_(model->getParameters()),
       original_fixed_parameters_(model->getFixedParameters()),
+      original_tstart_(model->t0()),
       original_timepoints_(model->getTimepoints()),
       original_parameter_list_(model->getParameterList()),
       original_scaling_(model->getParameterScale()),
@@ -454,6 +455,7 @@ void ConditionContext::applyCondition(const ExpData *edata,
       break;
     }
 
+    model_->setT0(edata->tstart_);
     if(edata->nt()) {
         // fixed parameter in model are superseded by those provided in edata
         model_->setTimepoints(edata->getTimepoints());
@@ -475,6 +477,7 @@ void ConditionContext::restore()
 
     model_->setParameters(original_parameters_);
     model_->setFixedParameters(original_fixed_parameters_);
+    model_->setT0(original_tstart_);
     model_->setTimepoints(original_timepoints_);
     model_->setReinitializeFixedParameterInitialStates(
         original_reinitialize_fixed_parameter_initial_states_);


### PR DESCRIPTION
Might be useful to add other things too, e.g. `t_presim`, but I have only tried `tstart_` for my use case so far.
https://github.com/AMICI-dev/AMICI/blob/a2e543796d9f478673afd8cbd60fd2286912dc12/include/amici/simulation_parameters.h#L181