### PR TITLE
Avoid error if no measurements in PEtab problem; fix type handling in PEtab parameter mapping

### DIFF
--- a/python/amici/petab_objective.py
+++ b/python/amici/petab_objective.py
@@ -153,9 +153,10 @@ def simulate_petab(
 
     # Log results
     sim_cond = petab_problem.get_simulation_conditions_from_measurement_df()
-    for i, rdata in enumerate(rdatas):
-        logger.debug(f"Condition: {sim_cond.iloc[i, :].values}, status: "
-                     f"{rdata['status']}, llh: {rdata['llh']}")
+    if not sim_cond.empty:
+        for i, rdata in enumerate(rdatas):
+            logger.debug(f"Condition: {sim_cond.iloc[i, :].values}, status: "
+                         f"{rdata['status']}, llh: {rdata['llh']}")
 
     return {
         LLH: llh,
@@ -230,7 +231,7 @@ def create_parameterized_edatas(
 
 def create_parameter_mapping(
         petab_problem: petab.Problem,
-        simulation_conditions: Union[pd.DataFrame, Dict],
+        simulation_conditions: Union[pd.DataFrame, List[Dict]],
         scaled_parameters: bool,
         amici_model: AmiciModel,
 ) -> ParameterMapping:
@@ -254,6 +255,8 @@ def create_parameter_mapping(
     if simulation_conditions is None:
         simulation_conditions = \
             petab_problem.get_simulation_conditions_from_measurement_df()
+    if isinstance(simulation_conditions, list):
+        simulation_conditions = pd.DataFrame(data=simulation_conditions)
 
     # Because AMICI globalizes all local parameters during model import,
     # we need to do that here as well to prevent parameter mapping errors

--- a/python/amici/petab_objective.py
+++ b/python/amici/petab_objective.py
@@ -153,10 +153,12 @@ def simulate_petab(
 
     # Log results
     sim_cond = petab_problem.get_simulation_conditions_from_measurement_df()
-    if not sim_cond.empty:
-        for i, rdata in enumerate(rdatas):
-            logger.debug(f"Condition: {sim_cond.iloc[i, :].values}, status: "
-                         f"{rdata['status']}, llh: {rdata['llh']}")
+    for i, rdata in enumerate(rdatas):
+        sim_cond_id = "N/A" if sim_cond.empty else sim_cond.iloc[i, :].values
+        logger.debug(
+            f"Condition: {sim_cond_id}, status: {rdata['status']}, "
+            f"llh: {rdata['llh']}"
+        )
 
     return {
         LLH: llh,


### PR DESCRIPTION
No measurements can occur if simulating a timecourse as a series of PEtab problems, where each PEtab problem has a subset of the original measurements table, and some timecourse period happens to have no measurements during it.

`iterrows` fails if `simulation_conditions` is passed as a dictionary.
https://github.com/AMICI-dev/AMICI/blob/da34367cba51e35aaaddbf00707a16a5135b01c7/python/amici/petab_objective.py#L281