### PR TITLE
Fix substitution of expressions in root and stau

### DIFF
--- a/python/amici/ode_export.py
+++ b/python/amici/ode_export.py
@@ -1297,7 +1297,7 @@ class ODEModel:
             expr.set_val(self._process_heavisides(expr.get_val(), roots))
 
         # remove all possible Heavisides from roots, which may arise from
-        # the substitution of `'w'` in `_get_unique_root`
+        # the substitution of `'w'` in `_collect_heaviside_roots`
         for root in roots:
             root.set_val(self._process_heavisides(root.get_val(), roots))
 
@@ -2066,15 +2066,6 @@ class ODEModel:
             unique identifier for root, or ``None`` if the root is not
             time-dependent
         """
-        # substitute 'w' expressions into root expressions now, to avoid
-        # rewriting '{model_name}_root.cpp' and '{model_name}_stau.cpp' headers
-        # to include 'w.h'
-        w_sorted = toposort_symbols(dict(zip(
-            [expr.get_id() for expr in self._expressions],
-            [expr.get_val() for expr in self._expressions],
-        )))
-        root_found = root_found.subs(w_sorted)
-
         if not self._expr_is_time_dependent(root_found):
             return None
 
@@ -2114,6 +2105,18 @@ class ODEModel:
                 root_funs.append(arg.args[0])
             elif arg.has(sp.Heaviside):
                 root_funs.extend(self._collect_heaviside_roots(arg.args))
+
+        # substitute 'w' expressions into root expressions now, to avoid
+        # rewriting '{model_name}_root.cpp' and '{model_name}_stau.cpp' headers
+        # to include 'w.h'
+        w_sorted = toposort_symbols(dict(zip(
+            [expr.get_id()  for expr in self._expressions],
+            [expr.get_val() for expr in self._expressions],
+        )))
+        root_funs = [
+            r.subs(w_sorted)
+            for r in root_funs
+        ]
 
         return root_funs
 


### PR DESCRIPTION
Caused an error like the following for a model

```
famos_cd4_root.cpp: In function ‘void amici::model_famos_cd4::root_famos_cd4(amici::realtype*, amici::realtype, const realtype*, const realtype*, const realtype*, const realtype*, const realtype*)’:
famos_cd4_root.cpp:17:15: error: ‘scaling_con_tau’ was not declared in this scope; did you mean ‘scaling_para_tau’?
   17 |     root[0] = scaling_con_tau*scaling_para_tau*tau - t;
      |               ^~~~~~~~~~~~~~~
      |               scaling_para_tau

famos_cd4_stau.cpp: In function ‘void amici::model_famos_cd4::stau_famos_cd4(amici::realtype*, amici::realtype, const realtype*, const realtype*, const realtype*, const realtype*, const realtype*, const realtype*, int, int)’:
famos_cd4_stau.cpp:22:31: error: ‘scaling_con_tau’ was not declared in this scope; did you mean ‘scaling_para_tau’?
   22 |                     stau[0] = scaling_con_tau*scaling_para_tau;
      |                               ^~~~~~~~~~~~~~~
      |                               scaling_para_tau
famos_cd4_stau.cpp:32:31: error: ‘scaling_con_tau’ was not declared in this scope; did you mean ‘scaling_para_tau’?
   32 |                     stau[0] = scaling_con_tau*scaling_para_tau;
      |                               ^~~~~~~~~~~~~~~
      |                               scaling_para_tau

```