### PR TITLE
CI: Fix some libgcov errors

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -6,6 +6,7 @@ omit =
     */amici_without_hdf5.py
     */ThirdParty/*
     *.template.*
+    /tmp/*
 parallel = true
 
 [report]

--- a/tests/petab_test_suite/test_petab_suite.py
+++ b/tests/petab_test_suite/test_petab_suite.py
@@ -65,9 +65,12 @@ def _test_case(case, model_type):
     # compile amici model
     if case.startswith('0006') and model_type != "pysb":
         petab.flatten_timepoint_specific_output_overrides(problem)
-    model_output_dir = f'amici_models/model_{case}'
+    model_name = f"petab_{model_type}_test_case_{case}"
+    model_output_dir = f'amici_models/{model_name}'
     model = import_petab_problem(
-        problem, model_output_dir=model_output_dir,
+        petab_problem=problem,
+        model_output_dir=model_output_dir,
+        model_name=model_name,
         force_compile=True)
     solver = model.getSolver()
     solver.setSteadyStateToleranceFactor(1.0)


### PR DESCRIPTION
* Ignore coverage of temporary model files.
  Fixes `/home/runner/work/AMICI/AMICI/build/venv/lib/python3.8/site-packages/coverage/report.py:87: CoverageWarning: Couldn't parse '/tmp/tmp0y55olyl/setup.py': No source for code: '/tmp/tmp0y55olyl/setup.py'. (couldnt-parse)`

* Don't re-use same path for different models as this confuses libgcov
  Fixes `libgcov profiling error:/home/runner/work/AMICI/AMICI/amici_models/model_0001/build/temp.linux-x86_64-cpython-38/wrapfunctions.gcda:overwriting an existing profile data with a different timestamp`