### PR TITLE
Re-arrange application of parameters from edata to avoid initial sensis error

### DIFF
--- a/.github/workflows/deploy_protected.yml
+++ b/.github/workflows/deploy_protected.yml
@@ -28,7 +28,7 @@ jobs:
     - uses: actions/checkout@master
     - run: git archive -o docker/amici.tar.gz --format=tar.gz HEAD
     - name: Publish to Registry
-      uses: elgohr/Publish-Docker-Github-Action@2.8
+      uses: elgohr/Publish-Docker-Github-Action@v4
       with:
         name: dweindl/amici
         username: ${{ secrets.DOCKER_USERNAME }}

--- a/python/tests/test_edata.py
+++ b/python/tests/test_edata.py
@@ -1,0 +1,57 @@
+"""Tests related to amici.ExpData via Python"""
+import os
+import re
+import shutil
+from urllib.request import urlopen
+
+import libsbml
+import numpy as np
+import pytest
+
+import amici
+from amici.gradient_check import check_derivatives
+from amici.sbml_import import SbmlImporter
+from amici.testing import TemporaryDirectoryWinSafe as TemporaryDirectory
+
+from test_sbml_import import model_units_module
+
+
+def test_edata_sensi_unscaling(model_units_module):
+    """
+    ExpData parameters should be used for unscaling initial state
+    sensitivities.
+    """
+    parameters0 = (5,5)
+    parameters1 = (2,2)
+
+    sx0 = (3,3,3,3)
+
+    parameter_scales_log10 = \
+        [amici.ParameterScaling.log10.value]*len(parameters0)
+    amici_parameter_scales_log10 = \
+        amici.parameterScalingFromIntVector(parameter_scales_log10)
+
+    model = model_units_module.getModel()
+    model.setTimepoints(np.linspace(0, 1, 3))
+    model.setParameterScale(parameter_scales_log10)
+    model.setParameters(parameters0)
+
+    solver = model.getSolver()
+    solver.setSensitivityOrder(amici.SensitivityOrder.first)
+
+    edata = amici.ExpData(model)
+    edata.pscale = amici_parameter_scales_log10
+    edata.parameters = parameters0
+    edata.sx0 = sx0
+
+    edata2 = amici.ExpData(model)
+    edata2.pscale = amici_parameter_scales_log10
+    edata2.parameters = parameters1
+    edata2.sx0 = sx0
+
+    rdata = amici.runAmiciSimulation(model, solver, edata)
+    rdata2 = amici.runAmiciSimulation(model, solver, edata2)
+
+    # The initial state sensitivities are as specified.
+    assert (rdata.sx0.flatten() == sx0).all()
+    assert (rdata2.sx0.flatten() == sx0).all()

--- a/python/tests/test_edata.py
+++ b/python/tests/test_edata.py
@@ -14,7 +14,8 @@ def test_edata_sensi_unscaling(model_units_module):
     parameters0 = (5, 5)
     parameters1 = (2, 2)
 
-    sx0 = np.array((3, 3, 3, 3))
+    sx0 = (3, 3, 3, 3)
+    np_sx0 = np.array(sx0)
 
     parameter_scales_log10 = \
         [amici.ParameterScaling.log10.value]*len(parameters0)
@@ -43,5 +44,5 @@ def test_edata_sensi_unscaling(model_units_module):
     rdata2 = amici.runAmiciSimulation(model, solver, edata2)
 
     # The initial state sensitivities are as specified.
-    assert (rdata.sx0.flatten() == sx0).all()
-    assert (rdata2.sx0.flatten() == sx0).all()
+    assert (rdata.sx0.flatten() == np_sx0).all()
+    assert (rdata2.sx0.flatten() == np_sx0).all()

--- a/python/tests/test_edata.py
+++ b/python/tests/test_edata.py
@@ -14,7 +14,7 @@ def test_edata_sensi_unscaling(model_units_module):
     parameters0 = (5, 5)
     parameters1 = (2, 2)
 
-    sx0 = (3, 3, 3, 3)
+    sx0 = np.array((3, 3, 3, 3))
 
     parameter_scales_log10 = \
         [amici.ParameterScaling.log10.value]*len(parameters0)

--- a/python/tests/test_edata.py
+++ b/python/tests/test_edata.py
@@ -1,17 +1,7 @@
 """Tests related to amici.ExpData via Python"""
-import os
-import re
-import shutil
-from urllib.request import urlopen
-
-import libsbml
 import numpy as np
-import pytest
 
 import amici
-from amici.gradient_check import check_derivatives
-from amici.sbml_import import SbmlImporter
-from amici.testing import TemporaryDirectoryWinSafe as TemporaryDirectory
 
 from test_sbml_import import model_units_module
 
@@ -21,10 +11,10 @@ def test_edata_sensi_unscaling(model_units_module):
     ExpData parameters should be used for unscaling initial state
     sensitivities.
     """
-    parameters0 = (5,5)
-    parameters1 = (2,2)
+    parameters0 = (5, 5)
+    parameters1 = (2, 2)
 
-    sx0 = (3,3,3,3)
+    sx0 = (3, 3, 3, 3)
 
     parameter_scales_log10 = \
         [amici.ParameterScaling.log10.value]*len(parameters0)

--- a/python/tests/test_edata.py
+++ b/python/tests/test_edata.py
@@ -15,7 +15,6 @@ def test_edata_sensi_unscaling(model_units_module):
     parameters1 = (2, 2)
 
     sx0 = (3, 3, 3, 3)
-    np_sx0 = np.array(sx0)
 
     parameter_scales_log10 = \
         [amici.ParameterScaling.log10.value]*len(parameters0)
@@ -30,19 +29,19 @@ def test_edata_sensi_unscaling(model_units_module):
     solver = model.getSolver()
     solver.setSensitivityOrder(amici.SensitivityOrder.first)
 
-    edata = amici.ExpData(model)
-    edata.pscale = amici_parameter_scales_log10
-    edata.parameters = parameters0
-    edata.sx0 = sx0
+    edata0 = amici.ExpData(model)
+    edata0.pscale = amici_parameter_scales_log10
+    edata0.parameters = parameters0
+    edata0.sx0 = sx0
 
-    edata2 = amici.ExpData(model)
-    edata2.pscale = amici_parameter_scales_log10
-    edata2.parameters = parameters1
-    edata2.sx0 = sx0
+    edata1 = amici.ExpData(model)
+    edata1.pscale = amici_parameter_scales_log10
+    edata1.parameters = parameters1
+    edata1.sx0 = sx0
 
-    rdata = amici.runAmiciSimulation(model, solver, edata)
-    rdata2 = amici.runAmiciSimulation(model, solver, edata2)
+    rdata0 = amici.runAmiciSimulation(model, solver, edata0)
+    rdata1 = amici.runAmiciSimulation(model, solver, edata1)
 
     # The initial state sensitivities are as specified.
-    assert (rdata.sx0.flatten() == np_sx0).all()
-    assert (rdata2.sx0.flatten() == np_sx0).all()
+    assert np.isclose(rdata0.sx0.flatten(), sx0).all()
+    assert np.isclose(rdata1.sx0.flatten(), sx0).all()

--- a/python/tests/test_sbml_import.py
+++ b/python/tests/test_sbml_import.py
@@ -182,7 +182,7 @@ def model_steadystate_module():
     shutil.rmtree(outdir, ignore_errors=True)
 
 
-@pytest.fixture
+@pytest.fixture(scope='session')
 def model_units_module():
     sbml_file = os.path.join(os.path.dirname(__file__), '..',
                              'examples', 'example_units',

--- a/python/tests/test_sbml_import.py
+++ b/python/tests/test_sbml_import.py
@@ -2,6 +2,7 @@
 import os
 import re
 import shutil
+from pathlib import Path
 from urllib.request import urlopen
 
 import libsbml
@@ -184,21 +185,18 @@ def model_steadystate_module():
 
 @pytest.fixture(scope='session')
 def model_units_module():
-    sbml_file = os.path.join(os.path.dirname(__file__), '..',
-                             'examples', 'example_units',
-                             'model_units.xml')
+    sbml_file = Path(__file__).parent / '..' / 'examples' \
+                / 'example_units' / 'model_units.xml'
+    module_name = 'test_model_units'
+
     sbml_importer = amici.SbmlImporter(sbml_file)
 
-    outdir = 'test_model_units'
-    module_name = 'test_model_units'
-    sbml_importer.sbml2amici(model_name=module_name,
-                             output_dir=outdir)
+    with TemporaryDirectory() as outdir:
+        sbml_importer.sbml2amici(model_name=module_name,
+                                 output_dir=outdir)
 
-    model_module = amici.import_model_module(module_name=module_name,
-                                             module_path=outdir)
-    yield model_module
-
-    shutil.rmtree(outdir, ignore_errors=True)
+        yield amici.import_model_module(module_name=module_name,
+                                        module_path=outdir)
 
 
 def test_presimulation(sbml_example_presimulation_module):

--- a/src/edata.cpp
+++ b/src/edata.cpp
@@ -380,6 +380,14 @@ void ConditionContext::applyCondition(const ExpData *edata,
         model_->setParameterScale(edata->pscale);
     }
 
+    if(!edata->parameters.empty()) {
+        if(edata->parameters.size() != (unsigned) model_->np())
+            throw AmiException("Number of parameters (%d) in model does not"
+                               " match ExpData (%zd).",
+                               model_->np(), edata->parameters.size());
+        model_->setParameters(edata->parameters);
+    }
+
     if(!edata->x0.empty()) {
         if(edata->x0.size() != (unsigned) model_->nx_rdata)
             throw AmiException("Number of initial conditions (%d) in model does"
@@ -395,14 +403,6 @@ void ConditionContext::applyCondition(const ExpData *edata,
                                model_->nx_rdata * model_->nplist(),
                                edata->sx0.size());
         model_->setInitialStateSensitivities(edata->sx0);
-    }
-
-    if(!edata->parameters.empty()) {
-        if(edata->parameters.size() != (unsigned) model_->np())
-            throw AmiException("Number of parameters (%d) in model does not"
-                               " match ExpData (%zd).",
-                               model_->np(), edata->parameters.size());
-        model_->setParameters(edata->parameters);
     }
 
     model_->setReinitializeFixedParameterInitialStates(

--- a/src/edata.cpp
+++ b/src/edata.cpp
@@ -380,6 +380,8 @@ void ConditionContext::applyCondition(const ExpData *edata,
         model_->setParameterScale(edata->pscale);
     }
 
+    // this needs to be set in the model before handling initial state
+    // sensitivities, which may be unscaled using model parameter values
     if(!edata->parameters.empty()) {
         if(edata->parameters.size() != (unsigned) model_->np())
             throw AmiException("Number of parameters (%d) in model does not"


### PR DESCRIPTION
When using `ExpData` to specify simulation settings, initial state sensitivities were set before parameters were set [1]. Setting initial state sensitivities involves unscaling scaled-sensitivities using parameters [2].

If the parameter scale is `log*`, but the parameter value in the model is `0`, then there will be a division by zero [2]. This is also incorrect, if sensitivities should be computed (and unscaled) with respect to parameters supplied with `ExpData`.

This PR just re-arranges how the settings are set, so that parameters from `ExpData` are set in the model before model parameters are used to unscale scaled-initial-state-sensitivities.

[1] https://github.com/AMICI-dev/AMICI/blob/477fd1bb037f03f1c22ec0da02309eaf93dae7cf/src/edata.cpp#L371-L409=
[2] https://github.com/AMICI-dev/AMICI/blob/8fe888416d009728b3bb34b833d7f9d392735ea1/src/model.cpp#L763-L784=