### PR TITLE
move sim_steps increment

### DIFF
--- a/src/steadystateproblem.cpp
+++ b/src/steadystateproblem.cpp
@@ -640,13 +640,6 @@ void SteadystateProblem::runSteadystateSimulation(const Solver &solver,
         convergence_check_frequency = 25;
         
     while (true) {
-        /* One step of ODE integration
-         reason for tout specification:
-         max with 1 ensures correct direction (any positive value would do)
-         multiplication with 10 ensures nonzero difference and should ensure
-         stable computation value is not important for AMICI_ONE_STEP mode,
-         only direction w.r.t. current t
-         */
         /* check for maxsteps  */
         if (sim_steps >= solver.getMaxSteps()) {
             throw NewtonFailure(AMICI_TOO_MUCH_WORK,
@@ -658,7 +651,14 @@ void SteadystateProblem::runSteadystateSimulation(const Solver &solver,
                                 " point without convergence of RHS");
         }        
         /* increase counter */
-        sim_steps++; 
+        sim_steps++;         
+        /* One step of ODE integration
+         reason for tout specification:
+         max with 1 ensures correct direction (any positive value would do)
+         multiplication with 10 ensures nonzero difference and should ensure
+         stable computation value is not important for AMICI_ONE_STEP mode,
+         only direction w.r.t. current t
+         */
         solver.step(std::max(state_.t, 1.0) * 10);
        
         if (backward) {

--- a/src/steadystateproblem.cpp
+++ b/src/steadystateproblem.cpp
@@ -647,7 +647,10 @@ void SteadystateProblem::runSteadystateSimulation(const Solver &solver,
          stable computation value is not important for AMICI_ONE_STEP mode,
          only direction w.r.t. current t
          */
+        /* increase counter */
+        sim_steps++; 
         solver.step(std::max(state_.t, 1.0) * 10);
+       
         if (backward) {
             solver.writeSolution(&state_.t, xB_, state_.dx, state_.sx, xQ_);
         } else {
@@ -670,8 +673,7 @@ void SteadystateProblem::runSteadystateSimulation(const Solver &solver,
 
         if (wrms_ < conv_thresh)
             break; // converged
-        /* increase counter, check for maxsteps */
-        sim_steps++;
+        /* check for maxsteps  */
         if (sim_steps >= solver.getMaxSteps()) {
             throw NewtonFailure(AMICI_TOO_MUCH_WORK,
                                 "exceeded maximum number of steps");

--- a/src/steadystateproblem.cpp
+++ b/src/steadystateproblem.cpp
@@ -647,6 +647,16 @@ void SteadystateProblem::runSteadystateSimulation(const Solver &solver,
          stable computation value is not important for AMICI_ONE_STEP mode,
          only direction w.r.t. current t
          */
+        /* check for maxsteps  */
+        if (sim_steps >= solver.getMaxSteps()) {
+            throw NewtonFailure(AMICI_TOO_MUCH_WORK,
+                                "exceeded maximum number of steps");
+        }
+        if (state_.t >= 1e200) {
+            throw NewtonFailure(AMICI_NO_STEADY_STATE,
+                                "simulated to late time"
+                                " point without convergence of RHS");
+        }        
         /* increase counter */
         sim_steps++; 
         solver.step(std::max(state_.t, 1.0) * 10);
@@ -673,16 +683,6 @@ void SteadystateProblem::runSteadystateSimulation(const Solver &solver,
 
         if (wrms_ < conv_thresh)
             break; // converged
-        /* check for maxsteps  */
-        if (sim_steps >= solver.getMaxSteps()) {
-            throw NewtonFailure(AMICI_TOO_MUCH_WORK,
-                                "exceeded maximum number of steps");
-        }
-        if (state_.t >= 1e200) {
-            throw NewtonFailure(AMICI_NO_STEADY_STATE,
-                                "simulated to late time"
-                                " point without convergence of RHS");
-        }
     }
     
     // if check_sensi_conv_ is deactivated, we still have to update sensis


### PR DESCRIPTION
moved `sim_steps` increment to the beginning of the while loop, as otherwise if the simulation is successful on the first step resulting `sim_steps = 0`. 

moved also the max steps check and the large time point check, as otherwise one step is made even if maxSteps is set to zero