### PR TITLE
Remove `constant_species_to_parameters`

### DIFF
--- a/python/amici/petab_import.py
+++ b/python/amici/petab_import.py
@@ -75,7 +75,7 @@ def _add_global_parameter(sbml_model: libsbml.Model,
 def get_fixed_parameters(
         sbml_model: 'libsbml.Model',
         condition_df: Optional[pd.DataFrame] = None,
-        const_species_to_parameters: bool = False) -> List[str]:
+) -> List[str]:
     """
     Determine, set and return fixed model parameters.
 
@@ -88,11 +88,6 @@ def get_fixed_parameters(
 
     :param sbml_model:
         libsbml.Model instance
-
-    :param const_species_to_parameters:
-        If `True`, species which are marked constant within the SBML model
-        will be turned into constant parameters *within* the given
-        `sbml_model`.
 
     :return:
         List of IDs of parameters which are to be considered constant.
@@ -126,22 +121,6 @@ def get_fixed_parameters(
                 'len(fixed_parameters) != len(set(fixed_parameters))')
     else:
         fixed_parameters = []
-
-    # Others are optional
-    if const_species_to_parameters:
-        # Turn species which are marked constant in the SBML model into
-        # parameters
-        constant_species = constant_species_to_parameters(sbml_model)
-
-        logger.debug("Constant species converted to parameters: "
-                     + str(len(constant_species)))
-        logger.info("Non-constant species "
-                    + str(len(sbml_model.getListOfSpecies())))
-
-        # ... and append them to the list of fixed_parameters
-        for species in constant_species:
-            if species not in fixed_parameters:
-                fixed_parameters.append(species)
 
     # Ensure mentioned parameters exist in the model. Remove additional ones
     # from list
@@ -235,30 +214,6 @@ def species_to_parameters(species_ids: List[str],
                 pass
 
     return transformables
-
-
-def constant_species_to_parameters(sbml_model: 'libsbml.Model') -> List[str]:
-    """
-    Convert constant species in the SBML model to constant parameters.
-
-    This can be used e.g. for setting up models with condition-specific
-    constant species for PEtab, since there it is not possible to specify
-    constant species in the condition table.
-
-    :param sbml_model:
-        SBML Model
-
-    :return:
-        List of IDs of SBML species that have been turned into constants
-    """
-    transformables = []
-    for species in sbml_model.getListOfSpecies():
-        if not species.getConstant() and not species.getBoundaryCondition():
-            continue
-
-        transformables.append(species.getId())
-
-    return species_to_parameters(transformables, sbml_model)
 
 
 def import_petab_problem(

--- a/python/tests/test_petab_import.py
+++ b/python/tests/test_petab_import.py
@@ -38,19 +38,3 @@ def simple_sbml_model():
         species_ref.setSpecies(name)
 
     return document, model
-
-
-def test_constant_species_to_parameters(simple_sbml_model):
-    """Test conversion from species to constant parameters"""
-
-    document, model = simple_sbml_model
-
-    amici_petab_import.constant_species_to_parameters(model)
-
-    assert len(list(model.getListOfParameters())) == 1
-    assert len(list(model.getListOfSpecies())) == 0
-
-    r = model.getReaction(0)
-    assert len(list(r.getListOfReactants())) == 0
-    assert len(list(r.getListOfProducts())) == 0
-    assert len(list(r.getListOfModifiers())) == 0


### PR DESCRIPTION
This functionality wasn't really accessible for PEtab import, was probably never really used, and is not relevant anymore, since constant species can be handled by the conservation law machinery.