### PR TITLE
Fix missing CPU time reset

### DIFF
--- a/src/amici.cpp
+++ b/src/amici.cpp
@@ -238,6 +238,14 @@ AmiciApplication::runAmiciSimulation(Solver& solver,
     rdata->cpu_time_total = static_cast<double>(clock() - start_time_total)
                             * 1000.0 / CLOCKS_PER_SEC;
 
+    // verify that reported CPU times are plausible
+    gsl_EnsuresDebug(rdata->cpu_time <= rdata->cpu_time_total);
+    gsl_EnsuresDebug(rdata->cpu_timeB <= rdata->cpu_time_total);
+    gsl_EnsuresDebug(rdata->preeq_cpu_time <= rdata->cpu_time_total);
+    gsl_EnsuresDebug(rdata->preeq_cpu_timeB <= rdata->cpu_time_total);
+    gsl_EnsuresDebug(rdata->posteq_cpu_time <= rdata->cpu_time_total);
+    gsl_EnsuresDebug(rdata->posteq_cpu_timeB <= rdata->cpu_time_total);
+
     return rdata;
 }
 

--- a/src/solver.cpp
+++ b/src/solver.cpp
@@ -172,6 +172,8 @@ void Solver::setup(const realtype t0, Model *model, const AmiVector &x0,
     /* calculate consistent DAE initial conditions (no effect for ODE) */
     if (model->nt() > 1)
         calcIC(model->getTimepoint(1));
+
+    cpu_time_ = 0.0;
 }
 
 void Solver::setupB(int *which, const realtype tf, Model *model,
@@ -203,6 +205,8 @@ void Solver::setupB(int *which, const realtype tf, Model *model,
     applyQuadTolerancesASA(*which);
 
     setStabLimDetB(*which, stldet_);
+
+    cpu_timeB_ = 0.0;
 }
 
 void Solver::setupSteadystate(const realtype t0, Model *model, const AmiVector &x0,


### PR DESCRIPTION
Fixes incorrect CPU times reported if a Solver instance is used for multiple simulations. (So far, the cumulative CPU time would have been reported).

Fixes #1812