### PR TITLE
Check for unused parameters in simulate_petab

### DIFF
--- a/python/amici/parameter_mapping.py
+++ b/python/amici/parameter_mapping.py
@@ -16,8 +16,10 @@ the mapping is automatized.
 
 
 import numbers
-from typing import Any, Dict, List, Union
+import warnings
+from typing import Any, Dict, List, Union, Set
 from collections.abc import Sequence
+from itertools import chain
 
 import amici
 import numpy as np
@@ -100,6 +102,18 @@ class ParameterMappingForCondition:
                 f"map_sim_fix={repr(self.map_sim_fix)},"
                 f"scale_map_sim_fix={repr(self.scale_map_sim_fix)})")
 
+    @property
+    def free_symbols(self) -> Set[str]:
+        """Get IDs of all (symbolic) parameters present in this mapping"""
+        return {
+            p for p in chain(
+                self.map_sim_var.values(),
+                self.map_preeq_fix.values(),
+                self.map_sim_fix.values()
+            )
+            if isinstance(p, str)
+        }
+
 
 class ParameterMapping(Sequence):
     r"""Parameter mapping for multiple conditions.
@@ -130,12 +144,18 @@ class ParameterMapping(Sequence):
 
     def append(
             self,
-            parameter_mapping_for_condition: ParameterMappingForCondition):
+            parameter_mapping_for_condition: ParameterMappingForCondition
+    ):
         """Append a condition specific parameter mapping."""
         self.parameter_mappings.append(parameter_mapping_for_condition)
 
     def __repr__(self):
         return f"{self.__class__.__name__}({repr(self.parameter_mappings)})"
+
+    @property
+    def free_symbols(self) -> Set[str]:
+        """Get IDs of all (symbolic) parameters present in this mapping"""
+        return set.union(*(mapping.free_symbols for mapping in self))
 
 
 def fill_in_parameters(
@@ -143,7 +163,8 @@ def fill_in_parameters(
         problem_parameters: Dict[str, numbers.Number],
         scaled_parameters: bool,
         parameter_mapping: ParameterMapping,
-        amici_model: AmiciModel) -> None:
+        amici_model: AmiciModel
+) -> None:
     """Fill fixed and dynamic parameters into the edatas (in-place).
 
     :param edatas:
@@ -162,6 +183,11 @@ def fill_in_parameters(
     :param amici_model:
         AMICI model.
     """
+    if unused_parameters := (set(problem_parameters.keys())
+                             - parameter_mapping.free_symbols):
+        warnings.warn("The following problem parameters were not used: "
+                      + str(unused_parameters), RuntimeWarning)
+
     for edata, mapping_for_condition in zip(edatas, parameter_mapping):
         fill_in_parameters_for_condition(
             edata, problem_parameters, scaled_parameters,

--- a/python/tests/util.py
+++ b/python/tests/util.py
@@ -129,8 +129,7 @@ def check_trajectories_without_sensitivities(
 
     # Does the AMICI simulation match the analytical solution?
     solver = amici_model.getSolver()
-    solver.setAbsoluteTolerance(1e-16)
-    solver.setRelativeTolerance(1e-9)
+    solver.setAbsoluteTolerance(1e-15)
     rdata = runAmiciSimulation(amici_model, solver=solver)
     np.testing.assert_almost_equal(rdata['x'], result_expected_x, decimal=5)
 

--- a/python/tests/util.py
+++ b/python/tests/util.py
@@ -13,13 +13,6 @@ from amici import (
 )
 
 
-def assert_almost_equal(*args, **kwargs):
-    """Wrapper around numpy.testing.assert_almost_equal to print the complete
-    arrays without truncation."""
-    with np.printoptions(threshold=np.inf):
-        np.testing.assert_almost_equal(*args, **kwargs)
-
-
 def create_amici_model(sbml_model, model_name) -> AmiciModel:
     """
     Import an sbml file and create an AMICI model from it
@@ -139,14 +132,14 @@ def check_trajectories_without_sensitivities(
     solver.setAbsoluteTolerance(1e-16)
     solver.setRelativeTolerance(1e-9)
     rdata = runAmiciSimulation(amici_model, solver=solver)
-    assert_almost_equal(rdata['x'], result_expected_x, decimal=5)
+    np.testing.assert_almost_equal(rdata['x'], result_expected_x, decimal=5)
 
     # Show that we can do arbitrary precision here (test 8 digits)
     solver = amici_model.getSolver()
     solver.setAbsoluteTolerance(1e-15)
     solver.setRelativeTolerance(1e-12)
     rdata = runAmiciSimulation(amici_model, solver=solver)
-    assert_almost_equal(rdata['x'], result_expected_x, decimal=8)
+    np.testing.assert_almost_equal(rdata['x'], result_expected_x, decimal=8)
 
 
 def check_trajectories_with_forward_sensitivities(
@@ -165,8 +158,8 @@ def check_trajectories_with_forward_sensitivities(
     solver.setSensitivityOrder(SensitivityOrder.first)
     solver.setSensitivityMethod(SensitivityMethod.forward)
     rdata = runAmiciSimulation(amici_model, solver=solver)
-    assert_almost_equal(rdata['x'], result_expected_x, decimal=5)
-    assert_almost_equal(rdata['sx'], result_expected_sx, decimal=5)
+    np.testing.assert_almost_equal(rdata['x'], result_expected_x, decimal=5)
+    np.testing.assert_almost_equal(rdata['sx'], result_expected_sx, decimal=5)
 
     # Show that we can do arbitrary precision here (test 8 digits)
     solver = amici_model.getSolver()
@@ -177,5 +170,5 @@ def check_trajectories_with_forward_sensitivities(
     solver.setAbsoluteToleranceFSA(1e-15)
     solver.setRelativeToleranceFSA(1e-13)
     rdata = runAmiciSimulation(amici_model, solver=solver)
-    assert_almost_equal(rdata['x'], result_expected_x, decimal=8)
-    assert_almost_equal(rdata['sx'], result_expected_sx, decimal=8)
+    np.testing.assert_almost_equal(rdata['x'], result_expected_x, decimal=8)
+    np.testing.assert_almost_equal(rdata['sx'], result_expected_sx, decimal=8)

--- a/python/tests/util.py
+++ b/python/tests/util.py
@@ -136,7 +136,8 @@ def check_trajectories_without_sensitivities(
 
     # Does the AMICI simulation match the analytical solution?
     solver = amici_model.getSolver()
-    solver.setAbsoluteTolerance(1e-15)
+    solver.setAbsoluteTolerance(1e-16)
+    solver.setRelativeTolerance(1e-9)
     rdata = runAmiciSimulation(amici_model, solver=solver)
     assert_almost_equal(rdata['x'], result_expected_x, decimal=5)
 

--- a/python/tests/util.py
+++ b/python/tests/util.py
@@ -13,6 +13,13 @@ from amici import (
 )
 
 
+def assert_almost_equal(*args, **kwargs):
+    """Wrapper around numpy.testing.assert_almost_equal to print the complete
+    arrays without truncation."""
+    with np.printoptions(threshold=np.inf):
+        np.testing.assert_almost_equal(*args, **kwargs)
+
+
 def create_amici_model(sbml_model, model_name) -> AmiciModel:
     """
     Import an sbml file and create an AMICI model from it
@@ -131,14 +138,14 @@ def check_trajectories_without_sensitivities(
     solver = amici_model.getSolver()
     solver.setAbsoluteTolerance(1e-15)
     rdata = runAmiciSimulation(amici_model, solver=solver)
-    np.testing.assert_almost_equal(rdata['x'], result_expected_x, decimal=5)
+    assert_almost_equal(rdata['x'], result_expected_x, decimal=5)
 
     # Show that we can do arbitrary precision here (test 8 digits)
     solver = amici_model.getSolver()
     solver.setAbsoluteTolerance(1e-15)
     solver.setRelativeTolerance(1e-12)
     rdata = runAmiciSimulation(amici_model, solver=solver)
-    np.testing.assert_almost_equal(rdata['x'], result_expected_x, decimal=8)
+    assert_almost_equal(rdata['x'], result_expected_x, decimal=8)
 
 
 def check_trajectories_with_forward_sensitivities(
@@ -157,8 +164,8 @@ def check_trajectories_with_forward_sensitivities(
     solver.setSensitivityOrder(SensitivityOrder.first)
     solver.setSensitivityMethod(SensitivityMethod.forward)
     rdata = runAmiciSimulation(amici_model, solver=solver)
-    np.testing.assert_almost_equal(rdata['x'], result_expected_x, decimal=5)
-    np.testing.assert_almost_equal(rdata['sx'], result_expected_sx, decimal=5)
+    assert_almost_equal(rdata['x'], result_expected_x, decimal=5)
+    assert_almost_equal(rdata['sx'], result_expected_sx, decimal=5)
 
     # Show that we can do arbitrary precision here (test 8 digits)
     solver = amici_model.getSolver()
@@ -169,5 +176,5 @@ def check_trajectories_with_forward_sensitivities(
     solver.setAbsoluteToleranceFSA(1e-15)
     solver.setRelativeToleranceFSA(1e-13)
     rdata = runAmiciSimulation(amici_model, solver=solver)
-    np.testing.assert_almost_equal(rdata['x'], result_expected_x, decimal=8)
-    np.testing.assert_almost_equal(rdata['sx'], result_expected_sx, decimal=8)
+    assert_almost_equal(rdata['x'], result_expected_x, decimal=8)
+    assert_almost_equal(rdata['sx'], result_expected_sx, decimal=8)


### PR DESCRIPTION
Raise a warning if parameters have been passed that do not occur in the parameter mapping and wouldn't be used anywhere.