### PR TITLE
Fix `ParameterMapping.__getitem__`

### DIFF
--- a/python/amici/parameter_mapping.py
+++ b/python/amici/parameter_mapping.py
@@ -13,7 +13,7 @@ While the parameter mapping can be used directly with AMICI, it was developed
 for usage together with PEtab, for which the whole workflow of generating
 the mapping is automatized.
 """
-
+from __future__ import annotations
 
 import numbers
 import warnings
@@ -136,8 +136,8 @@ class ParameterMapping(Sequence):
     def __iter__(self):
         yield from self.parameter_mappings
 
-    def __getitem__(self, item):
-        return self.parameter_mappings[item]
+    def __getitem__(self, item) -> ParameterMapping:
+        return ParameterMapping(self.parameter_mappings[item])
 
     def __len__(self):
         return len(self.parameter_mappings)

--- a/python/amici/parameter_mapping.py
+++ b/python/amici/parameter_mapping.py
@@ -137,7 +137,10 @@ class ParameterMapping(Sequence):
         yield from self.parameter_mappings
 
     def __getitem__(self, item) -> ParameterMapping:
-        return ParameterMapping(self.parameter_mappings[item])
+        result = self.parameter_mappings[item]
+        if isinstance(result, ParameterMappingForCondition):
+            return result
+        return ParameterMapping(result)
 
     def __len__(self):
         return len(self.parameter_mappings)

--- a/python/amici/parameter_mapping.py
+++ b/python/amici/parameter_mapping.py
@@ -136,7 +136,9 @@ class ParameterMapping(Sequence):
     def __iter__(self):
         yield from self.parameter_mappings
 
-    def __getitem__(self, item) -> ParameterMapping:
+    def __getitem__(
+            self, item
+    ) -> Union[ParameterMapping, ParameterMappingForCondition]:
         result = self.parameter_mappings[item]
         if isinstance(result, ParameterMappingForCondition):
             return result

--- a/python/tests/test_parameter_mapping.py
+++ b/python/tests/test_parameter_mapping.py
@@ -55,3 +55,6 @@ def test_parameter_mapping():
     parameter_mapping.append(par_map_for_condition)
 
     assert len(parameter_mapping) == 1
+
+    assert isinstance(parameter_mapping[0], ParameterMappingForCondition)
+    assert isinstance(parameter_mapping[:], ParameterMapping)


### PR DESCRIPTION
`ParameterMapping.__getitem__` should either return a `ParameterMappingForCondition` or a new `ParameterMapping`, but not a list.