### PR TITLE
Show model path in version incompatibility warnings

### DIFF
--- a/python/amici/__init__.template.py
+++ b/python/amici/__init__.template.py
@@ -1,12 +1,14 @@
 """AMICI-generated module for model TPL_MODELNAME"""
 
 import amici
+from pathlib import Path
 
 # Ensure we are binary-compatible, see #556
 if 'TPL_AMICI_VERSION' != amici.__version__:
     raise amici.AmiciVersionError(
-        'Cannot use model `TPL_MODELNAME`, generated with amici=='
-        f'TPL_AMICI_VERSION, together with amici=={amici.__version__} '
+        f'Cannot use model `TPL_MODELNAME` in {Path(__file__).parent}, '
+        'generated with amici==TPL_AMICI_VERSION, '
+        f'together with amici=={amici.__version__} '
         'which is currently installed. To use this model, install '
         'amici==TPL_AMICI_VERSION or re-import the model with the amici '
         'version currently installed.'


### PR DESCRIPTION
Makes it easier to find and delete the problematic model.