### PR TITLE
Checked narrowing casts

### DIFF
--- a/include/amici/forwardproblem.h
+++ b/include/amici/forwardproblem.h
@@ -221,7 +221,7 @@ class ForwardProblem {
      * @return index
      */
     int getEventCounter() const {
-        return static_cast<int>(event_states_.size() - 1);
+        return gsl::narrow<int>(event_states_.size()) - 1;
     }
 
     /**
@@ -229,7 +229,7 @@ class ForwardProblem {
      * @return index
      */
     int getRootCounter() const {
-        return static_cast<int>(discs_.size() - 1);
+        return gsl::narrow<int>(discs_.size()) - 1;
     }
 
     /**

--- a/include/amici/model.h
+++ b/include/amici/model.h
@@ -717,15 +717,15 @@ class Model : public AbstractModel, public ModelDimensions {
      * @param state Model state
      */
     void setModelState(ModelState const &state) {
-        if (static_cast<int>(state.unscaledParameters.size()) != np())
+        if (gsl::narrow<int>(state.unscaledParameters.size()) != np())
             throw AmiException("Mismatch in parameter size");
-        if (static_cast<int>(state.fixedParameters.size()) != nk())
+        if (gsl::narrow<int>(state.fixedParameters.size()) != nk())
             throw AmiException("Mismatch in fixed parameter size");
-        if (static_cast<int>(state.h.size()) != ne)
+        if (gsl::narrow<int>(state.h.size()) != ne)
             throw AmiException("Mismatch in Heaviside size");
-        if (static_cast<int>(state.total_cl.size()) != ncl())
+        if (gsl::narrow<int>(state.total_cl.size()) != ncl())
             throw AmiException("Mismatch in conservation law size");
-        if (static_cast<int>(state.stotal_cl.size()) != ncl() * np() )
+        if (gsl::narrow<int>(state.stotal_cl.size()) != ncl() * np() )
             throw AmiException("Mismatch in conservation law sensitivity size");
         state_ = state;
     };

--- a/include/amici/sundials_matrix_wrapper.h
+++ b/include/amici/sundials_matrix_wrapper.h
@@ -259,7 +259,7 @@ class SUNMatrixWrapper {
     void set_indexvals(const gsl::span<const sunindextype> vals) {
         assert(matrix_);
         assert(matrix_id() == SUNMATRIX_SPARSE);
-        assert(static_cast<sunindextype>(vals.size()) == capacity());
+        assert(gsl::narrow<sunindextype>(vals.size()) == capacity());
         assert(indexvals_ == SM_INDEXVALS_S(matrix_));
         std::copy_n(vals.begin(), capacity(), indexvals_);
     }
@@ -300,7 +300,7 @@ class SUNMatrixWrapper {
     void set_indexptrs(const gsl::span<const sunindextype> ptrs) {
         assert(matrix_);
         assert(matrix_id() == SUNMATRIX_SPARSE);
-        assert(static_cast<sunindextype>(ptrs.size()) == num_indexptrs() + 1);
+        assert(gsl::narrow<sunindextype>(ptrs.size()) == num_indexptrs() + 1);
         assert(indexptrs_ == SM_INDEXPTRS_S(matrix_));
         std::copy_n(ptrs.begin(), num_indexptrs() + 1, indexptrs_);
         num_nonzeros_ = indexptrs_[num_indexptrs()];

--- a/include/amici/vector.h
+++ b/include/amici/vector.h
@@ -47,7 +47,7 @@ class AmiVector {
      */
     explicit AmiVector(std::vector<realtype> rvec)
         : vec_(std::move(rvec)),
-          nvec_(N_VMake_Serial(static_cast<long int>(vec_.size()), vec_.data())) {}
+          nvec_(N_VMake_Serial(gsl::narrow<long int>(vec_.size()), vec_.data())) {}
 
     /** Copy data from gsl::span and constructs a vector
      * @brief constructor from gsl::span,
@@ -62,7 +62,7 @@ class AmiVector {
      */
     AmiVector(const AmiVector &vold) : vec_(vold.vec_) {
         nvec_ =
-            N_VMake_Serial(static_cast<long int>(vold.vec_.size()), vec_.data());
+            N_VMake_Serial(gsl::narrow<long int>(vold.vec_.size()), vec_.data());
     }
 
     /**

--- a/python/sdist/setup_clibs.py
+++ b/python/sdist/setup_clibs.py
@@ -281,7 +281,10 @@ def get_lib_amici(
         'cflags_mingw32': ['-std=c++14'],
         'cflags_unix': ['-std=c++14'],
         'cflags_msvc': ['/std:c++14'],
-        'macros': [("gsl_CONFIG_CONTRACT_VIOLATION_THROWS", None)],
+        'macros': [
+            ("gsl_CONFIG_CONTRACT_VIOLATION_THROWS", None),
+            ("gsl_CONFIG_NARROW_THROWS_ON_TRUNCATION", 1),
+        ],
     })
 
     if h5pkgcfg and 'include_dirs' in h5pkgcfg:

--- a/src/edata.cpp
+++ b/src/edata.cpp
@@ -115,7 +115,7 @@ std::vector<realtype> const& ExpData::getTimepoints() const {
 }
 
 int ExpData::nt() const {
-    return static_cast<int>(ts_.size());
+    return gsl::narrow<int>(ts_.size());
 }
 
 realtype ExpData::getTimepoint(int it) const {

--- a/src/forwardproblem.cpp
+++ b/src/forwardproblem.cpp
@@ -19,9 +19,9 @@ ForwardProblem::ForwardProblem(const ExpData *edata, Model *model,
     : model(model),
       solver(solver),
       edata(edata),
-      nroots_(static_cast<decltype (nroots_)::size_type>(model->ne), 0),
-      rootvals_(static_cast<decltype (rootvals_)::size_type>(model->ne), 0.0),
-      rval_tmp_(static_cast<decltype (rval_tmp_)::size_type>(model->ne), 0.0),
+      nroots_(gsl::narrow<decltype (nroots_)::size_type>(model->ne), 0),
+      rootvals_(gsl::narrow<decltype (rootvals_)::size_type>(model->ne), 0.0),
+      rval_tmp_(gsl::narrow<decltype (rval_tmp_)::size_type>(model->ne), 0.0),
       dJydx_(model->nJ * model->nx_solver * model->nt(), 0.0),
       dJzdx_(model->nJ * model->nx_solver * model->nMaxEvent(), 0.0),
       t_(model->t0()),
@@ -63,7 +63,7 @@ void ForwardProblem::workForwardProblem() {
     if (presimulate)
         t0 -= edata->t_presim;
     solver->setup(t0, model, x_, dx_, sx_, sdx_);
-    
+
     if (model->ne && std::any_of(roots_found_.begin(), roots_found_.end(),
                                  [](int rf){return rf==1;}))
         handleEvent(&t0, false, true);
@@ -82,7 +82,7 @@ void ForwardProblem::workForwardProblem() {
                 handleEvent(&t0, false, true);
         }
     }
-    
+
     /* when computing adjoint sensitivity analysis with presimulation,
      we need to store sx after the reinitialization after preequilibration
      but before reinitialization after presimulation. As presimulation with ASA

--- a/src/hdf5.cpp
+++ b/src/hdf5.cpp
@@ -685,11 +685,11 @@ void writeSolverSettingsToHDF5(Solver const& solver,
     H5LTset_attribute_double(file.getId(), hdf5Location.c_str(),
                              "maxtime", &dbuffer, 1);
 
-    ibuffer = static_cast<int>(solver.getMaxSteps());
+    ibuffer = gsl::narrow<int>(solver.getMaxSteps());
     H5LTset_attribute_int(file.getId(), hdf5Location.c_str(),
                           "maxsteps", &ibuffer, 1);
 
-    ibuffer = static_cast<int>(solver.getMaxStepsBackwardProblem());
+    ibuffer = gsl::narrow<int>(solver.getMaxStepsBackwardProblem());
     H5LTset_attribute_int(file.getId(), hdf5Location.c_str(),
                           "maxstepsB", &ibuffer, 1);
 
@@ -725,7 +725,7 @@ void writeSolverSettingsToHDF5(Solver const& solver,
     H5LTset_attribute_int(file.getId(), hdf5Location.c_str(),
                           "sensi", &ibuffer, 1);
 
-    ibuffer = static_cast<int>(solver.getNewtonMaxSteps());
+    ibuffer = gsl::narrow<int>(solver.getNewtonMaxSteps());
     H5LTset_attribute_int(file.getId(), hdf5Location.c_str(),
                           "newton_maxsteps", &ibuffer, 1);
 
@@ -748,11 +748,11 @@ void writeSolverSettingsToHDF5(Solver const& solver,
     ibuffer = static_cast<int>(solver.getReturnDataReportingMode());
     H5LTset_attribute_int(file.getId(), hdf5Location.c_str(),
                           "rdrm", &ibuffer, 1);
-    
+
     ibuffer = static_cast<int>(solver.getNewtonStepSteadyStateCheck());
     H5LTset_attribute_int(file.getId(), hdf5Location.c_str(),
                           "newton_step_steadystate_conv", &ibuffer, 1);
-    
+
     ibuffer = static_cast<int>(solver.getSensiSteadyStateCheck());
     H5LTset_attribute_int(file.getId(), hdf5Location.c_str(),
                           "check_sensi_steadystate_conv", &ibuffer, 1);
@@ -928,12 +928,12 @@ void readSolverSettingsFromHDF5(H5::H5File const& file, Solver &solver,
                     static_cast<RDataReporting>(
                         getIntScalarAttribute(file, datasetPath, "rdrm")));
     }
-    
+
     if(attributeExists(file, datasetPath, "newton_step_steadystate_conv")) {
         solver.setNewtonStepSteadyStateCheck(
                     getIntScalarAttribute(file, datasetPath, "newton_step_steadystate_conv"));
     }
-    
+
     if(attributeExists(file, datasetPath, "check_sensi_steadystate_conv")) {
         solver.setSensiSteadyStateCheck(
                     getIntScalarAttribute(file, datasetPath, "check_sensi_steadystate_conv"));

--- a/src/model.cpp
+++ b/src/model.cpp
@@ -164,8 +164,8 @@ Model::Model(ModelDimensions const & model_dimensions,
       state_is_non_negative_(nx_solver, false),
       w_recursion_depth_(w_recursion_depth),
       simulation_parameters_(std::move(simulation_parameters)) {
-    Expects(model_dimensions.np == static_cast<int>(simulation_parameters_.parameters.size()));
-    Expects(model_dimensions.nk == static_cast<int>(simulation_parameters_.fixedParameters.size()));
+    Expects(model_dimensions.np == gsl::narrow<int>(simulation_parameters_.parameters.size()));
+    Expects(model_dimensions.nk == gsl::narrow<int>(simulation_parameters_.fixedParameters.size()));
 
     simulation_parameters.pscale = std::vector<ParameterScaling>(model_dimensions.np, ParameterScaling::none);
 
@@ -198,9 +198,9 @@ Model::Model(ModelDimensions const & model_dimensions,
             dwdx_hierarchical_.emplace_back(
                 SUNMatrixWrapper(nw, nx_solver, irec * ndwdw + ndwdx, CSC_MAT));
         }
-        assert(static_cast<int>(dwdp_hierarchical_.size()) ==
+        assert(gsl::narrow<int>(dwdp_hierarchical_.size()) ==
                w_recursion_depth_ + 1);
-        assert(static_cast<int>(dwdx_hierarchical_.size()) ==
+        assert(gsl::narrow<int>(dwdx_hierarchical_.size()) ==
                w_recursion_depth_ + 1);
 
         derived_state_.dxdotdp_explicit = SUNMatrixWrapper(
@@ -341,11 +341,11 @@ void Model::initEvents(AmiVector const &x, AmiVector const &dx,
     }
 }
 
-int Model::nplist() const { return static_cast<int>(state_.plist.size()); }
+int Model::nplist() const { return gsl::narrow<int>(state_.plist.size()); }
 
-int Model::np() const { return static_cast<int>(static_cast<ModelDimensions const&>(*this).np); }
+int Model::np() const { return gsl::narrow<int>(static_cast<ModelDimensions const&>(*this).np); }
 
-int Model::nk() const { return static_cast<int>(state_.fixedParameters.size()); }
+int Model::nk() const { return gsl::narrow<int>(state_.fixedParameters.size()); }
 
 int Model::ncl() const { return nx_rdata - nx_solver; }
 
@@ -357,7 +357,7 @@ int Model::nMaxEvent() const { return nmaxevent_; }
 
 void Model::setNMaxEvent(int nmaxevent) { nmaxevent_ = nmaxevent; }
 
-int Model::nt() const { return static_cast<int>(simulation_parameters_.ts_.size()); }
+int Model::nt() const { return gsl::narrow<int>(simulation_parameters_.ts_.size()); }
 
 const std::vector<ParameterScaling> &Model::getParameterScale() const {
     return simulation_parameters_.pscale;
@@ -691,7 +691,7 @@ void Model::setStateIsNonNegative(std::vector<bool> const &nonNegative) {
         // in case of conservation laws
         return;
     }
-    if (state_is_non_negative_.size() != static_cast<unsigned long>(nx_rdata)) {
+    if (state_is_non_negative_.size() != gsl::narrow<unsigned long>(nx_rdata)) {
         throw AmiException("Dimension of input stateIsNonNegative (%u) does "
                            "not agree with number of state variables (%d)",
                            state_is_non_negative_.size(), nx_rdata);
@@ -1359,7 +1359,7 @@ int Model::checkFinite(gsl::span<const realtype> array,
                   "AMICI encountered a %s value for %s[%i] (%s)",
                   non_finite_type.c_str(),
                   model_quantity_str.c_str(),
-                  static_cast<int>(flat_index),
+                  gsl::narrow<int>(flat_index),
                   element_id.c_str()
                   );
 
@@ -1470,7 +1470,7 @@ int Model::checkFinite(gsl::span<const realtype> array,
                   "AMICI encountered a %s value for %s[%i] (%s, %s)",
                   non_finite_type.c_str(),
                   model_quantity_str.c_str(),
-                  static_cast<int>(flat_index),
+                  gsl::narrow<int>(flat_index),
                   row_id.c_str(),
                   col_id.c_str()
                   );
@@ -1559,7 +1559,7 @@ int Model::checkFinite(SUNMatrix m, ModelQuantity model_quantity, realtype t) co
                   "AMICI encountered a %s value for %s[%i] (%s, %s) at t=%g",
                   non_finite_type.c_str(),
                   model_quantity_str.c_str(),
-                  static_cast<int>(flat_index),
+                  gsl::narrow<int>(flat_index),
                   row_id.c_str(),
                   col_id.c_str(),
                   t
@@ -1724,11 +1724,11 @@ void Model::writeLLHSensitivitySlice(const std::vector<realtype> &dLLhdp,
 
 void Model::checkLLHBufferSize(std::vector<realtype> const &sllh,
                                std::vector<realtype> const &s2llh) const {
-    if (sllh.size() != static_cast<unsigned>(nplist()))
+    if (sllh.size() != gsl::narrow<unsigned>(nplist()))
         throw AmiException("Incorrect sllh buffer size! Was %u, expected %i.",
                            sllh.size(), nplist());
 
-    if (s2llh.size() != static_cast<unsigned>((nJ - 1) * nplist()))
+    if (s2llh.size() != gsl::narrow<unsigned>((nJ - 1) * nplist()))
         throw AmiException("Incorrect s2llh buffer size! Was %u, expected %i.",
                            s2llh.size(), (nJ - 1) * nplist());
 }

--- a/src/rdata.cpp
+++ b/src/rdata.cpp
@@ -661,7 +661,7 @@ void ReturnData::applyChainRuleFactorToSimulationResults(const Model &model) {
 
 
         if (!sres.empty())
-            for (int ires = 0; ires < static_cast<int>(res.size()); ++ires)
+            for (int ires = 0; ires < gsl::narrow<int>(res.size()); ++ires)
                 for (int ip = 0; ip < nplist; ++ip)
                     sres.at((ires * nplist + ip)) *= pcoefficient.at(ip);
 

--- a/src/solver.cpp
+++ b/src/solver.cpp
@@ -266,16 +266,16 @@ void Solver::storeDiagnosis() const {
 
     long int lnumber;
     getNumSteps(solver_memory_.get(), &lnumber);
-    ns_.push_back(static_cast<int>(lnumber));
+    ns_.push_back(gsl::narrow<int>(lnumber));
 
     getNumRhsEvals(solver_memory_.get(), &lnumber);
-    nrhs_.push_back(static_cast<int>(lnumber));
+    nrhs_.push_back(gsl::narrow<int>(lnumber));
 
     getNumErrTestFails(solver_memory_.get(), &lnumber);
-    netf_.push_back(static_cast<int>(lnumber));
+    netf_.push_back(gsl::narrow<int>(lnumber));
 
     getNumNonlinSolvConvFails(solver_memory_.get(), &lnumber);
-    nnlscf_.push_back(static_cast<int>(lnumber));
+    nnlscf_.push_back(gsl::narrow<int>(lnumber));
 
     int number;
     getLastOrder(solver_memory_.get(), &number);
@@ -293,16 +293,16 @@ void Solver::storeDiagnosisB(const int which) const {
 
     long int number;
     getNumSteps(solver_memory_B_.at(which).get(), &number);
-    nsB_.push_back(static_cast<int>(number));
+    nsB_.push_back(gsl::narrow<int>(number));
 
     getNumRhsEvals(solver_memory_B_.at(which).get(), &number);
-    nrhsB_.push_back(static_cast<int>(number));
+    nrhsB_.push_back(gsl::narrow<int>(number));
 
     getNumErrTestFails(solver_memory_B_.at(which).get(), &number);
-    netfB_.push_back(static_cast<int>(number));
+    netfB_.push_back(gsl::narrow<int>(number));
 
     getNumNonlinSolvConvFails(solver_memory_B_.at(which).get(), &number);
-    nnlscfB_.push_back(static_cast<int>(number));
+    nnlscfB_.push_back(gsl::narrow<int>(number));
 }
 
 void Solver::initializeLinearSolver(const Model *model) const {

--- a/src/sundials_linsol_wrapper.cpp
+++ b/src/sundials_linsol_wrapper.cpp
@@ -44,7 +44,7 @@ int SUNLinSolWrapper::Solve(SUNMatrix A, N_Vector x, N_Vector b, realtype tol) c
 }
 
 long SUNLinSolWrapper::getLastFlag() const {
-    return static_cast<long>(SUNLinSolLastFlag(solver_));
+    return gsl::narrow<long>(SUNLinSolLastFlag(solver_));
 }
 
 int SUNLinSolWrapper::space(long *lenrwLS, long *leniwLS) const {

--- a/src/sundials_matrix_wrapper.cpp
+++ b/src/sundials_matrix_wrapper.cpp
@@ -227,14 +227,14 @@ void SUNMatrixWrapper::multiply(gsl::span<realtype> c,
     if (!matrix_)
         return;
 
-    assert(rows() == static_cast<sunindextype>(c.size()));
-    assert(columns() == static_cast<sunindextype>(b.size()));
+    assert(rows() == gsl::narrow<sunindextype>(c.size()));
+    assert(columns() == gsl::narrow<sunindextype>(b.size()));
 
     switch (matrix_id()) {
     case SUNMATRIX_DENSE:
         amici_dgemv(BLASLayout::colMajor, BLASTranspose::noTrans,
-                    static_cast<int>(rows()), static_cast<int>(columns()),
-                    alpha, data(), static_cast<int>(rows()),
+                    gsl::narrow<int>(rows()), gsl::narrow<int>(columns()),
+                    alpha, data(), gsl::narrow<int>(rows()),
                     b.data(), 1, 1.0, c.data(), 1);
         break;
     case SUNMATRIX_SPARSE:
@@ -270,10 +270,10 @@ void SUNMatrixWrapper::multiply(gsl::span<realtype> c,
 
     if (transpose) {
         assert(cols.size() == c.size());
-        assert(rows() == static_cast<sunindextype>(b.size()));
+        assert(rows() == gsl::narrow<sunindextype>(b.size()));
     } else {
-        assert(rows() == static_cast<sunindextype>(c.size()));
-        assert(columns() == static_cast<sunindextype>(b.size()));
+        assert(rows() == gsl::narrow<sunindextype>(c.size()));
+        assert(columns() == gsl::narrow<sunindextype>(b.size()));
     }
 
     check_csc(this);
@@ -294,13 +294,13 @@ void SUNMatrixWrapper::multiply(gsl::span<realtype> c,
 
                 auto idx_val = get_indexval(idx);
                 assert(icols < c.size());
-                assert(static_cast<std::size_t>(idx_val) < b.size());
+                assert(gsl::narrow<std::size_t>(idx_val) < b.size());
 
                 c_ptr[icols] += get_data(idx) * b_ptr[idx_val];
             }
         }
     } else {
-        auto num_cols = static_cast<std::size_t>(columns());
+        auto num_cols = gsl::narrow<std::size_t>(columns());
         for (std::size_t icols = 0; icols < num_cols; ++icols) {
             auto idx_next_col = get_indexptr(cols[icols] + 1);
 
@@ -309,7 +309,7 @@ void SUNMatrixWrapper::multiply(gsl::span<realtype> c,
                 auto idx_val = get_indexval(idx);
 
                 assert(icols < b.size());
-                assert(static_cast<std::size_t>(idx_val) < c.size());
+                assert(gsl::narrow<std::size_t>(idx_val) < c.size());
 
                 c_ptr[idx_val] += get_data(idx) * b_ptr[icols];
             }
@@ -327,9 +327,9 @@ void SUNMatrixWrapper::sparse_multiply(SUNMatrixWrapper &C,
     check_csc(&B);
     check_csc(&C);
 
-    assert(rows() == static_cast<sunindextype>(C.rows()));
+    assert(rows() == gsl::narrow<sunindextype>(C.rows()));
     assert(C.columns() == B.columns());
-    assert(static_cast<sunindextype>(B.rows()) == columns());
+    assert(gsl::narrow<sunindextype>(B.rows()) == columns());
 
     C.zero();
 
@@ -394,10 +394,10 @@ void SUNMatrixWrapper::sparse_add(const SUNMatrixWrapper &A, realtype alpha,
     check_csc(&A);
     check_csc(&B);
 
-    assert(rows() == static_cast<sunindextype>(A.rows()));
-    assert(rows() == static_cast<sunindextype>(B.rows()));
-    assert(columns() == static_cast<sunindextype>(A.columns()));
-    assert(columns() == static_cast<sunindextype>(B.columns()));
+    assert(rows() == gsl::narrow<sunindextype>(A.rows()));
+    assert(rows() == gsl::narrow<sunindextype>(B.rows()));
+    assert(columns() == gsl::narrow<sunindextype>(A.columns()));
+    assert(columns() == gsl::narrow<sunindextype>(B.columns()));
 
     zero();
 
@@ -434,7 +434,7 @@ void SUNMatrixWrapper::sparse_add(const SUNMatrixWrapper &A, realtype alpha,
         // no reallocation should happen here
         for (cidx = get_indexptr(ccol); cidx < nnz; cidx++) {
             auto x_idx = get_indexval(cidx);
-            assert(x_idx >= 0 && static_cast<std::size_t>(x_idx) < x.size());
+            assert(x_idx >= 0 && gsl::narrow<std::size_t>(x_idx) < x.size());
             set_data(cidx, x[x_idx]); // copy data to C
         }
     }
@@ -492,7 +492,7 @@ void SUNMatrixWrapper::sparse_sum(const std::vector<SUNMatrixWrapper> &mats) {
         // no reallocation should happen here
         for (aidx = get_indexptr(acol); aidx < nnz; aidx++) {
             auto x_idx = get_indexval(aidx);
-            assert(x_idx >= 0 && static_cast<std::size_t>(x_idx) < x.size());
+            assert(x_idx >= 0 && gsl::narrow<std::size_t>(x_idx) < x.size());
             set_data(aidx, x[x_idx]); // copy data to C
         }
     }
@@ -524,7 +524,7 @@ sunindextype SUNMatrixWrapper::scatter(const sunindextype acol,
     for (aidx = get_indexptr(acol); aidx < get_indexptr(acol+1); aidx++)
     {
         auto arow = get_indexval(aidx);          /* A(arow,acol) is nonzero */
-        assert(arow >= 0 && static_cast<std::size_t>(arow) <= x.size());
+        assert(arow >= 0 && gsl::narrow<std::size_t>(arow) <= x.size());
         if (w && w[arow] < mark) {
             w[arow] = mark;                      /* arow is new entry in C(:,*) */
             if (C)
@@ -543,7 +543,7 @@ sunindextype SUNMatrixWrapper::scatter(const sunindextype acol,
 static void cumsum(gsl::span<sunindextype> p, std::vector<sunindextype> &c) {
     sunindextype nz = 0;
     assert(p.size() == c.size() + 1);
-    for (sunindextype i = 0; i < static_cast<sunindextype>(c.size()); i++)
+    for (sunindextype i = 0; i < gsl::narrow<sunindextype>(c.size()); i++)
     {
         p[i] = nz;
         nz += c[i];

--- a/src/vector.cpp
+++ b/src/vector.cpp
@@ -21,7 +21,7 @@ const_N_Vector AmiVector::getNVector() const { return nvec_; }
 
 std::vector<realtype> const &AmiVector::getVector() const { return vec_; }
 
-int AmiVector::getLength() const { return static_cast<int>(vec_.size()); }
+int AmiVector::getLength() const { return gsl::narrow<int>(vec_.size()); }
 
 void AmiVector::zero() { set(0.0); }
 
@@ -33,15 +33,15 @@ void AmiVector::minus() {
 void AmiVector::set(realtype val) { std::fill(vec_.begin(), vec_.end(), val); }
 
 realtype &AmiVector::operator[](int pos) {
-    return vec_.at(static_cast<decltype(vec_)::size_type>(pos));
+    return vec_.at(gsl::narrow<decltype(vec_)::size_type>(pos));
 }
 
 realtype &AmiVector::at(int pos) {
-    return vec_.at(static_cast<decltype(vec_)::size_type>(pos));
+    return vec_.at(gsl::narrow<decltype(vec_)::size_type>(pos));
 }
 
 const realtype &AmiVector::at(int pos) const {
-    return vec_.at(static_cast<decltype(vec_)::size_type>(pos));
+    return vec_.at(gsl::narrow<decltype(vec_)::size_type>(pos));
 }
 
 void AmiVector::copy(const AmiVector &other) {
@@ -56,7 +56,7 @@ void AmiVector::copy(const AmiVector &other) {
 void AmiVector::synchroniseNVector() {
     if (nvec_)
         N_VDestroy_Serial(nvec_);
-    nvec_ = N_VMake_Serial(static_cast<long int>(vec_.size()), vec_.data());
+    nvec_ = N_VMake_Serial(gsl::narrow<long int>(vec_.size()), vec_.data());
 }
 
 AmiVector::~AmiVector() {
@@ -116,7 +116,7 @@ const AmiVector &AmiVectorArray::operator[](int pos) const {
 }
 
 int AmiVectorArray::getLength() const {
-    return static_cast<int>(vec_array_.size());
+    return gsl::narrow<int>(vec_array_.size());
 }
 
 void AmiVectorArray::zero() {
@@ -125,12 +125,12 @@ void AmiVectorArray::zero() {
 }
 
 void AmiVectorArray::flatten_to_vector(std::vector<realtype> &vec) const {
-    int n_outer = static_cast<int>(vec_array_.size());
+    int n_outer = gsl::narrow<int>(vec_array_.size());
     if (n_outer == 0)
         return; // nothing to do ...
     int n_inner = vec_array_.at(0).getLength();
 
-    if (static_cast<int>(vec.size()) != n_inner * n_outer) {
+    if (gsl::narrow<int>(vec.size()) != n_inner * n_outer) {
         throw AmiException("Dimension of AmiVectorArray (%ix%i) does not "
                            "match target vector dimension (%u)",
                            n_inner, n_outer, vec.size());


### PR DESCRIPTION
Use gsl::narrow instead of plain static_cast. This will let us spot quickly when things get too large for our omnipresent to-int conversions.