### PR TITLE
Fix event tests

### DIFF
--- a/python/sdist/setup.cfg
+++ b/python/sdist/setup.cfg
@@ -38,6 +38,7 @@ install_requires =
     wurlitzer
     toposort
     setuptools>=48
+    mpmath
 include_package_data = True
 zip_safe = False
 

--- a/python/tests/test_events.py
+++ b/python/tests/test_events.py
@@ -1,16 +1,13 @@
 """Tests for SBML events, including piecewise expressions."""
-import numpy as np
-import pytest
-import os
-from scipy.linalg import expm
 from copy import deepcopy
 
-from util import (
-    create_sbml_model,
-    create_amici_model,
-    check_trajectories_without_sensitivities,
-    check_trajectories_with_forward_sensitivities,
-)
+import numpy as np
+import pytest
+
+from util import (check_trajectories_with_forward_sensitivities,
+                  check_trajectories_without_sensitivities, create_amici_model,
+                  create_sbml_model)
+
 
 @pytest.fixture(params=[
     'events_plus_heavisides',
@@ -349,3 +346,12 @@ def test_models(model):
     check_trajectories_with_forward_sensitivities(amici_model,
                                                   result_expected_x,
                                                   result_expected_sx)
+
+
+def expm(x):
+    """``expm`` wrapper
+
+    Uses ``expm`` from ``mpmath``. *Something* changed in scipy's ``expm`` in
+    version 1.9.0 breaking these tests"""
+    from mpmath import expm
+    return np.array(expm(x).tolist()).astype(float)


### PR DESCRIPTION
Uses `expm` from `mpmath`. *Something* changed in scipy's `expm` in version [1.9.0](https://docs.scipy.org/doc/scipy/release.1.9.0.html#scipy-linalg-improvements) breaking these tests