### PR TITLE
Fix potential deadlocks during parallel simplification

### DIFF
--- a/python/amici/ode_export.py
+++ b/python/amici/ode_export.py
@@ -444,8 +444,11 @@ def smart_jacobian(eq: sp.MutableDenseMatrix,
         )
 
     # parallel
-    from multiprocessing import Pool
-    with Pool(n_procs) as p:
+    from multiprocessing import get_context
+    # "spawn" should avoid potential deadlocks occurring with fork
+    #  see e.g. https://stackoverflow.com/a/66113051
+    ctx = get_context('spawn')
+    with ctx.Pool(n_procs) as p:
         mapped = p.starmap(_jacobian_element, elements)
     return sp.MutableSparseMatrix(nrow, ncol, dict(mapped))
 


### PR DESCRIPTION
For larger models, I experienced occassional deadlocks during import. Unclear why.
Most such issues seem to be related to forking, so let's do without.