### PR TITLE
Cleanup includes

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -122,7 +122,6 @@ set(AMICI_SRC_LIST
     ${CMAKE_SOURCE_DIR}/include/amici/exception.h
     ${CMAKE_SOURCE_DIR}/include/amici/forwardproblem.h
     ${CMAKE_SOURCE_DIR}/include/amici/hdf5.h
-    ${CMAKE_SOURCE_DIR}/include/amici/interface_matlab.h
     ${CMAKE_SOURCE_DIR}/include/amici/misc.h
     ${CMAKE_SOURCE_DIR}/include/amici/model_dae.h
     ${CMAKE_SOURCE_DIR}/include/amici/model_dimensions.h
@@ -131,7 +130,6 @@ set(AMICI_SRC_LIST
     ${CMAKE_SOURCE_DIR}/include/amici/model_state.h
     ${CMAKE_SOURCE_DIR}/include/amici/newton_solver.h
     ${CMAKE_SOURCE_DIR}/include/amici/rdata.h
-    ${CMAKE_SOURCE_DIR}/include/amici/returndata_matlab.h
     ${CMAKE_SOURCE_DIR}/include/amici/serialization.h
     ${CMAKE_SOURCE_DIR}/include/amici/simulation_parameters.h
     ${CMAKE_SOURCE_DIR}/include/amici/solver_cvodes.h
@@ -206,21 +204,36 @@ endif()
 # Create targets to make the sources show up in IDEs for convenience
 
 # For matlab interface
-add_custom_target(matlabInterface
-    SOURCES
+set(matlab_sources
     src/interface_matlab.cpp
     src/returndata_matlab.cpp
-    include/amici/interface_matlab.h)
-set_target_properties(matlabInterface
-    PROPERTIES INCLUDE_DIRECTORIES "${CMAKE_SOURCE_DIR}/include/")
+    include/amici/interface_matlab.h
+    include/amici/returndata_matlab.h
+)
 find_package(Matlab)
+# In case we can find Matlab, we create a respective library to compile the
+# extension from cmake. Otherwise we just create a dummy target for
+# the files to show up inside IDEs.
+# (Set the Matlab_ROOT_DIR cmake variable if CMake cannot find your Matlab
+# installation)
 if (${Matlab_FOUND})
-    # In case we can find Matlab, use the respective include directories
-    # for better IDE integration (set Matlab_ROOT_DIR cmake variable
-    # if CMake cannot find your Matlab installation)
-    set_property(TARGET matlabInterface APPEND
-        PROPERTY INCLUDE_DIRECTORIES "${Matlab_INCLUDE_DIRS}")
+    add_library(matlabInterface
+        ${matlab_sources}
+    )
+    set_target_properties(matlabInterface
+        PROPERTIES INCLUDE_DIRECTORIES "${Matlab_INCLUDE_DIRS}")
+
+    target_link_libraries(matlabInterface
+        PUBLIC amici
+    )
+
+else()
+    add_custom_target(matlabInterface
+        SOURCES ${matlab_sources}
+    )
 endif()
+set_property(TARGET matlabInterface APPEND
+    PROPERTY INCLUDE_DIRECTORIES  "${CMAKE_SOURCE_DIR}/include/")
 
 # For template files
 add_custom_target(

--- a/include/amici/amici.h
+++ b/include/amici/amici.h
@@ -1,16 +1,20 @@
 #ifndef amici_h
 #define amici_h
 
-#include "amici/cblas.h"
-#include "amici/defines.h"
 #include "amici/edata.h"
-#include "amici/exception.h"
 #include "amici/model.h"
 #include "amici/rdata.h"
 #include "amici/solver.h"
-#include "amici/symbolic_functions.h"
+
 
 namespace amici {
+
+/**
+ * Type for function to process warnings or error messages.
+ */
+using outputFunctionType = std::function<void(std::string const& identifier,
+                                              std::string const& message)>;
+
 
 /*!
  * @brief Prints a specified error message associated with the specified

--- a/include/amici/defines.h
+++ b/include/amici/defines.h
@@ -6,7 +6,6 @@
 #endif
 
 #include <functional>
-#include <string>
 #include <cmath>
 
 /* Math constants in case _USE_MATH_DEFINES is not supported */
@@ -220,12 +219,6 @@ enum class RDataReporting {
     residuals,
     likelihood,
 };
-
-/**
- * Type for function to process warnings or error messages.
- */
-using outputFunctionType = std::function<void(std::string const& identifier,
-                                              std::string const& message)>;
 
 // clang-format on
 

--- a/include/amici/edata.h
+++ b/include/amici/edata.h
@@ -2,7 +2,6 @@
 #define AMICI_EDATA_H
 
 #include "amici/defines.h"
-#include "amici/vector.h"
 #include "amici/misc.h"
 #include "amici/simulation_parameters.h"
 

--- a/include/amici/exception.h
+++ b/include/amici/exception.h
@@ -5,6 +5,7 @@
 
 #include <exception>
 #include <array>
+#include <cstdarg>
 
 namespace amici {
 

--- a/include/amici/forwardproblem.h
+++ b/include/amici/forwardproblem.h
@@ -5,7 +5,7 @@
 #include "amici/vector.h"
 #include "amici/model.h"
 #include "amici/misc.h"
-#include "amici/sundials_matrix_wrapper.h"
+#include <amici/amici.h>
 
 #include <sundials/sundials_direct.h>
 #include <vector>
@@ -17,23 +17,6 @@ class ExpData;
 class Solver;
 class SteadystateProblem;
 class FinalStateStorer;
-
-/**
- * @brief implements an exchange format to store and transfer the state of a simulation at a
- * specific timepoint.
- */
-struct SimulationState{
-    /** timepoint */
-    realtype t;
-    /** state variables */
-    AmiVector x;
-    /** state variables */
-    AmiVector dx;
-    /** state variable sensitivity */
-    AmiVectorArray sx;
-    /** state of the model that was used for simulation */
-    ModelState state;
-};
 
 
 /**

--- a/include/amici/interface_matlab.h
+++ b/include/amici/interface_matlab.h
@@ -1,20 +1,21 @@
 #ifndef AMICI_INTERFACE_MATLAB_H
 #define AMICI_INTERFACE_MATLAB_H
 
-#include "amici/amici.h"
+#include <amici/defines.h>
 
 #include <mex.h>
 #include <memory>
 
-
 namespace amici {
+
+class Model;
+class Solver;
+class ReturnDataMatlab;
+class ExpData;
 
 namespace generic_model {
 extern std::unique_ptr<amici::Model> getModel();
 } // namespace generic_model
-
-class Model;
-class ReturnDataMatlab;
 
 
 /**

--- a/include/amici/model_state.h
+++ b/include/amici/model_state.h
@@ -293,6 +293,24 @@ struct ModelStateDerived {
 };
 
 
+/**
+ * @brief implements an exchange format to store and transfer the state of a simulation at a
+ * specific timepoint.
+ */
+struct SimulationState{
+    /** timepoint */
+    realtype t;
+    /** state variables */
+    AmiVector x;
+    /** state variables */
+    AmiVector dx;
+    /** state variable sensitivity */
+    AmiVectorArray sx;
+    /** state of the model that was used for simulation */
+    ModelState state;
+};
+
+
 } // namespace amici
 
 #endif // AMICI_MODEL_STATE_H

--- a/include/amici/newton_solver.h
+++ b/include/amici/newton_solver.h
@@ -1,9 +1,7 @@
 #ifndef amici_newton_solver_h
 #define amici_newton_solver_h
 
-#include "amici/defines.h"
 #include "amici/solver.h"
-#include "amici/sundials_linsol_wrapper.h"
 #include "amici/sundials_matrix_wrapper.h"
 #include "amici/vector.h"
 
@@ -14,6 +12,7 @@ namespace amici {
 class Model;
 class Solver;
 class AmiVector;
+class SimulationState;
 
 /**
  * @brief The NewtonSolver class sets up the linear solver for the Newton

--- a/include/amici/newton_solver.h
+++ b/include/amici/newton_solver.h
@@ -12,7 +12,7 @@ namespace amici {
 class Model;
 class Solver;
 class AmiVector;
-class SimulationState;
+struct SimulationState;
 
 /**
  * @brief The NewtonSolver class sets up the linear solver for the Newton

--- a/include/amici/rdata.h
+++ b/include/amici/rdata.h
@@ -5,7 +5,7 @@
 #include "amici/vector.h"
 #include "amici/model.h"
 #include "amici/misc.h"
-#include "amici/forwardproblem.h"
+
 #include <vector>
 
 namespace amici {

--- a/include/amici/solver.h
+++ b/include/amici/solver.h
@@ -1,10 +1,8 @@
 #ifndef AMICI_SOLVER_H
 #define AMICI_SOLVER_H
 
-#include "amici/amici.h"
 #include "amici/defines.h"
 #include "amici/sundials_linsol_wrapper.h"
-#include "amici/symbolic_functions.h"
 #include "amici/vector.h"
 
 #include <cmath>

--- a/include/amici/steadystateproblem.h
+++ b/include/amici/steadystateproblem.h
@@ -1,11 +1,10 @@
 #ifndef AMICI_STEADYSTATEPROBLEM_H
 #define AMICI_STEADYSTATEPROBLEM_H
 
-#include "amici/defines.h"
-#include "amici/forwardproblem.h"
-#include "amici/solver_cvodes.h"
-#include "amici/vector.h"
+#include <amici/defines.h>
+#include <amici/vector.h>
 #include <amici/newton_solver.h>
+#include <amici/model_state.h>
 
 #include <nvector/nvector_serial.h>
 
@@ -339,27 +338,27 @@ class SteadystateProblem {
      * dampening (false)
      */
     bool updateDampingFactor(bool step_successful);
-    
+
     /**
      * @brief Updates member variables to indicate that state_.x has been updated and xdot_, delta_, etc.
      * need to be recomputed.
      */
     void flagUpdatedState();
-    
+
     /**
      * @brief Retrieves simulation sensitivities from the provided solver and sets the corresponding flag
      * to indicate they are up to date
      * @param solver simulation solver instance
      */
     void updateSensiSimulation(const Solver &solver);
-    
+
     /**
      * @brief Computes the right hand side for the current state_.x and sets the corresponding flag to
      * indicate xdot_ is up to date.
      * @param model model instance
      */
     void updateRightHandSide(Model &model);
-    
+
     /**
      * @brief Computes the newton step for the current state_.x and sets the corresponding flag to
      * indicate delta_ is up to date.
@@ -449,14 +448,14 @@ class SteadystateProblem {
     bool newton_step_conv_ {false};
     /** whether sensitivities should be checked for convergence to steadystate */
     bool check_sensi_conv_ {true};
-    
+
     /** flag indicating whether xdot_ has been computed for the current state */
     bool xdot_updated_ {false};
     /** flag indicating whether delta_ has been computed for the current state */
     bool delta_updated_ {false};
     /** flag indicating whether simulation sensitivities have been retrieved for the current state */
     bool sensis_updated_ {false};
-    
+
 };
 
 } // namespace amici

--- a/include/amici/sundials_linsol_wrapper.h
+++ b/include/amici/sundials_linsol_wrapper.h
@@ -1,7 +1,6 @@
 #ifndef AMICI_SUNDIALS_LINSOL_WRAPPER_H
 #define AMICI_SUNDIALS_LINSOL_WRAPPER_H
 
-#include "amici/exception.h"
 #include "amici/sundials_matrix_wrapper.h"
 #include "amici/vector.h"
 

--- a/python/amici/ode_export.py
+++ b/python/amici/ode_export.py
@@ -1717,7 +1717,7 @@ class ODEModel:
             event_ids = [
                 e.get_id() for e in self._events
             ]
-            # TODO: get rid of this stupid 1-based indexing as soon as we can 
+            # TODO: get rid of this stupid 1-based indexing as soon as we can
             # the matlab interface
             z2event = [
                 event_ids.index(event_obs.get_event()) + 1
@@ -2686,7 +2686,6 @@ class ODEExporter:
             '#include "sundials/sundials_types.h"',
             '',
             '#include <gsl/gsl-lite.hpp>',
-            '#include <array>',
             '#include <algorithm>',
             ''
         ]
@@ -2777,7 +2776,6 @@ class ODEExporter:
         :param indextype:
             type of index {'colptrs', 'rowvals'}
         """
-
         if indextype == 'colptrs':
             values = self.model.colptrs(function)
             setter = 'indexptrs'

--- a/src/forwardproblem.cpp
+++ b/src/forwardproblem.cpp
@@ -1,6 +1,5 @@
 #include "amici/forwardproblem.h"
 
-#include "amici/cblas.h"
 #include "amici/misc.h"
 #include "amici/model.h"
 #include "amici/solver.h"

--- a/src/hdf5.cpp
+++ b/src/hdf5.cpp
@@ -7,8 +7,12 @@
  * issues.
  */
 
-#include "amici/hdf5.h"
-#include "amici/amici.h"
+#include <amici/hdf5.h>
+
+#include <amici/model.h>
+#include <amici/solver.h>
+#include <amici/rdata.h>
+#include <amici/edata.h>
 
 #include <hdf5_hl.h>
 

--- a/src/interface_matlab.cpp
+++ b/src/interface_matlab.cpp
@@ -8,9 +8,11 @@
 
 #include "amici/interface_matlab.h"
 
+#include "amici/amici.h"
 #include "amici/model.h"
 #include "amici/exception.h"
 #include "amici/edata.h"
+#include "amici/solver.h"
 #include "amici/returndata_matlab.h"
 
 #include <assert.h>
@@ -120,7 +122,7 @@ std::unique_ptr<ExpData> expDataFromMatlabCall(const mxArray *prhs[],
     if (!mxGetPr(prhs[RHS_DATA]))
         return nullptr;
 
-    auto edata = std::unique_ptr<ExpData>(new ExpData(model));
+    auto edata = std::make_unique<ExpData>(model);
 
     // Y
     if (mxArray *dataY = mxGetProperty(prhs[RHS_DATA], 0, "Y")) {

--- a/src/misc.cpp
+++ b/src/misc.cpp
@@ -1,5 +1,4 @@
 #include "amici/misc.h"
-#include "amici/amici.h"
 #include "amici/symbolic_functions.h"
 
 #include <cstdio>

--- a/src/model.ODE_template.cpp
+++ b/src/model.ODE_template.cpp
@@ -1,5 +1,5 @@
-#include "TPL_MODELNAME.h"
 #include <array>
+#include <amici/defines.h>
 
 namespace amici {
 

--- a/src/model.cpp
+++ b/src/model.cpp
@@ -1,8 +1,10 @@
-#include "amici/model.h"
-#include "amici/amici.h"
-#include "amici/exception.h"
-#include "amici/misc.h"
-#include "amici/symbolic_functions.h"
+#include <amici/model.h>
+#include <amici/amici.h>
+#include <amici/exception.h>
+#include <amici/misc.h>
+#include <amici/symbolic_functions.h>
+#include <amici/cblas.h>
+
 
 #include <algorithm>
 #include <cmath>

--- a/src/model_header.ODE_template.h
+++ b/src/model_header.ODE_template.h
@@ -5,9 +5,6 @@
 #include <gsl/gsl-lite.hpp>
 
 #include "amici/model_ode.h"
-#include "amici/solver_cvodes.h"
-
-#include "sundials/sundials_types.h"
 
 namespace amici {
 

--- a/src/newton_solver.cpp
+++ b/src/newton_solver.cpp
@@ -1,10 +1,11 @@
 #include "amici/newton_solver.h"
 
-#include "amici/model.h"
-#include "amici/solver.h"
+#include <amici/amici.h>
+#include <amici/model.h>
+#include <amici/solver.h>
 
-#include "sunlinsol/sunlinsol_dense.h" // dense solver
-#include "sunlinsol/sunlinsol_klu.h"   // sparse solver
+#include <sunlinsol/sunlinsol_dense.h> // dense solver
+#include <sunlinsol/sunlinsol_klu.h>   // sparse solver
 #include <sundials/sundials_config.h>  // roundoffs
 
 #include <cmath>

--- a/src/rdata.cpp
+++ b/src/rdata.cpp
@@ -2,7 +2,6 @@
 
 #include "amici/backwardproblem.h"
 #include "amici/edata.h"
-#include "amici/exception.h"
 #include "amici/forwardproblem.h"
 #include "amici/misc.h"
 #include "amici/model.h"

--- a/src/solver.cpp
+++ b/src/solver.cpp
@@ -1,9 +1,10 @@
 #include "amici/solver.h"
 
 #include "amici/exception.h"
-#include "amici/misc.h"
+#include "amici/amici.h"
 #include "amici/model.h"
-#include "amici/rdata.h"
+#include "amici/symbolic_functions.h"
+
 
 #include <cstdio>
 #include <cstring>

--- a/src/solver_cvodes.cpp
+++ b/src/solver_cvodes.cpp
@@ -1,7 +1,6 @@
 #include "amici/solver_cvodes.h"
 
 #include "amici/exception.h"
-#include "amici/misc.h"
 #include "amici/model_ode.h"
 #include "amici/sundials_linsol_wrapper.h"
 

--- a/src/solver_idas.cpp
+++ b/src/solver_idas.cpp
@@ -1,7 +1,6 @@
 #include "amici/solver_idas.h"
 
 #include "amici/exception.h"
-#include "amici/misc.h"
 #include "amici/model_dae.h"
 #include "amici/sundials_linsol_wrapper.h"
 

--- a/src/steadystateproblem.cpp
+++ b/src/steadystateproblem.cpp
@@ -2,12 +2,11 @@
 #include "amici/backwardproblem.h"
 #include "amici/defines.h"
 #include "amici/edata.h"
-#include "amici/forwardproblem.h"
 #include "amici/misc.h"
 #include "amici/model.h"
 #include "amici/newton_solver.h"
 #include "amici/solver.h"
-#include "amici/solver_cvodes.h"
+#include "amici/amici.h"
 
 #include <cmath>
 #include <cstring>
@@ -95,7 +94,7 @@ void SteadystateProblem::findSteadyState(const Solver &solver, Model &model,
                                          int it) {
     steady_state_status_.resize(3, SteadyStateStatus::not_run);
     bool turnOffNewton = model.getSteadyStateSensitivityMode() ==
-        SteadyStateSensitivityMode::integrationOnly && 
+        SteadyStateSensitivityMode::integrationOnly &&
         ((it == -1 && solver.getSensitivityMethodPreequilibration() ==
          SensitivityMethod::forward) || solver.getSensitivityMethod() ==
         SensitivityMethod::forward);
@@ -254,12 +253,12 @@ void SteadystateProblem::computeSteadyStateQuadrature(const Solver &solver,
     auto sensitivityMode = model.getSteadyStateSensitivityMode();
 
     /* Try to compute the analytical solution for quadrature algebraically */
-    if (sensitivityMode == SteadyStateSensitivityMode::newtonOnly 
+    if (sensitivityMode == SteadyStateSensitivityMode::newtonOnly
         || sensitivityMode == SteadyStateSensitivityMode::integrateIfNewtonFails)
         getQuadratureByLinSolve(model);
 
     /* Perform simulation */
-    if (sensitivityMode == SteadyStateSensitivityMode::integrationOnly || 
+    if (sensitivityMode == SteadyStateSensitivityMode::integrationOnly ||
         (sensitivityMode == SteadyStateSensitivityMode::integrateIfNewtonFails
          && !hasQuadrature()))
         getQuadratureBySimulation(solver, model);
@@ -381,7 +380,7 @@ bool SteadystateProblem::getSensitivityFlag(const Model &model,
         solver.getSensitivityOrder() >= SensitivityOrder::first &&
         steady_state_status_[1] == SteadyStateStatus::success &&
         (model.getSteadyStateSensitivityMode() ==
-         SteadyStateSensitivityMode::integrationOnly || 
+         SteadyStateSensitivityMode::integrationOnly ||
          model.getSteadyStateSensitivityMode() ==
          SteadyStateSensitivityMode::integrateIfNewtonFails);
 
@@ -408,10 +407,10 @@ bool SteadystateProblem::getSensitivityFlag(const Model &model,
         !simulationStartedInSteadystate;
 
     /* When we're creating a new solver object */
-    bool needForwardSensiAtCreation = 
+    bool needForwardSensiAtCreation =
         needForwardSensisPreeq &&
         (model.getSteadyStateSensitivityMode() ==
-         SteadyStateSensitivityMode::integrationOnly || 
+         SteadyStateSensitivityMode::integrationOnly ||
          model.getSteadyStateSensitivityMode() ==
          SteadyStateSensitivityMode::integrateIfNewtonFails
         );
@@ -483,11 +482,11 @@ realtype SteadystateProblem::getWrms(Model &model,
 realtype SteadystateProblem::getWrmsFSA(Model &model) {
     /* Forward sensitivities: Compute weighted error norm for their RHS */
     realtype wrms = 0.0;
-    
+
     /* we don't need to call prepareLinearSystem in this function, since it was
      already computed in the preceding getWrms call and both equations have the
      same jacobian */
-    
+
     xdot_updated_ = false;
     for (int ip = 0; ip < model.nplist(); ++ip) {
         model.fsxdot(state_.t, state_.x, state_.dx, ip, state_.sx[ip],
@@ -547,7 +546,7 @@ void SteadystateProblem::applyNewtonsMethod(Model &model, bool newton_retry) {
         linearSum(1.0, x_old_, gamma_,
                   update_direction ? delta_ : delta_old_, state_.x);
         flagUpdatedState();
-            
+
         /* Compute new xdot and residuals */
         realtype wrms_tmp = getWrms(model, SensitivityMethod::none);
 
@@ -563,7 +562,7 @@ void SteadystateProblem::applyNewtonsMethod(Model &model, bool newton_retry) {
             /* update x_old_ _after_ positivity was enforced */
             x_old_.copy(state_.x);
         }
-        
+
         update_direction = updateDampingFactor(step_successful);
         /* increase step counter */
         i_newtonstep++;
@@ -631,14 +630,14 @@ void SteadystateProblem::runSteadystateSimulation(const Solver &solver,
 
     /* If run after Newton's method checks again if it converged */
     wrms_ = getWrms(model, sensitivityFlag);
-    
+
     int &sim_steps = backward ? numstepsB_ : numsteps_.at(1);
-    
+
     int convergence_check_frequency = 1;
-    
+
     if (newton_step_conv_)
         convergence_check_frequency = 25;
-        
+
     while (true) {
         /* check for maxsteps  */
         if (sim_steps >= solver.getMaxSteps()) {
@@ -649,9 +648,9 @@ void SteadystateProblem::runSteadystateSimulation(const Solver &solver,
             throw NewtonFailure(AMICI_NO_STEADY_STATE,
                                 "simulated to late time"
                                 " point without convergence of RHS");
-        }        
+        }
         /* increase counter */
-        sim_steps++;         
+        sim_steps++;
         /* One step of ODE integration
          reason for tout specification:
          max with 1 ensures correct direction (any positive value would do)
@@ -660,7 +659,7 @@ void SteadystateProblem::runSteadystateSimulation(const Solver &solver,
          only direction w.r.t. current t
          */
         solver.step(std::max(state_.t, 1.0) * 10);
-       
+
         if (backward) {
             solver.writeSolution(&state_.t, xB_, state_.dx, state_.sx, xQ_);
         } else {
@@ -668,7 +667,7 @@ void SteadystateProblem::runSteadystateSimulation(const Solver &solver,
                                   xQ_);
             flagUpdatedState();
         }
-        
+
         /* Check for convergence */
         if (sim_steps % convergence_check_frequency == 0) {
             wrms_ = getWrms(model, sensitivityFlag);
@@ -684,7 +683,7 @@ void SteadystateProblem::runSteadystateSimulation(const Solver &solver,
         if (wrms_ < conv_thresh)
             break; // converged
     }
-    
+
     // if check_sensi_conv_ is deactivated, we still have to update sensis
     if (sensitivityFlag == SensitivityMethod::forward)
         updateSensiSimulation(solver);


### PR DESCRIPTION
Removing unused includes might improve compile times slightly.

Moves a few functions/classes to more appropriate places.

Also adds a CMake target for the matlab extension, making it easier to check for compilation errors there.