### PR TITLE
Pin setuptools for python-C++ code coverage

### DIFF
--- a/scripts/installAmiciSource.sh
+++ b/scripts/installAmiciSource.sh
@@ -29,6 +29,6 @@ fi
 
 pip install --upgrade pip pkgconfig scipy matplotlib coverage pytest pytest-cov
 pip install git+https://github.com/pysb/pysb # pin to develop to fix sympy compatibility
-
-pip install --verbose -e ${AMICI_PATH}/python/sdist[petab,test]
+pip install -U "setuptools<64"
+pip install --verbose -e ${AMICI_PATH}/python/sdist[petab,test] --no-build-isolation
 deactivate


### PR DESCRIPTION
setuptools>=64 builds the extension in some temporary directory, even with editable installation and no build isolation. This breaks our current code coverage analysis. Not sure how to best address this. For now, pin setuptools.