### PR TITLE
Proper type annotations for the swig interface

### DIFF
--- a/python/amici/swig.py
+++ b/python/amici/swig.py
@@ -87,6 +87,9 @@ class TypeHintFixer(ast.NodeTransformer):
         'void': None,
         'double': ast.Name('float'),
         'int': ast.Name('int'),
+        'long': ast.Name('int'),
+        'ptrdiff_t': ast.Name('int'),
+        'size_t': ast.Name('int'),
         'bool': ast.Name('bool'),
         'std::unique_ptr< amici::Solver >': ast.Constant('Solver'),
         'amici::InternalSensitivityMethod':
@@ -110,7 +113,7 @@ class TypeHintFixer(ast.NodeTransformer):
             ast.Constant('SteadyStateSensitivityMode'),
         'amici::realtype': ast.Name('float'),
         'DoubleVector': ast.Constant('numpy.ndarray'),
-        'IntVector': ast.Name('List[int]'),
+        'IntVector': ast.Name('Sequence[int]'),
         'std::string': ast.Name('str'),
         'std::string const &': ast.Name('str'),
         'std::unique_ptr< amici::ExpData >': ast.Constant('ExpData'),
@@ -150,7 +153,7 @@ class TypeHintFixer(ast.NodeTransformer):
 
         # std::vector
         if (value_type := re.sub(
-                r'std::vector< (.*),std::allocator< \1 > >',
+                r'std::vector< (.*),std::allocator< \1 > >( const &)?',
                 r'\1', old_annot)) in self.mapping:
             value_type_annot = self.mapping[value_type]
             if isinstance(value_type_annot, ast.Constant):

--- a/python/amici/swig.py
+++ b/python/amici/swig.py
@@ -1,12 +1,10 @@
 """Functions for downloading/building/finding SWIG"""
-
-
-from typing import Tuple
 import ast
 import contextlib
 import os
-import subprocess
 import re
+import subprocess
+from typing import Tuple
 
 
 def find_swig() -> str:
@@ -120,7 +118,6 @@ class TypeHintFixer(ast.NodeTransformer):
         'std::vector< amici::ParameterScaling,'
         'std::allocator< amici::ParameterScaling > > const &':
             ast.Constant('ParameterScalingVector')
-
     }
 
     def visit_FunctionDef(self, node):

--- a/python/amici/swig.py
+++ b/python/amici/swig.py
@@ -85,44 +85,79 @@ class TypeHintFixer(ast.NodeTransformer):
 
     mapping = {
         'void': None,
-        'std::unique_ptr< amici::Solver >': 'Solver',
-        'amici::InternalSensitivityMethod': 'InternalSensitivityMethod',
-        'amici::InterpolationType': 'InterpolationType',
-        'amici::LinearMultistepMethod': 'LinearMultistepMethod',
-        'amici::LinearSolver': 'LinearSolver',
-        'amici::Model *': 'Model',
-        'amici::Model const *': 'Model',
-        'amici::NewtonDampingFactorMode': 'NewtonDampingFactorMode',
-        'amici::NonlinearSolverIteration': 'NonlinearSolverIteration',
-        'amici::RDataReporting': 'RDataReporting',
-        'amici::SensitivityMethod': 'SensitivityMethod',
-        'amici::SensitivityOrder': 'SensitivityOrder',
-        'amici::Solver *': 'Solver',
-        'amici::SteadyStateSensitivityMode': 'SteadyStateSensitivityMode',
-        'amici::realtype': 'float',
-        'DoubleVector': 'numpy.ndarray',
-        'IntVector': 'List[int]',
-        'std::string': 'str',
-        'std::string const &': 'str',
-        'std::unique_ptr< amici::ExpData >': 'ExpData',
-        'std::unique_ptr< amici::ReturnData >': 'ReturnData',
+        'double': ast.Name('float'),
+        'int': ast.Name('int'),
+        'bool': ast.Name('bool'),
+        'std::unique_ptr< amici::Solver >': ast.Constant('Solver'),
+        'amici::InternalSensitivityMethod':
+            ast.Constant('InternalSensitivityMethod'),
+        'amici::InterpolationType': ast.Constant('InterpolationType'),
+        'amici::LinearMultistepMethod': ast.Constant('LinearMultistepMethod'),
+        'amici::LinearSolver': ast.Constant('LinearSolver'),
+        'amici::Model *': ast.Constant('Model'),
+        'amici::Model const *': ast.Constant('Model'),
+        'amici::NewtonDampingFactorMode':
+            ast.Constant('NewtonDampingFactorMode'),
+        'amici::NonlinearSolverIteration':
+            ast.Constant('NonlinearSolverIteration'),
+        'amici::ObservableScaling': ast.Constant('ObservableScaling'),
+        'amici::ParameterScaling': ast.Constant('ParameterScaling'),
+        'amici::RDataReporting': ast.Constant('RDataReporting'),
+        'amici::SensitivityMethod': ast.Constant('SensitivityMethod'),
+        'amici::SensitivityOrder': ast.Constant('SensitivityOrder'),
+        'amici::Solver *': ast.Constant('Solver'),
+        'amici::SteadyStateSensitivityMode':
+            ast.Constant('SteadyStateSensitivityMode'),
+        'amici::realtype': ast.Name('float'),
+        'DoubleVector': ast.Constant('numpy.ndarray'),
+        'IntVector': ast.Name('List[int]'),
+        'std::string': ast.Name('str'),
+        'std::string const &': ast.Name('str'),
+        'std::unique_ptr< amici::ExpData >': ast.Constant('ExpData'),
+        'std::unique_ptr< amici::ReturnData >': ast.Constant('ReturnData'),
+        'std::vector< amici::ParameterScaling,'
+        'std::allocator< amici::ParameterScaling > > const &':
+            ast.Constant('ParameterScalingVector')
+
     }
 
     def visit_FunctionDef(self, node):
         # Has a return type annotation?
         if node.returns:
-            node.returns.value = self._new_annot(node.returns.value)
+            node.returns = self._new_annot(node.returns.value)
 
         # Has arguments?
         if node.args.args:
             for arg in node.args.args:
                 if not arg.annotation:
                     continue
-                arg.annotation.value = self._new_annot(arg.annotation.value)
+                arg.annotation = self._new_annot(arg.annotation.value)
         return node
 
-    def _new_annot(self, old_annot):
-        return self.mapping.get(old_annot, old_annot)
+    def _new_annot(self, old_annot: str):
+        try:
+            return self.mapping[old_annot]
+        except KeyError:
+            # std::vector size type
+            if old_annot.startswith("std::vector< ") \
+                    and old_annot.endswith(" >::size_type"):
+                return ast.Name("int")
+            # std::vector value type
+            if (value_type := re.sub(
+                    r'std::vector< (.*) >::value_type( const &)?',
+                    r'\1', old_annot)) in self.mapping:
+                return self.mapping[value_type]
+            # std::vector
+            if (value_type := re.sub(
+                    r'std::vector< (.*),std::allocator< \1 > >',
+                    r'\1', old_annot)) in self.mapping:
+                value_type_annot = self.mapping[value_type]
+                if isinstance(value_type_annot, ast.Constant):
+                    return ast.Name(f"Tuple['{value_type_annot.value}']")
+                if isinstance(value_type_annot, ast.Name):
+                    return ast.Name(f"Tuple[{value_type_annot.id}]")
+
+            return ast.Constant(old_annot)
 
 
 def fix_typehints(infilename, outfilename):

--- a/swig/amici.i
+++ b/swig/amici.i
@@ -265,8 +265,7 @@ if sys.platform == 'win32':
 
 // import additional types for typehints
 %pythonbegin %{
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Iterable, List, Tuple, Sequence
 if TYPE_CHECKING:
-    from typing import Iterable, List, Tuple
     import numpy
 %}


### PR DESCRIPTION
Replaces a big part of the swig-generated C++ annotations by proper Python annotations, so that they can actually be used for type checking.