### PR TITLE
Add downstream test for pypesto

### DIFF
--- a/.github/workflows/test_downstream.yml
+++ b/.github/workflows/test_downstream.yml
@@ -38,10 +38,9 @@ jobs:
       run: |
         scripts/installAmiciSource.sh
 
-    - name: Install pyPESTO
+    - name: Download pyPESTO
       run: |
         git clone https://github.com/ICB-DCM/pyPESTO.git
-        cd pyPESTO
 
     - name: Run pyPESTO tests
       run: |

--- a/.github/workflows/test_downstream.yml
+++ b/.github/workflows/test_downstream.yml
@@ -38,6 +38,13 @@ jobs:
       run: |
         scripts/installAmiciSource.sh
 
+    - name: Download BioNetGen
+      run: |      
+        wget -q -O bionetgen.tar \
+          https://github.com/RuleWorld/bionetgen/releases/download/BioNetGen-2.7.0/BioNetGen-2.6.0-linux.tgz
+        tar -xf bionetgen.tar
+        echo "BNGPATH=${pwd}/BioNetGen-2.7.0" >> $GITHUB_ENV
+
     - name: Download pyPESTO
       run: |
         git clone https://github.com/ICB-DCM/pyPESTO.git

--- a/.github/workflows/test_downstream.yml
+++ b/.github/workflows/test_downstream.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [3.10]
+        python-version: ['3.10']
 
     steps:
     - name: Set up Python ${{ matrix.python-version }}
@@ -22,23 +22,12 @@ jobs:
     - name: Install AMICI apt dependencies
       run: |
         sudo apt-get update && sudo apt-get install -y \
-          cmake \
-          g++ \
-          libatlas-base-dev \
-          libboost-serialization-dev \
-          libhdf5-serial-dev \
-          python3-venv \
           swig \
-          lcov \
-          libboost-math-dev
+          libatlas-base-dev
 
-    - name: Build AMICI dependencies
+    - name: Install AMICI
       run: |
-        scripts/buildDependencies.sh
-
-    - name: Build AMICI
-      run: |
-        scripts/buildAmici.sh
+        scripts/installAmiciSource.sh
 
     - name: Install pyPESTO
       run: |

--- a/.github/workflows/test_downstream.yml
+++ b/.github/workflows/test_downstream.yml
@@ -43,7 +43,7 @@ jobs:
         wget -q -O bionetgen.tar \
           https://github.com/RuleWorld/bionetgen/releases/download/BioNetGen-2.7.0/BioNetGen-2.7.0-linux.tgz
         tar -xf bionetgen.tar
-        echo "BNGPATH=${pwd}/BioNetGen-2.7.0" >> $GITHUB_ENV
+        echo "BNGPATH=$(pwd)/BioNetGen-2.7.0" >> $GITHUB_ENV
 
     - name: Download pyPESTO
       run: |

--- a/.github/workflows/test_downstream.yml
+++ b/.github/workflows/test_downstream.yml
@@ -28,7 +28,7 @@ jobs:
       with:
         fetch-depth: 20
 
-    - name: Install AMICI apt dependencies
+    - name: Install AMICI dependencies
       run: |
         sudo apt-get update && sudo apt-get install -y \
           swig \
@@ -40,7 +40,7 @@ jobs:
 
     - name: Install pyPESTO
       run: |
-        git clone git@github.com:ICB-DCM/pyPESTO.git
+        git clone https://github.com/ICB-DCM/pyPESTO.git
         cd pyPESTO
 
     - name: Run pyPESTO tests

--- a/.github/workflows/test_downstream.yml
+++ b/.github/workflows/test_downstream.yml
@@ -41,7 +41,7 @@ jobs:
     - name: Download BioNetGen
       run: |      
         wget -q -O bionetgen.tar \
-          https://github.com/RuleWorld/bionetgen/releases/download/BioNetGen-2.7.0/BioNetGen-2.6.0-linux.tgz
+          https://github.com/RuleWorld/bionetgen/releases/download/BioNetGen-2.7.0/BioNetGen-2.7.0-linux.tgz
         tar -xf bionetgen.tar
         echo "BNGPATH=${pwd}/BioNetGen-2.7.0" >> $GITHUB_ENV
 

--- a/.github/workflows/test_downstream.yml
+++ b/.github/workflows/test_downstream.yml
@@ -1,0 +1,52 @@
+name: Downstream tests
+on:
+  pull_request:
+    branches:
+      - develop
+      - master
+
+jobs:
+  pypesto:
+    name: Test pyPESTO
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: [3.10]
+
+    steps:
+    - name: Set up Python ${{ matrix.python-version }}
+      uses: actions/setup-python@v2
+      with:
+        python-version: ${{ matrix.python-version }}
+
+    - name: Install AMICI apt dependencies
+      run: |
+        sudo apt-get update && sudo apt-get install -y \
+          cmake \
+          g++ \
+          libatlas-base-dev \
+          libboost-serialization-dev \
+          libhdf5-serial-dev \
+          python3-venv \
+          swig \
+          lcov \
+          libboost-math-dev
+
+    - name: Build AMICI dependencies
+      run: |
+        scripts/buildDependencies.sh
+
+    - name: Build AMICI
+      run: |
+        scripts/buildAmici.sh
+
+    - name: Install pyPESTO
+      run: |
+        git clone git@github.com:ICB-DCM/pyPESTO.git
+        cd pyPESTO
+
+    - name: Run pyPESTO tests
+      run: |
+        cd pyPESTO
+        pip install -r requirements-dev.txt
+        tox -e petab

--- a/.github/workflows/test_downstream.yml
+++ b/.github/workflows/test_downstream.yml
@@ -1,4 +1,8 @@
-name: Downstream tests
+# Test downstream tools which may be affected by AMICI API changes
+# These tests are not expected to pass, but can inform about
+# future inconsistencies
+
+name: Downstream
 on:
   pull_request:
     branches:
@@ -7,7 +11,7 @@ on:
 
 jobs:
   pypesto:
-    name: Test pyPESTO
+    name: pyPESTO
     runs-on: ubuntu-latest
     strategy:
       matrix:
@@ -18,6 +22,11 @@ jobs:
       uses: actions/setup-python@v2
       with:
         python-version: ${{ matrix.python-version }}
+
+    - name: Checkout project
+      uses: actions/checkout@master
+      with:
+        fetch-depth: 20
 
     - name: Install AMICI apt dependencies
       run: |


### PR DESCRIPTION
Add downstream tests of tools that depend on AMICI and for which we want to ensure near-continuous compatibility (e.g. pyPESTO). These tests are not expected to pass, but can inform when AMICI changes can lead to problems downstream.