### PR TITLE
PEtab import: Add option for treating fixed parameters as constants

### DIFF
--- a/python/sdist/amici/petab_import.py
+++ b/python/sdist/amici/petab_import.py
@@ -340,14 +340,16 @@ def import_petab_problem(
     return model
 
 
-def check_model(amici_model: amici.Model, petab_problem: petab.Problem) -> None:
+def check_model(
+    amici_model: amici.Model,
+    petab_problem: petab.Problem,
+) -> None:
     """Check that the model is consistent with the PEtab problem."""
     if petab_problem.parameter_df is None:
         return
 
     amici_ids_free = set(amici_model.getParameterIds())
     amici_ids = amici_ids_free | set(amici_model.getFixedParameterIds())
-    petab_ids = set(petab_problem.parameter_df.index)
 
     petab_ids_free = set(petab_problem.parameter_df.loc[
         petab_problem.parameter_df[ESTIMATE] == 1

--- a/python/sdist/amici/petab_import.py
+++ b/python/sdist/amici/petab_import.py
@@ -357,8 +357,8 @@ def check_model(amici_model: amici.Model, petab_problem: petab.Problem) -> None:
             raise ValueError(
                 'The available AMICI model does not support estimating the '
                 'following parameters. Please recompile the model and ensure '
-                'that these parameters are not treated as constants. '
-                'Parameters: '
+                'that these parameters are not treated as constants. Deleting '
+                'the current model might also resolve this. Parameters: '
                 f'{amici_ids_free_required.difference(amici_ids_free)}'
             )
 

--- a/python/sdist/amici/petab_import.py
+++ b/python/sdist/amici/petab_import.py
@@ -117,8 +117,7 @@ def get_fixed_parameters(
     #  turned into AMICI constants
     # due to legacy API, we might not always have a parameter table, though
     fixed_parameters = set()
-    if non_estimated_parameters_as_constants \
-            and petab_problem.parameter_df is not None:
+    if petab_problem.parameter_df is not None:
         all_parameters = get_valid_parameters_for_parameter_table(
             model=petab_problem.model,
             condition_df=petab_problem.condition_df,
@@ -129,8 +128,13 @@ def get_fixed_parameters(
             if petab_problem.measurement_df is not None
             else pd.DataFrame(columns=petab.MEASUREMENT_DF_REQUIRED_COLS),
         )
-        estimated_parameters = petab_problem.parameter_df.index.values[
-                                    petab_problem.parameter_df[ESTIMATE] == 1]
+        if non_estimated_parameters_as_constants:
+            estimated_parameters = \
+                petab_problem.parameter_df.index.values[
+                    petab_problem.parameter_df[ESTIMATE] == 1]
+        else:
+            # don't treat parameter table parameters as constants
+            estimated_parameters = petab_problem.parameter_df.index.values
         fixed_parameters = set(all_parameters) - set(estimated_parameters)
 
     sbml_model = petab_problem.sbml_model

--- a/python/sdist/amici/petab_import.py
+++ b/python/sdist/amici/petab_import.py
@@ -342,25 +342,27 @@ def import_petab_problem(
 
 def check_model(amici_model: amici.Model, petab_problem: petab.Problem) -> None:
     """Check that the model is consistent with the PEtab problem."""
-    if petab_problem.parameter_df is not None:
-        amici_ids_free = set(amici_model.getParameterIds())
-        amici_ids = amici_ids_free | set(amici_model.getFixedParameterIds())
-        petab_ids = set(petab_problem.parameter_df.index)
+    if petab_problem.parameter_df is None:
+        return
 
-        petab_ids_free = set(petab_problem.parameter_df.loc[
-            petab_problem.parameter_df[ESTIMATE] == 1
-        ].index)
+    amici_ids_free = set(amici_model.getParameterIds())
+    amici_ids = amici_ids_free | set(amici_model.getFixedParameterIds())
+    petab_ids = set(petab_problem.parameter_df.index)
 
-        amici_ids_free_required = petab_ids_free.intersection(amici_ids)
+    petab_ids_free = set(petab_problem.parameter_df.loc[
+        petab_problem.parameter_df[ESTIMATE] == 1
+    ].index)
 
-        if not amici_ids_free_required.issubset(amici_ids_free):
-            raise ValueError(
-                'The available AMICI model does not support estimating the '
-                'following parameters. Please recompile the model and ensure '
-                'that these parameters are not treated as constants. Deleting '
-                'the current model might also resolve this. Parameters: '
-                f'{amici_ids_free_required.difference(amici_ids_free)}'
-            )
+    amici_ids_free_required = petab_ids_free.intersection(amici_ids)
+
+    if not amici_ids_free_required.issubset(amici_ids_free):
+        raise ValueError(
+            'The available AMICI model does not support estimating the '
+            'following parameters. Please recompile the model and ensure '
+            'that these parameters are not treated as constants. Deleting '
+            'the current model might also resolve this. Parameters: '
+            f'{amici_ids_free_required.difference(amici_ids_free)}'
+        )
 
 
 def _create_model_output_dir_name(sbml_model: 'libsbml.Model') -> Path:

--- a/python/sdist/amici/petab_import.py
+++ b/python/sdist/amici/petab_import.py
@@ -342,21 +342,25 @@ def import_petab_problem(
 
 def check_model(amici_model: amici.Model, petab_problem: petab.Problem) -> None:
     """Check that the model is consistent with the PEtab problem."""
-    amici_ids_free = set(amici_model.getParameterIds())
-    amici_ids = amici_ids_free | set(amici_model.getFixedParameterIds())
-    petab_ids = set(petab_problem.parameter_df.index)
+    if petab_problem.parameter_df is not None:
+        amici_ids_free = set(amici_model.getParameterIds())
+        amici_ids = amici_ids_free | set(amici_model.getFixedParameterIds())
+        petab_ids = set(petab_problem.parameter_df.index)
 
-    petab_ids_free = set(petab_problem.parameter_df.loc[petab_problem.parameter_df[ESTIMATE] == 1].index)
+        petab_ids_free = set(petab_problem.parameter_df.loc[
+            petab_problem.parameter_df[ESTIMATE] == 1
+        ].index)
 
-    amici_ids_free_required = petab_ids_free.intersection(amici_ids)
+        amici_ids_free_required = petab_ids_free.intersection(amici_ids)
 
-    if not amici_ids_free_required.issubset(amici_ids_free):
-        raise ValueError(
-            'The available AMICI model does not support estimating the '
-            'following parameters. Please recompile the model and ensure that '
-            'these parameters are not treated as constants. '
-            f'Parameters: {amici_ids_free_required.difference(amici_ids_free)}'
-        )
+        if not amici_ids_free_required.issubset(amici_ids_free):
+            raise ValueError(
+                'The available AMICI model does not support estimating the '
+                'following parameters. Please recompile the model and ensure '
+                'that these parameters are not treated as constants. '
+                'Parameters: '
+                f'{amici_ids_free_required.difference(amici_ids_free)}'
+            )
 
 
 def _create_model_output_dir_name(sbml_model: 'libsbml.Model') -> Path:

--- a/python/sdist/amici/petab_import.py
+++ b/python/sdist/amici/petab_import.py
@@ -73,7 +73,8 @@ def _add_global_parameter(sbml_model: libsbml.Model,
 
 
 def get_fixed_parameters(
-        petab_problem: petab.Problem
+        petab_problem: petab.Problem,
+        non_estimated_parameters_as_constants=True,
 ) -> List[str]:
     """
     Determine, set and return fixed model parameters.
@@ -84,6 +85,12 @@ def get_fixed_parameters(
 
     :param petab_problem:
         The PEtab problem instance
+
+    :param non_estimated_parameters_as_constants:
+        Whether parameters marked as non-estimated in PEtab should be
+        considered constant in AMICI. Setting this to ``True`` will reduce
+        model size and simulation times. If sensitivities with respect to those
+        parameters are required, this should be set to ``False``.
 
     :return:
         List of IDs of parameters which are to be considered constant.
@@ -107,10 +114,11 @@ def get_fixed_parameters(
 
     # if we have a parameter table, all parameters that are allowed to be
     #  listed in the parameter table, but are not marked as estimated, can be
-    #  turned in to AMICI constants
+    #  turned into AMICI constants
     # due to legacy API, we might not always have a parameter table, though
     fixed_parameters = set()
-    if petab_problem.parameter_df is not None:
+    if non_estimated_parameters_as_constants \
+            and petab_problem.parameter_df is not None:
         all_parameters = get_valid_parameters_for_parameter_table(
             model=petab_problem.model,
             condition_df=petab_problem.condition_df,
@@ -234,6 +242,7 @@ def import_petab_problem(
         model_output_dir: Union[str, Path, None] = None,
         model_name: str = None,
         force_compile: bool = False,
+        non_estimated_parameters_as_constants = True,
         **kwargs) -> 'amici.Model':
     """
     Import model from petab problem.
@@ -253,6 +262,12 @@ def import_petab_problem(
     :param force_compile:
         Whether to compile the model even if the target folder is not empty,
         or the model exists already.
+
+    :param non_estimated_parameters_as_constants:
+        Whether parameters marked as non-estimated in PEtab should be
+        considered constant in AMICI. Setting this to ``True`` will reduce
+        model size and simulation times. If sensitivities with respect to those
+        parameters are required, this should be set to ``False``.
 
     :param kwargs:
         Additional keyword arguments to be passed to
@@ -306,6 +321,8 @@ def import_petab_problem(
                 petab_problem=petab_problem,
                 model_name=model_name,
                 model_output_dir=model_output_dir,
+                non_estimated_parameters_as_constants=
+                non_estimated_parameters_as_constants,
                 **kwargs)
 
     # import model
@@ -373,6 +390,7 @@ def import_model_sbml(
         verbose: Optional[Union[bool, int]] = True,
         allow_reinit_fixpar_initcond: bool = True,
         validate: bool = True,
+        non_estimated_parameters_as_constants=True,
         **kwargs) -> amici.SbmlImporter:
     """
     Create AMICI model from PEtab problem
@@ -414,6 +432,12 @@ def import_model_sbml(
 
     :param validate:
         Whether to validate the PEtab problem
+
+    :param non_estimated_parameters_as_constants:
+        Whether parameters marked as non-estimated in PEtab should be
+        considered constant in AMICI. Setting this to ``True`` will reduce
+        model size and simulation times. If sensitivities with respect to those
+        parameters are required, this should be set to ``False``.
 
     :param kwargs:
         Additional keyword arguments to be passed to
@@ -591,6 +615,8 @@ def import_model_sbml(
     fixed_parameters.extend(
         get_fixed_parameters(
             petab_problem=petab_problem,
+            non_estimated_parameters_as_constants=
+            non_estimated_parameters_as_constants,
         ))
 
     logger.debug(f"Fixed parameters are {fixed_parameters}")

--- a/python/sdist/amici/petab_import.py
+++ b/python/sdist/amici/petab_import.py
@@ -332,11 +332,31 @@ def import_petab_problem(
     # import model
     model_module = amici.import_model_module(model_name, model_output_dir)
     model = model_module.getModel()
+    check_model(amici_model=model, petab_problem=petab_problem)
 
     logger.info(f"Successfully loaded model {model_name} "
                 f"from {model_output_dir}.")
 
     return model
+
+
+def check_model(amici_model: amici.Model, petab_problem: petab.Problem) -> None:
+    """Check that the model is consistent with the PEtab problem."""
+    amici_ids_free = set(amici_model.getParameterIds())
+    amici_ids = amici_ids_free | set(amici_model.getFixedParameterIds())
+    petab_ids = set(petab_problem.parameter_df.index)
+
+    petab_ids_free = set(petab_problem.parameter_df.loc[petab_problem.parameter_df[ESTIMATE] == 1].index)
+
+    amici_ids_free_required = petab_ids_free.intersection(amici_ids)
+
+    if not amici_ids_free_required.issubset(amici_ids_free):
+        raise ValueError(
+            'The available AMICI model does not support estimating the '
+            'following parameters. Please recompile the model and ensure that '
+            'these parameters are not treated as constants. '
+            f'Parameters: {amici_ids_free_required.difference(amici_ids_free)}'
+        )
 
 
 def _create_model_output_dir_name(sbml_model: 'libsbml.Model') -> Path:
@@ -640,6 +660,11 @@ def import_model_sbml(
         noise_distributions=noise_distrs,
         verbose=verbose,
         **kwargs)
+
+    # check model
+    model_module = amici.import_model_module(model_name, model_output_dir)
+    model = model_module.getModel()
+    check_model(amici_model=model, petab_problem=petab_problem)
 
     return sbml_importer
 

--- a/python/tests/test_petab_import.py
+++ b/python/tests/test_petab_import.py
@@ -6,8 +6,7 @@ import pandas as pd
 from amici.testing import skip_on_valgrind
 
 
-petab = pytest.importorskip("petab")
-SbmlModel = pytest.importorskip("petab.models.sbml_model.SbmlModel")
+petab = pytest.importorskip("petab", reason="Missing petab")
 amici_petab_import = pytest.importorskip("amici.petab_import")
 
 
@@ -47,6 +46,7 @@ def test_get_fixed_parameters(simple_sbml_model):
     p4: not fixed (via parameter table `estimate=1`)
     p5: fixed (implicitly, because not listed as estimated)
     """
+    from petab.models.sbml_model import SbmlModel
     sbml_doc, sbml_model = simple_sbml_model
     condition_df = petab.get_condition_df(
         pd.DataFrame({
@@ -69,4 +69,7 @@ def test_get_fixed_parameters(simple_sbml_model):
     assert set(amici_petab_import.get_fixed_parameters(petab_problem)) \
         == {"p1", "p3", "p5"}
 
-    # TODO: any non-estimated model parameter should be made constant
+    assert set(amici_petab_import.get_fixed_parameters(
+        petab_problem,
+        non_estimated_parameters_as_constants=False)) \
+        == {"p1", "p5"}


### PR DESCRIPTION
Makes the changes from https://github.com/AMICI-dev/AMICI/pull/1810/ optional, as sometimes users prefer more flexible models.
The default remains to treat non-estimated parameters in PEtab as constants in AMICI.

Also adds a basic check for loading existing models during PEtab, to see if they are compatible to what was supposed to be imported. Only checks non-constant parameter IDs so far. 