### PR TITLE
Make sympy code optimizations optional

### DIFF
--- a/python/tests/test_cxxcodeprinter.py
+++ b/python/tests/test_cxxcodeprinter.py
@@ -10,7 +10,5 @@ def test_optimizations():
         AmiciCxxCodePrinter.optimizations = optims_c99
         cp = AmiciCxxCodePrinter()
         assert "expm1" in cp.doprint(sp.sympify("exp(x) - 1"))
-    except Exception:
-        raise
     finally:
         AmiciCxxCodePrinter.optimizations = old_optim

--- a/python/tests/test_cxxcodeprinter.py
+++ b/python/tests/test_cxxcodeprinter.py
@@ -1,0 +1,16 @@
+from amici.cxxcodeprinter import AmiciCxxCodePrinter
+from sympy.codegen.rewriting import optims_c99
+import sympy as sp
+
+
+def test_optimizations():
+    """Check that AmiciCxxCodePrinter handles optimizations correctly."""
+    try:
+        old_optim = AmiciCxxCodePrinter.optimizations
+        AmiciCxxCodePrinter.optimizations = optims_c99
+        cp = AmiciCxxCodePrinter()
+        assert "expm1" in cp.doprint(sp.sympify("exp(x) - 1"))
+    except Exception:
+        raise
+    finally:
+        AmiciCxxCodePrinter.optimizations = old_optim


### PR DESCRIPTION
Turns out that applying sympy optimizations as introduced in https://github.com/AMICI-dev/AMICI/pull/1377 is potentially very costly. Therefore, they are disabled by default. They can be enabled by setting `AmiciCxxCodePrinter.optimizations` as shown in the test case.