### PR TITLE
Code-gen: Fix missing `return` in non-void-returning functions

### DIFF
--- a/python/sdist/amici/ode_export.py
+++ b/python/sdist/amici/ode_export.py
@@ -3388,23 +3388,22 @@ def get_model_override_implementation(fun: str, name: str,
     :return:
         C++ function implementation string
     """
-    impl = '{return_type} f{fun}({signature}) override {{'
-
-    if nobody:
-        impl += '}}\n'
-    else:
-        impl += '\n{ind8}{fun}_{name}({eval_signature});\n{ind4}}}\n'
-
     func_info = functions[fun]
-
-    return impl.format(
-        ind4=' ' * 4,
-        ind8=' ' * 8,
+    body = "" if nobody \
+        else '\n{ind8}{maybe_return}{fun}_{name}({eval_signature});{ind4}\n' \
+        .format(
+            ind4=' ' * 4,
+            ind8=' ' * 8,
+            maybe_return="" if func_info.return_type == "void" else "return ",
+            fun=fun,
+            name=name,
+            eval_signature=remove_argument_types(func_info.arguments),
+        )
+    return '{return_type} f{fun}({signature}) override {{{body}}}\n'.format(
+        return_type=func_info.return_type,
         fun=fun,
-        name=name,
         signature=func_info.arguments,
-        eval_signature=remove_argument_types(func_info.arguments),
-        return_type=func_info.return_type
+        body=body,
     )
 
 

--- a/python/sdist/amici/setuptools.py
+++ b/python/sdist/amici/setuptools.py
@@ -213,7 +213,7 @@ def add_debug_flags_if_required(cxx_flags: List[str],
             and os.environ['ENABLE_AMICI_DEBUGGING'] == 'TRUE':
         print("ENABLE_AMICI_DEBUGGING was set to TRUE."
               " Building AMICI with debug symbols.")
-        cxx_flags.extend(['-g', '-O0', '-UNDEBUG'])
+        cxx_flags.extend(['-g', '-O0', '-UNDEBUG', '-Werror'])
         linker_flags.extend(['-g'])
 
 


### PR DESCRIPTION
... and set `-Werror` for compiling models in debug mode.