### PR TITLE
Fix `petab_import.import_model(..., compile=False)` failure

### DIFF
--- a/python/sdist/amici/__init__.py
+++ b/python/sdist/amici/__init__.py
@@ -197,7 +197,6 @@ def _get_default_argument(func: Callable, arg: str) -> Any:
     """Get the default value of the given argument in the given function."""
     import inspect
     signature = inspect.signature(func)
-    print(signature, signature.parameters)
     if (default := signature.parameters[arg].default) is not inspect.Parameter.empty:
         return default
     raise ValueError(f"No default value for argument {arg} of {func}.")

--- a/python/sdist/amici/__init__.py
+++ b/python/sdist/amici/__init__.py
@@ -28,7 +28,7 @@ import re
 import sys
 from pathlib import Path
 from types import ModuleType as ModelModule
-from typing import Optional, Union
+from typing import Optional, Union, Callable, Any
 
 
 def _get_amici_path():
@@ -191,3 +191,13 @@ class AmiciVersionError(RuntimeError):
     """Error thrown if an AMICI model is loaded that is incompatible with
     the installed AMICI base package"""
     pass
+
+
+def _get_default_argument(func: Callable, arg: str) -> Any:
+    """Get the default value of the given argument in the given function."""
+    import inspect
+    signature = inspect.signature(func)
+    print(signature, signature.parameters)
+    if (default := signature.parameters[arg].default) is not inspect.Parameter.empty:
+        return default
+    raise ValueError(f"No default value for argument {arg} of {func}.")

--- a/python/sdist/amici/petab_import.py
+++ b/python/sdist/amici/petab_import.py
@@ -669,10 +669,12 @@ def import_model_sbml(
         verbose=verbose,
         **kwargs)
 
-    # check model
-    model_module = amici.import_model_module(model_name, model_output_dir)
-    model = model_module.getModel()
-    check_model(amici_model=model, petab_problem=petab_problem)
+    if kwargs.get('compile', amici._get_default_argument(
+            sbml_importer.sbml2amici, 'compile')):
+        # check that the model extension was compiled successfully
+        model_module = amici.import_model_module(model_name, model_output_dir)
+        model = model_module.getModel()
+        check_model(amici_model=model, petab_problem=petab_problem)
 
     return sbml_importer
 

--- a/python/tests/test_misc.py
+++ b/python/tests/test_misc.py
@@ -103,3 +103,17 @@ def test_monkeypatch():
 
     # check that the monkeypatch is transient
     assert (t ** n).diff(t).subs(vals) is sp.nan
+
+
+@skip_on_valgrind
+def test_get_default_argument():
+    # no default
+    with pytest.raises(ValueError):
+        amici._get_default_argument(lambda x: x, 'x')
+
+    # non-existant parameter
+    with pytest.raises(KeyError):
+        amici._get_default_argument(lambda x: x, 'y')
+
+    # okay
+    assert amici._get_default_argument(lambda x=1: x, 'x') == 1


### PR DESCRIPTION
Fixes a bug where amici would fail importing an extension that was never built.