### PR TITLE
Update clang-format style, fix clang-format target

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,96 +1,13 @@
 ---
+BasedOnStyle: LLVM
+IndentWidth: 4
+---
 Language:        Cpp
-# BasedOnStyle:  LLVM
-AccessModifierOffset: -2
-AlignAfterOpenBracket: Align
-AlignConsecutiveAssignments: false
-AlignConsecutiveDeclarations: false
-AlignEscapedNewlinesLeft: false
-AlignOperands:   true
-AlignTrailingComments: true
-AllowAllParametersOfDeclarationOnNextLine: true
-AllowShortBlocksOnASingleLine: false
-AllowShortCaseLabelsOnASingleLine: false
-AllowShortFunctionsOnASingleLine: All
-AllowShortIfStatementsOnASingleLine: false
-AllowShortLoopsOnASingleLine: false
-AlwaysBreakAfterDefinitionReturnType: None
-AlwaysBreakAfterReturnType: None
-AlwaysBreakBeforeMultilineStrings: false
-AlwaysBreakTemplateDeclarations: false
-BinPackArguments: true
-BinPackParameters: true
-BraceWrapping:   
-  AfterClass:      false
-  AfterControlStatement: false
-  AfterEnum:       false
-  AfterFunction:   false
-  AfterNamespace:  false
-  AfterObjCDeclaration: false
-  AfterStruct:     false
-  AfterUnion:      false
-  BeforeCatch:     false
-  BeforeElse:      false
-  IndentBraces:    false
-BreakBeforeBinaryOperators: None
-BreakBeforeBraces: Attach
-BreakBeforeTernaryOperators: true
-BreakConstructorInitializersBeforeComma: false
-BreakAfterJavaFieldAnnotations: false
-BreakStringLiterals: true
-ColumnLimit:     80
-CommentPragmas:  '^ IWYU pragma:'
-ConstructorInitializerAllOnOneLineOrOnePerLine: false
-ConstructorInitializerIndentWidth: 4
-ContinuationIndentWidth: 4
-Cpp11BracedListStyle: true
-DerivePointerAlignment: false
-DisableFormat:   false
-ExperimentalAutoDetectBinPacking: false
-ForEachMacros:   [ foreach, Q_FOREACH, BOOST_FOREACH ]
-IncludeCategories: 
-  - Regex:           '^"(llvm|llvm-c|clang|clang-c)/'
-    Priority:        2
-  - Regex:           '^(<|"(gtest|isl|json)/)'
-    Priority:        3
-  - Regex:           '.*'
-    Priority:        1
-IncludeIsMainRegex: '$'
-IndentCaseLabels: false
-IndentWidth:     4
-IndentWrappedFunctionNames: false
-JavaScriptQuotes: Leave
-JavaScriptWrapImports: true
-KeepEmptyLinesAtTheStartOfBlocks: true
-MacroBlockBegin: ''
-MacroBlockEnd:   ''
-MaxEmptyLinesToKeep: 1
-NamespaceIndentation: None
-ObjCBlockIndentWidth: 2
-ObjCSpaceAfterProperty: false
-ObjCSpaceBeforeProtocolList: true
-PenaltyBreakBeforeFirstCallParameter: 19
-PenaltyBreakComment: 300
-PenaltyBreakFirstLessLess: 120
-PenaltyBreakString: 1000
-PenaltyExcessCharacter: 1000000
-PenaltyReturnTypeOnItsOwnLine: 60
-PointerAlignment: Right
-ReflowComments:  true
-SortIncludes:    true
-SpaceAfterCStyleCast: false
-SpaceAfterTemplateKeyword: true
-SpaceBeforeAssignmentOperators: true
-SpaceBeforeParens: ControlStatements
-SpaceInEmptyParentheses: false
-SpacesBeforeTrailingComments: 1
-SpacesInAngles:  false
-SpacesInContainerLiterals: true
-SpacesInCStyleCastParentheses: false
-SpacesInParentheses: false
-SpacesInSquareBrackets: false
-Standard:        Cpp11
-TabWidth:        8
-UseTab:          Never
-...
-
+AlignAfterOpenBracket: BlockIndent
+BreakBeforeBinaryOperators: All
+BreakConstructorInitializers: BeforeComma
+ColumnLimit: 80
+PointerAlignment: Left
+QualifierAlignment: Custom
+QualifierOrder: ['inline', 'static', 'type', 'const']
+ReferenceAlignment: Left

--- a/cmake/clang-tools.cmake
+++ b/cmake/clang-tools.cmake
@@ -12,7 +12,7 @@ find_program(CLANG_FORMAT "clang-format")
 if(CLANG_FORMAT)
     add_custom_target(
         clang-format
-        COMMAND bash -c "/usr/bin/clang-format -i ${ALL_CXX_SOURCE_FILES}"
+        COMMAND bash -c "${CLANG_FORMAT} -i ${ALL_CXX_SOURCE_FILES}"
         WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}
         )
 else()
@@ -26,7 +26,7 @@ find_program(CLANG_TIDY "clang-tidy")
 if(CLANG_TIDY)
     add_custom_target(
         clang-tidy
-        COMMAND sh -c "/usr/bin/clang-tidy ${ALL_CXX_SOURCE_FILES} -- -std=c++11 -I${CMAKE_SOURCE_DIR}"
+        COMMAND sh -c "${CLANG_TIDY} ${ALL_CXX_SOURCE_FILES} -- -std=c++14 -I${CMAKE_SOURCE_DIR}"
         WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}
         )
 else()

--- a/cmake/clang-tools.cmake
+++ b/cmake/clang-tools.cmake
@@ -1,7 +1,7 @@
 ######### Add targets for clang-format and clang-tidy ############
 
 # Find all source files
-execute_process(COMMAND sh -c "git ls-tree -r HEAD --name-only src/*.cpp include/*.h | tr '\n' ' '"
+execute_process(COMMAND sh -c "git ls-tree -r HEAD --name-only src/*.cpp include/amici/*.h | tr '\n' ' '"
     WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}
     OUTPUT_VARIABLE ALL_CXX_SOURCE_FILES
     )


### PR DESCRIPTION
Previously, `make clang-format` missed all header files.