### PR TITLE
PEtab import: fix handling of fixed parameters for rule targets

### DIFF
--- a/python/sdist/amici/petab_import.py
+++ b/python/sdist/amici/petab_import.py
@@ -176,6 +176,13 @@ def get_fixed_parameters(
                            " model. Ignoring.")
             fixed_parameters.remove(fixed_parameter)
 
+    # exclude targets of rules or initial assignments
+    for fixed_parameter in fixed_parameters.copy():
+        # check global parameters
+        if sbml_model.getInitialAssignmentBySymbol(fixed_parameter)\
+                or sbml_model.getRuleByVariable(fixed_parameter):
+            fixed_parameters.remove(fixed_parameter)
+
     return list(sorted(fixed_parameters))
 
 


### PR DESCRIPTION
Previously, targets of initial assignments or rules could have been selected as fixed parameters, which would lead to errors during model import. Those target parameters should be ignored.