### PR TITLE
Fix 'operator ==' swig warning

### DIFF
--- a/swig/amici.i
+++ b/swig/amici.i
@@ -63,6 +63,9 @@ nonstandard type conversions.
     }
 }
 
+// Warning 503: Can't wrap 'operator ==' unless renamed to a valid identifier.
+%rename("__eq__") operator ==;
+
 %{
 #define SWIG_FILE_WITH_INIT
 #define NPY_NO_DEPRECATED_API NPY_1_7_API_VERSION


### PR DESCRIPTION
Fixes
> amici/include/amici/edata.h:118: Warning 503: Can't wrap 'operator ==' unless renamed to a valid identifier.