### PR TITLE
Prevent swig4.0.1 segfault

### DIFF
--- a/include/amici/logging.h
+++ b/include/amici/logging.h
@@ -45,6 +45,8 @@ class Logger
      * @param ... arguments to be formatted
      */
 #else
+    // swig 4.0.1 segfaults on "@param ..."
+    // see https://github.com/swig/swig/issues/1643
     /**
      * @brief Add a log entry with printf-like message formatting
      * @param severity Severity level

--- a/include/amici/logging.h
+++ b/include/amici/logging.h
@@ -41,13 +41,13 @@ class Logger
      * @param severity Severity level
      * @param identifier Short identifier for the logged event
      * @param format printf format string
+#if SWIG_VERSION >= 0x040002
      * @param ... arguments to be formatted
+#endif
      */
-    void log(
-        LogSeverity severity,
-        std::string const& identifier,
-        const char* format, ...
-        );
+    void
+    log(LogSeverity severity, std::string const& identifier, char const* format,
+        ...);
 
     /** The log items */
     std::vector<LogItem> items;

--- a/include/amici/logging.h
+++ b/include/amici/logging.h
@@ -36,15 +36,22 @@ class Logger
         std::string const& message
         );
 
+#if SWIG_VERSION >= 0x040002
     /**
      * @brief Add a log entry with printf-like message formatting
      * @param severity Severity level
      * @param identifier Short identifier for the logged event
      * @param format printf format string
-#if SWIG_VERSION >= 0x040002
      * @param ... arguments to be formatted
-#endif
      */
+#else
+    /**
+     * @brief Add a log entry with printf-like message formatting
+     * @param severity Severity level
+     * @param identifier Short identifier for the logged event
+     * @param format printf format string
+     */
+#endif
     void
     log(LogSeverity severity, std::string const& identifier, char const* format,
         ...);


### PR DESCRIPTION
swig 4.0.1 is the default on Ubuntu 20.04 LTS which is still in use.