### PR TITLE
More informative `Solver.__repr__`

### DIFF
--- a/python/sdist/amici/swig.py
+++ b/python/sdist/amici/swig.py
@@ -133,6 +133,10 @@ class TypeHintFixer(ast.NodeTransformer):
             for arg in node.args.args:
                 if not arg.annotation:
                     continue
+                if isinstance(arg.annotation, ast.Name):
+                    # there is already proper annotation
+                    continue
+
                 arg.annotation = self._new_annot(arg.annotation.value)
         return node
 

--- a/python/tests/test_swig_interface.py
+++ b/python/tests/test_swig_interface.py
@@ -405,5 +405,5 @@ def test_model_instance_settings_custom_x0(pysb_example_presimulation_module):
 
 
 def test_solver_repr_doesnt_raise():
-    print(str(amici.CVodeSolver()))
+    print(amici.CVodeSolver())
     print(repr(amici.CVodeSolver()))

--- a/python/tests/test_swig_interface.py
+++ b/python/tests/test_swig_interface.py
@@ -405,12 +405,13 @@ def test_model_instance_settings_custom_x0(pysb_example_presimulation_module):
 
 
 def test_solver_repr():
-    solver = amici.CVodeSolver()
-    assert "maxsteps" in str(solver)
-    assert "maxsteps" in repr(solver)
+    for solver in (amici.CVodeSolver(), amici.IDASolver()):
+        assert "maxsteps" in str(solver)
+        assert "maxsteps" in repr(solver)
 
-    solver_ptr = amici.SolverPtr(solver.this)
-    assert "maxsteps" in str(solver_ptr)
-    assert "maxsteps" in repr(solver_ptr)
-    # avoid double delete!!
-    solver_ptr.release()
+        solver_ptr = amici.SolverPtr(solver.this)
+        assert "maxsteps" in str(solver_ptr)
+        assert "maxsteps" in repr(solver_ptr)
+        # avoid double delete!!
+        solver_ptr.release()
+

--- a/python/tests/test_swig_interface.py
+++ b/python/tests/test_swig_interface.py
@@ -403,3 +403,7 @@ def test_model_instance_settings_custom_x0(pysb_example_presimulation_module):
     assert model2.getInitialStateSensitivities() == sx0
     assert settings == amici.get_model_settings(model2)
 
+
+def test_solver_repr_doesnt_raise():
+    print(str(amici.CVodeSolver()))
+    print(repr(amici.CVodeSolver()))

--- a/python/tests/test_swig_interface.py
+++ b/python/tests/test_swig_interface.py
@@ -404,6 +404,13 @@ def test_model_instance_settings_custom_x0(pysb_example_presimulation_module):
     assert settings == amici.get_model_settings(model2)
 
 
-def test_solver_repr_doesnt_raise():
-    print(amici.CVodeSolver())
-    print(repr(amici.CVodeSolver()))
+def test_solver_repr():
+    solver = amici.CVodeSolver()
+    assert "maxsteps" in str(solver)
+    assert "maxsteps" in repr(solver)
+
+    solver_ptr = amici.SolverPtr(solver.this)
+    assert "maxsteps" in str(solver_ptr)
+    assert "maxsteps" in repr(solver_ptr)
+    # avoid double delete!!
+    solver_ptr.release()

--- a/swig/solver.i
+++ b/swig/solver.i
@@ -50,7 +50,7 @@ def __repr__(self):
         f"{RDataReporting(self.getReturnDataReportingMode())!r}",
         f"  sens_meth: {SensitivityMethod(self.getSensitivityMethod())!r}",
         f"  sens_order: {SensitivityOrder(self.getSensitivityOrder())!r}",
-        f"  sens_order: {SensitivityMethod(self.getSensitivityMethodPreequilibration())!r}",
+        f"  sens_meth_preeq: {SensitivityMethod(self.getSensitivityMethodPreequilibration())!r}",
         f"  maxsteps: {self.getMaxSteps()}",
         f"  maxtime: {self.getMaxTime()}s",
         f"  abs_tol: {self.getAbsoluteTolerance()}",

--- a/swig/solver.i
+++ b/swig/solver.i
@@ -40,6 +40,50 @@ using namespace amici;
 %ignore getRootInfo;
 %ignore updateAndReinitStatesAndSensitivities;
 
+// Solver.__repr__
+%extend amici::CVodeSolver {
+%pythoncode %{
+def __repr__(self):
+    return "\n".join([
+        self.this.__repr__()[:-1],
+        "  reporting_mode: "
+        f"{RDataReporting(self.getReturnDataReportingMode())!r}",
+        f"  sens_meth: {SensitivityMethod(self.getSensitivityMethod())!r}",
+        f"  sens_order: {SensitivityOrder(self.getSensitivityOrder())!r}",
+        f"  sens_order: {SensitivityMethod(self.getSensitivityMethodPreequilibration())!r}",
+        f"  maxsteps: {self.getMaxSteps()}",
+        f"  maxtime: {self.getMaxTime()}s",
+        f"  abs_tol: {self.getAbsoluteTolerance()}",
+        f"  rel_tol: {self.getRelativeTolerance()}",
+        f"  abs_tol_b: {self.getAbsoluteToleranceB()}",
+        f"  rel_tol_b: {self.getRelativeToleranceB()}",
+        f"  abs_tol_fsa: {self.getAbsoluteToleranceFSA()}",
+        f"  rel_tol_fsa: {self.getRelativeToleranceFSA()}",
+        f"  abs_tol_quad: {self.getAbsoluteToleranceQuadratures()}",
+        f"  rel_tol_quad: {self.getRelativeToleranceQuadratures()}",
+        f"  abs_tol_ss: {self.getAbsoluteToleranceSteadyState()}",
+        f"  rel_tol_ss: {self.getRelativeToleranceSteadyState()}",
+        f"  abs_tol_sss: {self.getAbsoluteToleranceSteadyStateSensi()}",
+        f"  rel_tol_sss: {self.getRelativeToleranceSteadyStateSensi()}",
+        f"  int_sens_meth: {InternalSensitivityMethod(self.getInternalSensitivityMethod())!r}",
+        f"  int_type: {InterpolationType(self.getInterpolationType())!r}",
+        f"  linsol: {LinearSolver(self.getLinearSolver())!r}",
+        f"  lmm: {LinearMultistepMethod(self.getLinearMultistepMethod())!r}",
+        f"  newton_damp_mode: {NewtonDampingFactorMode(self.getNewtonDampingFactorMode())!r}",
+        f"  newton_damp_lb: {self.getNewtonDampingFactorLowerBound()}",
+        f"  newton_maxsteps: {self.getNewtonMaxSteps()}",
+        f"  newton_ss_check: {self.getNewtonStepSteadyStateCheck()}",
+        f"  sens_ss_check: {self.getSensiSteadyStateCheck()}",
+        f"  interpolation_type: {InterpolationType(self.getInterpolationType())!r}",
+        f"  ism: {InternalSensitivityMethod(self.getInternalSensitivityMethod())!r}",
+        f"  nlsol_iter: {NonlinearSolverIteration(self.getNonlinearSolverIteration())!r}",
+        f"  stability_limit: {self.getStabilityLimitFlag()}",
+        f"  state_ordering: {self.getStateOrdering()}",
+        ">"
+    ])
+%}
+};
+
 
 %newobject amici::Solver::clone;
 // Process symbols in header

--- a/swig/solver.i
+++ b/swig/solver.i
@@ -41,9 +41,8 @@ using namespace amici;
 %ignore updateAndReinitStatesAndSensitivities;
 
 // Solver.__repr__
-%extend amici::CVodeSolver {
 %pythoncode %{
-def __repr__(self):
+def _solver_repr(self: Solver):
     return "\n".join([
         self.this.__repr__()[:-1],
         "  reporting_mode: "
@@ -81,6 +80,24 @@ def __repr__(self):
         f"  state_ordering: {self.getStateOrdering()}",
         ">"
     ])
+%}
+%extend amici::CVodeSolver {
+%pythoncode %{
+def __repr__(self):
+    return _solver_repr(self)
+%}
+};
+%extend amici::IDASolver {
+%pythoncode %{
+def __repr__(self):
+    return _solver_repr(self)
+%}
+};
+
+%extend std::unique_ptr<amici::Solver> {
+%pythoncode %{
+def __repr__(self):
+    return _solver_repr(self)
 %}
 };
 

--- a/swig/solver.i
+++ b/swig/solver.i
@@ -42,7 +42,7 @@ using namespace amici;
 
 // Solver.__repr__
 %pythoncode %{
-def _solver_repr(self: Solver):
+def _solver_repr(self: "Solver"):
     return "\n".join([
         self.this.__repr__()[:-1],
         "  reporting_mode: "


### PR DESCRIPTION
Closes #1926

Output of `print(amici.CVodeSolver())`:

```
<Swig Object of type 'amici::CVodeSolver *' at 0x7f988f70f090
  reporting_mode: <RDataReporting.full: 0>
  sens_meth: <SensitivityMethod.forward: 1>
  sens_order: <SensitivityOrder.none: 0>
  sens_meth_preeq: <SensitivityMethod.forward: 1>
  maxsteps: 10000
  maxtime: 1.7976931348623157e+308s
  abs_tol: 1e-16
  rel_tol: 1e-08
  abs_tol_b: 1e-16
  rel_tol_b: 1e-08
  abs_tol_fsa: 1e-16
  rel_tol_fsa: 1e-08
  abs_tol_quad: 1e-12
  rel_tol_quad: 1e-08
  abs_tol_ss: 1e-14
  rel_tol_ss: 1e-06
  abs_tol_sss: 1e-14
  rel_tol_sss: 1e-06
  int_sens_meth: <InternalSensitivityMethod.simultaneous: 1>
  int_type: <InterpolationType.hermite: 1>
  linsol: <LinearSolver.KLU: 9>
  lmm: <LinearMultistepMethod.BDF: 2>
  newton_damp_mode: <NewtonDampingFactorMode.on: 1>
  newton_damp_lb: 1e-08
  newton_maxsteps: 0
  newton_ss_check: False
  sens_ss_check: True
  interpolation_type: <InterpolationType.hermite: 1>
  ism: <InternalSensitivityMethod.simultaneous: 1>
  nlsol_iter: <NonlinearSolverIteration.newton: 2>
  stability_limit: True
  state_ordering: 0
>
```