### PR TITLE
Make model module accessible from model instance

### DIFF
--- a/python/sdist/amici/__init__.py
+++ b/python/sdist/amici/__init__.py
@@ -126,8 +126,13 @@ if not _imported_from_setup():
     class ModelModule(Protocol):
         """Enable Python static type checking for AMICI-generated model
         modules"""
+        module: "ModelModule"
+
         def getModel(self) -> amici.Model:
-            pass
+            ...
+
+        def get_model(self) -> amici.Model:
+            ...
 
 
 class add_path:

--- a/python/sdist/amici/__init__.py
+++ b/python/sdist/amici/__init__.py
@@ -120,13 +120,13 @@ if not _imported_from_setup():
     from .sbml_import import SbmlImporter, assignmentRules2observables
     from .ode_export import ODEModel, ODEExporter
 
-    from typing import Protocol
+    from typing import Protocol, runtime_checkable
 
 
+    @runtime_checkable
     class ModelModule(Protocol):
         """Enable Python static type checking for AMICI-generated model
         modules"""
-        module: "ModelModule"
 
         def getModel(self) -> amici.Model:
             ...

--- a/python/sdist/amici/__init__.template.py
+++ b/python/sdist/amici/__init__.template.py
@@ -14,6 +14,7 @@ if 'TPL_AMICI_VERSION' != amici.__version__:
         'version currently installed.'
     )
 
-from TPL_MODELNAME._TPL_MODELNAME import *
+from .TPL_MODELNAME import *
+from .TPL_MODELNAME import getModel as get_model
 
 __version__ = 'TPL_PACKAGE_VERSION'

--- a/python/tests/test_sbml_import.py
+++ b/python/tests/test_sbml_import.py
@@ -180,6 +180,11 @@ def test_logging_works(observable_dependent_error_model, caplog):
     assert rdata.status != amici.AMICI_SUCCESS
     assert "mxstep steps taken" in caplog.text
 
+@skip_on_valgrind
+def test_model_module_is_set(observable_dependent_error_model):
+    model_module = observable_dependent_error_model
+    assert isinstance(model_module.getModel().module, amici.ModelModule)
+
 
 @pytest.fixture(scope='session')
 def model_steadystate_module():

--- a/swig/modelname.template.i
+++ b/swig/modelname.template.i
@@ -10,5 +10,12 @@ using namespace amici;
 %}
 
 
+// Make model module accessible from the model
+%feature("pythonappend") amici::generic_model::getModel %{
+    import sys
+    val.module = sys.modules['.'.join(__name__.split('.')[:-1])]
+%}
+
+
 // Process symbols in header
 %include "wrapfunctions.h"


### PR DESCRIPTION
This makes it more convenient to create a new (unmodified) model instance, or to find out where the model files are located.

Also adds a snake_case version of `getModel`.