### PR TITLE
Add CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,5 @@
+# see https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners
+
+# default owners
+* @AMICI-dev/amici-maintainers
+


### PR DESCRIPTION
Not much to see. This is for auto-assigning reviewers to pull requests.