### PR TITLE
Change default interpolation type from hermite to polynomial

### DIFF
--- a/include/amici/solver.h
+++ b/include/amici/solver.h
@@ -1602,7 +1602,7 @@ class Solver {
     /** interpolation type for the forward problem solution which
      * is then used for the backwards problem.
      */
-    InterpolationType interp_type_ {InterpolationType::hermite};
+    InterpolationType interp_type_ {InterpolationType::polynomial};
 
     /** maximum number of allowed integration steps */
     long int maxsteps_ {10000};


### PR DESCRIPTION
According to [CVODES docs](https://sundials.readthedocs.io/en/latest/cvodes/Mathematics_link.html#checkpointing-scheme), polynomial should be the better choice:

> The variable-degree polynomial is more memory-efficient (it requires only half of the memory storage of the cubic Hermite interpolation) and is more accurate.