### PR TITLE
GHA: Fix boost paths

### DIFF
--- a/.github/workflows/test_python_cplusplus.yml
+++ b/.github/workflows/test_python_cplusplus.yml
@@ -162,8 +162,8 @@ jobs:
         brew install hdf5 swig gcc cppcheck libomp boost \
           && brew ls -v boost \
           && brew ls -v libomp \
-          && echo LDFLAGS="-L/usr/local/lib/ -L/usr/local/Cellar/boost/1.80.0/lib/" >> $GITHUB_ENV \
-          && echo CPPFLAGS="-I/usr/local/Cellar/boost/1.80.0/include/" >> $GITHUB_ENV
+          && echo LDFLAGS="-L/usr/local/lib/ -L/usr/local/Cellar/boost/1.81.0_1/lib/" >> $GITHUB_ENV \
+          && echo CPPFLAGS="-I /usr/local/Cellar/boost/1.81.0_1/include/" >> $GITHUB_ENV
 
     - name: Build AMICI
       run: |


### PR DESCRIPTION
Adapt to new default homebrew version.

Should fix current failures in, e.g., https://github.com/AMICI-dev/AMICI/actions/runs/4022709019/jobs/6912732658