### PR TITLE
Fix MSVC builds / remove -W* flags

### DIFF
--- a/python/sdist/amici/setuptools.py
+++ b/python/sdist/amici/setuptools.py
@@ -215,8 +215,13 @@ def add_debug_flags_if_required(cxx_flags: List[str],
             and os.environ['ENABLE_AMICI_DEBUGGING'] == 'TRUE':
         print("ENABLE_AMICI_DEBUGGING was set to TRUE."
               " Building AMICI with debug symbols.")
-        cxx_flags.extend(['-g', '-O0', '-UNDEBUG', '-Werror',
-                          '-Wno-error=deprecated-declarations'])
+        cxx_flags.extend(['-g', '-O0', '-UNDEBUG'])
+        if sys.platform != "win32":
+            # these options are incompatible with MSVC, but there is no easy
+            # way to detect which compiler will be used. so we just skip them
+            # altogether on windows.
+            cxx_flags.extend(['-Werror', '-Wno-error=deprecated-declarations'])
+
         linker_flags.extend(['-g'])
 
 


### PR DESCRIPTION
Removes `-W` compiler flags on Windows, which aren't understood by MSVC.

Fixes `cl : Command line error D8021 : invalid numeric argument '/Werror'` (which for some reason currently only occurs on branch `adjoint_event` :man_shrugging:)

See also https://learn.microsoft.com/en-us/cpp/build/reference/wx-treat-linker-warnings-as-errors?view=msvc-170