### PR TITLE
Restructure sphinx doc

### DIFF
--- a/documentation/CPP.rst
+++ b/documentation/CPP.rst
@@ -3,6 +3,8 @@ C++ interface
 
 .. toctree::
    :maxdepth: 2
+   :caption: C++
+
 
    Installation <cpp_installation>
    Usage <cpp_interface>

--- a/documentation/MATLAB.rst
+++ b/documentation/MATLAB.rst
@@ -3,6 +3,7 @@ Matlab interface
 
 .. toctree::
    :maxdepth: 2
+   :caption: MATLAB
 
    Installation <matlab_installation>
    Usage <matlab_interface>

--- a/documentation/PYTHON.rst
+++ b/documentation/PYTHON.rst
@@ -3,8 +3,10 @@ Python interface
 
 .. toctree::
    :maxdepth: 2
+   :caption: Python
 
    Installation <python_installation>
+   Examples <python_examples>
    Usage <python_interface>
    FAQ <python_faq>
    API reference <python_modules>

--- a/documentation/index.rst
+++ b/documentation/index.rst
@@ -30,13 +30,9 @@ Welcome to AMICI's documentation!
    glossary
    contributing
 
-.. toctree::
-   :maxdepth: 2
-   :caption: User's guide
-
-   PYTHON
-   CPP
-   MATLAB
+.. include:: PYTHON.rst
+.. include:: CPP.rst
+.. include:: MATLAB.rst
 
 .. toctree::
    :maxdepth: 2

--- a/documentation/python_examples.rst
+++ b/documentation/python_examples.rst
@@ -1,0 +1,18 @@
+Examples
+========
+
+Various example notebooks.
+
+.. image:: https://mybinder.org/badge_logo.svg
+ :target: https://mybinder.org/v2/gh/AMICI-dev/AMICI/develop?labpath=binder%2Foverview.ipynb
+
+.. toctree::
+   :maxdepth: 1
+
+   GettingStarted.ipynb
+   ExampleSteadystate.ipynb
+   petab.ipynb
+   ExampleExperimentalConditions.ipynb
+   ExampleEquilibrationLogic.ipynb
+   example_errors.ipynb
+   example_large_models/example_performance_optimization.ipynb

--- a/documentation/python_interface.rst
+++ b/documentation/python_interface.rst
@@ -134,23 +134,6 @@ SED-ML import
 We also plan to implement support for the
 `Simulation Experiment Description Markup Language (SED-ML) <https://sed-ml.org/>`_.
 
-Examples
-========
-
-.. image:: https://mybinder.org/badge_logo.svg
- :target: https://mybinder.org/v2/gh/AMICI-dev/AMICI/develop?labpath=binder%2Foverview.ipynb
-
-.. toctree::
-   :maxdepth: 1
-
-   GettingStarted.ipynb
-   ExampleSteadystate.ipynb
-   petab.ipynb
-   ExampleExperimentalConditions.ipynb
-   ExampleEquilibrationLogic.ipynb
-   example_errors.ipynb
-   example_large_models/example_performance_optimization.ipynb
-
 Environment variables affecting model import
 ============================================
 


### PR DESCRIPTION
* Move different interfaces one level up
* Add top-level link to Python examples

[before](https://amici.readthedocs.io/en/develop/) / [after](https://amici--1978.org.readthedocs.build/en/1978/)

