### PR TITLE
Use std::clock for measuring solver time

### DIFF
--- a/include/amici/solver.h
+++ b/include/amici/solver.h
@@ -7,6 +7,7 @@
 #include "amici/logging.h"
 
 #include <cmath>
+#include <ctime>
 #include <functional>
 #include <memory>
 #include <chrono>
@@ -487,7 +488,7 @@ class Solver {
     double getMaxTime() const;
 
     /**
-     * @brief Set the maximum time allowed for integration
+     * @brief Set the maximum CPU time allowed for integration
      * @param maxtime Time in seconds
      */
     void setMaxTime(double maxtime);
@@ -1607,11 +1608,11 @@ class Solver {
     /** maximum number of allowed integration steps */
     long int maxsteps_ {10000};
 
-    /** Maximum wall-time for integration in seconds */
+    /** Maximum CPU-time for integration in seconds */
     std::chrono::duration<double, std::ratio<1>> maxtime_ {std::chrono::duration<double>::max()};
 
     /** Time at which solver timer was started */
-    mutable std::chrono::time_point<std::chrono::system_clock> starttime_;
+    mutable std::clock_t starttime_;
 
     /** linear solver for the forward problem */
     mutable std::unique_ptr<SUNLinSolWrapper> linear_solver_;

--- a/src/solver.cpp
+++ b/src/solver.cpp
@@ -859,12 +859,13 @@ void Solver::setMaxTime(double maxtime)
 
 void Solver::startTimer() const
 {
-    starttime_ = std::chrono::system_clock::now();
+    starttime_ = std::clock();
 }
 
 bool Solver::timeExceeded() const
 {
-    return std::chrono::system_clock::now() - starttime_ > maxtime_;
+    auto cputime_exceed = static_cast<double>(std::clock() - starttime_) / CLOCKS_PER_SEC;
+    return std::chrono::duration<double>(cputime_exceed) > maxtime_;
 }
 
 void Solver::setMaxSteps(const long int maxsteps) {


### PR DESCRIPTION
So far, the value of `Solver::getMaxTime()` was checked against `std::chrono::system_clock`, which measures wall time. This is probably not what we want and can cause issues if a program is paused or the cpu is oversubscribed. Now changed to CPU time.

Closes #1913