### PR TITLE
Change default ReturnData::status to AMICI_NOT_RUN

### DIFF
--- a/include/amici/defines.h
+++ b/include/amici/defines.h
@@ -79,6 +79,7 @@ constexpr int AMICI_DAMPING_FACTOR_ERROR=    -86;
 constexpr int AMICI_SINGULAR_JACOBIAN=      -809;
 constexpr int AMICI_NOT_IMPLEMENTED=        -999;
 constexpr int AMICI_MAX_TIME_EXCEEDED  =   -1000;
+constexpr int AMICI_NOT_RUN=               -1001;
 constexpr int AMICI_SUCCESS=                   0;
 constexpr int AMICI_DATA_RETURN=               1;
 constexpr int AMICI_ROOT_RETURN=               2;

--- a/include/amici/rdata.h
+++ b/include/amici/rdata.h
@@ -335,8 +335,9 @@ class ReturnData: public ModelDimensions {
      *   within the allowed time (see Solver.{set,get}MaxTime)
      * * AMICI_ERROR, indicating that some error occurred during simulation
      *   (a more detailed error message will have been printed).
+     * * AMICI_NOT_RUN, if no simulation was started
      */
-    int status = 0;
+    int status = AMICI_NOT_RUN;
 
     /** number of states (alias `nx_rdata`, kept for backward compatibility) */
     int nx{0};

--- a/python/examples/example_errors.ipynb
+++ b/python/examples/example_errors.ipynb
@@ -91,7 +91,7 @@
     "    scaled_parameters=True\n",
     ")\n",
     "print(\"Status:\", [amici.simulation_status_to_str(rdata.status) for rdata in res[RDATAS]])\n",
-    "assert [amici.simulation_status_to_str(rdata.status) for rdata in res[RDATAS]] == ['AMICI_SUCCESS', 'AMICI_SUCCESS', 'AMICI_SUCCESS', 'AMICI_TOO_MUCH_WORK', 'AMICI_SUCCESS', 'AMICI_SUCCESS']"
+    "assert [amici.simulation_status_to_str(rdata.status) for rdata in res[RDATAS]] == ['AMICI_SUCCESS', 'AMICI_SUCCESS', 'AMICI_SUCCESS', 'AMICI_TOO_MUCH_WORK', 'AMICI_NOT_RUN', 'AMICI_NOT_RUN']"
    ]
   },
   {
@@ -291,7 +291,7 @@
     ")\n",
     "print(\"Status:\", [amici.simulation_status_to_str(rdata.status) for rdata in res[RDATAS]])\n",
     "\n",
-    "assert [amici.simulation_status_to_str(rdata.status) for rdata in res[RDATAS]] == ['AMICI_SUCCESS', 'AMICI_ERR_FAILURE', 'AMICI_SUCCESS', 'AMICI_SUCCESS', 'AMICI_SUCCESS', 'AMICI_SUCCESS']"
+    "assert [amici.simulation_status_to_str(rdata.status) for rdata in res[RDATAS]] == ['AMICI_SUCCESS', 'AMICI_ERR_FAILURE', 'AMICI_NOT_RUN', 'AMICI_NOT_RUN', 'AMICI_NOT_RUN', 'AMICI_NOT_RUN']"
    ]
   },
   {
@@ -397,7 +397,7 @@
     "    scaled_parameters=True\n",
     ")\n",
     "print(\"Status:\", [amici.simulation_status_to_str(rdata.status) for rdata in res[RDATAS]])\n",
-    "assert [amici.simulation_status_to_str(rdata.status) for rdata in res[RDATAS]] == ['AMICI_ERROR', 'AMICI_SUCCESS']"
+    "assert [amici.simulation_status_to_str(rdata.status) for rdata in res[RDATAS]] == ['AMICI_ERROR', 'AMICI_NOT_RUN']"
    ]
   },
   {
@@ -805,7 +805,7 @@
     "\n",
     "# hard to reproduce on GHA\n",
     "if os.getenv('GITHUB_ACTIONS') is None:\n",
-    "    assert [amici.simulation_status_to_str(rdata.status) for rdata in res[RDATAS]] == ['AMICI_ERROR', 'AMICI_SUCCESS', 'AMICI_SUCCESS', 'AMICI_SUCCESS', 'AMICI_SUCCESS', 'AMICI_SUCCESS', 'AMICI_SUCCESS', 'AMICI_SUCCESS']"
+    "    assert [amici.simulation_status_to_str(rdata.status) for rdata in res[RDATAS]] == ['AMICI_ERROR', 'AMICI_NOT_RUN', 'AMICI_NOT_RUN', 'AMICI_NOT_RUN', 'AMICI_NOT_RUN', 'AMICI_NOT_RUN', 'AMICI_NOT_RUN', 'AMICI_NOT_RUN']"
    ]
   },
   {
@@ -947,7 +947,7 @@
     "print(f\"{rdata.preeq_numsteps=}\")\n",
     "# hard to reproduce on GHA\n",
     "if os.getenv('GITHUB_ACTIONS') is None:\n",
-    "    assert [amici.simulation_status_to_str(rdata.status) for rdata in res[RDATAS]] == ['AMICI_ERROR', 'AMICI_SUCCESS', 'AMICI_SUCCESS', 'AMICI_SUCCESS', 'AMICI_SUCCESS', 'AMICI_SUCCESS', 'AMICI_SUCCESS', 'AMICI_SUCCESS']"
+    "    assert [amici.simulation_status_to_str(rdata.status) for rdata in res[RDATAS]] == ['AMICI_ERROR', 'AMICI_NOT_RUN', 'AMICI_NOT_RUN', 'AMICI_NOT_RUN', 'AMICI_NOT_RUN', 'AMICI_NOT_RUN', 'AMICI_NOT_RUN', 'AMICI_NOT_RUN']"
    ]
   },
   {

--- a/src/amici.cpp
+++ b/src/amici.cpp
@@ -61,6 +61,7 @@ std::map<int, std::string> simulation_status_to_str_map = {
     {AMICI_NOT_IMPLEMENTED, "AMICI_NOT_IMPLEMENTED"},
     {AMICI_MAX_TIME_EXCEEDED, "AMICI_MAX_TIME_EXCEEDED"},
     {AMICI_SUCCESS, "AMICI_SUCCESS"},
+    {AMICI_NOT_RUN, "AMICI_NOT_RUN"},
 };
 
 std::unique_ptr<ReturnData> runAmiciSimulation(


### PR DESCRIPTION
So far, if a simulation with `runAmiciSimulations(...., failfast=True)` failed, an empty `ReturnData` with `status=AMICI_SUCCESS` was returned for the skipped conditions. This was rather confusing.

This adds a new status: `AMICI_NOT_RUN`.

Fixes #1949