### PR TITLE
PEtab import: allow specifying default values for output parameters

### DIFF
--- a/python/sdist/amici/petab_import.py
+++ b/python/sdist/amici/petab_import.py
@@ -430,6 +430,7 @@ def import_model_sbml(
         allow_reinit_fixpar_initcond: bool = True,
         validate: bool = True,
         non_estimated_parameters_as_constants=True,
+        output_parameter_defaults: Optional[Dict[str, float]] = None,
         **kwargs) -> amici.SbmlImporter:
     """
     Create AMICI model from PEtab problem
@@ -477,6 +478,11 @@ def import_model_sbml(
         considered constant in AMICI. Setting this to ``True`` will reduce
         model size and simulation times. If sensitivities with respect to those
         parameters are required, this should be set to ``False``.
+
+    :param output_parameter_defaults:
+        Optional default parameter values for output parameters introduced in
+        the PEtab observables table, in particular for placeholder parameters.
+        Dictionary mapping parameter IDs to default values.
 
     :param kwargs:
         Additional keyword arguments to be passed to
@@ -592,8 +598,20 @@ def import_model_sbml(
                 output_parameters[sym] = None
     logger.debug("Adding output parameters to model: "
                  f"{list(output_parameters.keys())}")
+    output_parameter_defaults = output_parameter_defaults or {}
+    if extra_pars := (set(output_parameter_defaults)
+                   - set(output_parameters.keys())):
+        raise ValueError(
+            f"Default output parameter values were given for {extra_pars}, "
+            "but they those are not output parameters."
+        )
+
     for par in output_parameters.keys():
-        _add_global_parameter(sbml_model, par)
+        _add_global_parameter(
+            sbml_model=sbml_model,
+            parameter_id=par,
+            value=output_parameter_defaults.get(par, 0.0)
+        )
     # <EndWorkAround>
 
     # TODO: to parameterize initial states or compartment sizes, we currently

--- a/python/tests/test_petab_import.py
+++ b/python/tests/test_petab_import.py
@@ -3,7 +3,7 @@
 import libsbml
 import pytest
 import pandas as pd
-from amici.testing import skip_on_valgrind
+from amici.testing import skip_on_valgrind, TemporaryDirectoryWinSafe
 
 
 petab = pytest.importorskip("petab", reason="Missing petab")
@@ -16,6 +16,7 @@ def simple_sbml_model():
 
     document = libsbml.SBMLDocument(3, 1)
     model = document.createModel()
+    model.setId("simple_sbml_model")
     model.setTimeUnits("second")
     model.setExtentUnits("mole")
     model.setSubstanceUnits('mole')
@@ -32,6 +33,7 @@ def simple_sbml_model():
     s.setId('x1')
     s.setConstant(True)
     s.setInitialConcentration(1.0)
+    s.setCompartment(c.getId())
 
     return document, model
 
@@ -73,3 +75,51 @@ def test_get_fixed_parameters(simple_sbml_model):
         petab_problem,
         non_estimated_parameters_as_constants=False)) \
         == {"p1", "p5"}
+
+
+@skip_on_valgrind
+def test_default_output_parameters(simple_sbml_model):
+    from petab.models.sbml_model import SbmlModel
+    sbml_doc, sbml_model = simple_sbml_model
+    condition_df = petab.get_condition_df(
+        pd.DataFrame({
+            petab.CONDITION_ID: ["condition0"],
+        })
+    )
+    parameter_df = petab.get_parameter_df(
+        pd.DataFrame({
+            petab.PARAMETER_ID: [],
+            petab.ESTIMATE: []
+        })
+    )
+    observable_df = petab.get_observable_df(
+        pd.DataFrame({
+            petab.OBSERVABLE_ID: ["obs1"],
+            petab.OBSERVABLE_FORMULA: ["observableParameter1_obs1"],
+            petab.NOISE_FORMULA: [1],
+        })
+    )
+    petab_problem = petab.Problem(
+        model=SbmlModel(sbml_model),
+        parameter_df=parameter_df,
+        condition_df=condition_df,
+        observable_df=observable_df,
+    )
+
+    with TemporaryDirectoryWinSafe() as outdir:
+        sbml_importer = amici_petab_import.import_model(
+            petab_problem=petab_problem,
+            output_parameter_defaults={'observableParameter1_obs1': 1.0},
+            compile=False,
+            model_output_dir=outdir,
+        )
+        assert 1.0 == sbml_importer.sbml\
+            .getParameter("observableParameter1_obs1").getValue()
+
+        with pytest.raises(ValueError):
+            amici_petab_import.import_model(
+                petab_problem=petab_problem,
+                output_parameter_defaults={'nonExistentParameter': 1.0},
+                compile=False,
+                model_output_dir=outdir,
+            )


### PR DESCRIPTION
Allows specifying default parameter values for output parameters introduced in the PEtab observables table. This is convenient for placeholder parameters, for which the current value of 0.0 is not good choice (e.g. scaling parameters). Allows for meaningful model outputs if the model is just simulated with default parameters.