### PR TITLE
Reduce time-tracking overhead

### DIFF
--- a/include/amici/solver.h
+++ b/include/amici/solver.h
@@ -500,10 +500,13 @@ class Solver {
 
     /**
      * @brief Check whether maximum integration time was exceeded
+     * @param interval Only check the time every ``interval``ths call to avoid
+     * potentially relatively expensive syscalls
+
      * @return True if the maximum integration time was exceeded,
      * false otherwise.
      */
-    bool timeExceeded() const;
+    bool timeExceeded(int interval = 1) const;
 
     /**
      * @brief returns the maximum number of solver steps for the backward

--- a/include/amici/solver.h
+++ b/include/amici/solver.h
@@ -500,7 +500,7 @@ class Solver {
 
     /**
      * @brief Check whether maximum integration time was exceeded
-     * @param interval Only check the time every ``interval``ths call to avoid
+     * @param interval Only check the time every ``interval`` ths call to avoid
      * potentially relatively expensive syscalls
 
      * @return True if the maximum integration time was exceeded,

--- a/include/amici/solver.h
+++ b/include/amici/solver.h
@@ -489,7 +489,7 @@ class Solver {
 
     /**
      * @brief Set the maximum CPU time allowed for integration
-     * @param maxtime Time in seconds
+     * @param maxtime Time in seconds. Zero means infinte time.
      */
     void setMaxTime(double maxtime);
 
@@ -1609,7 +1609,7 @@ class Solver {
     long int maxsteps_ {10000};
 
     /** Maximum CPU-time for integration in seconds */
-    std::chrono::duration<double, std::ratio<1>> maxtime_ {std::chrono::duration<double>::max()};
+    std::chrono::duration<double, std::ratio<1>> maxtime_ {0};
 
     /** Time at which solver timer was started */
     mutable std::clock_t starttime_;

--- a/include/amici/solver.h
+++ b/include/amici/solver.h
@@ -489,7 +489,7 @@ class Solver {
 
     /**
      * @brief Set the maximum CPU time allowed for integration
-     * @param maxtime Time in seconds. Zero means infinte time.
+     * @param maxtime Time in seconds. Zero means infinite time.
      */
     void setMaxTime(double maxtime);
 

--- a/sbml_test_models/amici_models/piecewise_with_boolean_operations/piecewise_with_boolean_operations_xB.h
+++ b/sbml_test_models/amici_models/piecewise_with_boolean_operations/piecewise_with_boolean_operations_xB.h
@@ -1,0 +1,1 @@
+#define xB0 xB[0]

--- a/sbml_test_models/amici_models/piecewise_with_boolean_operations/piecewise_with_boolean_operations_xB.h
+++ b/sbml_test_models/amici_models/piecewise_with_boolean_operations/piecewise_with_boolean_operations_xB.h
@@ -1,1 +1,0 @@
-#define xB0 xB[0]

--- a/src/solver.cpp
+++ b/src/solver.cpp
@@ -864,7 +864,12 @@ void Solver::startTimer() const
 
 bool Solver::timeExceeded() const
 {
-    auto cputime_exceed = static_cast<double>(std::clock() - starttime_) / CLOCKS_PER_SEC;
+    // 0 means infinte time, don't call `clock()` then (expensive)
+    if(maxtime_.count() == 0)
+        return false;
+
+    auto cputime_exceed = static_cast<double>(std::clock() - starttime_)
+                          / CLOCKS_PER_SEC;
     return std::chrono::duration<double>(cputime_exceed) > maxtime_;
 }
 

--- a/src/solver.cpp
+++ b/src/solver.cpp
@@ -862,10 +862,15 @@ void Solver::startTimer() const
     starttime_ = std::clock();
 }
 
-bool Solver::timeExceeded() const
+bool Solver::timeExceeded(int interval) const
 {
-    // 0 means infinite time, don't call `clock()` then (expensive)
+    static int eval_counter = 0;
+
+    // 0 means infinite time
     if(maxtime_.count() == 0)
+        return false;
+
+    if (++eval_counter % interval)
         return false;
 
     auto cputime_exceed = static_cast<double>(std::clock() - starttime_)

--- a/src/solver.cpp
+++ b/src/solver.cpp
@@ -873,6 +873,7 @@ bool Solver::timeExceeded(int interval) const
     if (++eval_counter % interval)
         return false;
 
+    eval_counter = 0;
     auto cputime_exceed = static_cast<double>(std::clock() - starttime_)
                           / CLOCKS_PER_SEC;
     return std::chrono::duration<double>(cputime_exceed) > maxtime_;

--- a/src/solver.cpp
+++ b/src/solver.cpp
@@ -864,7 +864,7 @@ void Solver::startTimer() const
 
 bool Solver::timeExceeded() const
 {
-    // 0 means infinte time, don't call `clock()` then (expensive)
+    // 0 means infinite time, don't call `clock()` then (expensive)
     if(maxtime_.count() == 0)
         return false;
 

--- a/src/solver_cvodes.cpp
+++ b/src/solver_cvodes.cpp
@@ -1036,8 +1036,14 @@ static int fxdot(realtype t, N_Vector x, N_Vector xdot, void *user_data) {
     auto solver = dynamic_cast<CVodeSolver const *>(typed_udata->second);
     Expects(model);
 
-    if(solver->timeExceeded()) {
-        return AMICI_MAX_TIME_EXCEEDED;
+    // Avoid expensive syscalls by checking only every N rhs evaluations
+    static int eval_counter = 0;
+    int const interval = 1000;
+    if (++eval_counter / interval) {
+        eval_counter = 0;
+        if (solver->timeExceeded()) {
+            return AMICI_MAX_TIME_EXCEEDED;
+        }
     }
 
     if (t > 1e200
@@ -1072,8 +1078,14 @@ static int fxBdot(realtype t, N_Vector x, N_Vector xB, N_Vector xBdot,
     auto solver = dynamic_cast<CVodeSolver const*>(typed_udata->second);
     Expects(model);
 
-    if(solver->timeExceeded()) {
-        return AMICI_MAX_TIME_EXCEEDED;
+    // Avoid expensive syscalls by checking only every N rhs evaluations
+    static int eval_counter = 0;
+    int const interval = 1000;
+    if (++eval_counter / interval) {
+        eval_counter = 0;
+        if (solver->timeExceeded()) {
+            return AMICI_MAX_TIME_EXCEEDED;
+        }
     }
 
     model->fxBdot(t, x, xB, xBdot);

--- a/src/solver_cvodes.cpp
+++ b/src/solver_cvodes.cpp
@@ -1036,14 +1036,8 @@ static int fxdot(realtype t, N_Vector x, N_Vector xdot, void *user_data) {
     auto solver = dynamic_cast<CVodeSolver const *>(typed_udata->second);
     Expects(model);
 
-    // Avoid expensive syscalls by checking only every N rhs evaluations
-    static int eval_counter = 0;
-    int const interval = 1000;
-    if (++eval_counter / interval) {
-        eval_counter = 0;
-        if (solver->timeExceeded()) {
-            return AMICI_MAX_TIME_EXCEEDED;
-        }
+    if (solver->timeExceeded(500)) {
+        return AMICI_MAX_TIME_EXCEEDED;
     }
 
     if (t > 1e200
@@ -1078,14 +1072,8 @@ static int fxBdot(realtype t, N_Vector x, N_Vector xB, N_Vector xBdot,
     auto solver = dynamic_cast<CVodeSolver const*>(typed_udata->second);
     Expects(model);
 
-    // Avoid expensive syscalls by checking only every N rhs evaluations
-    static int eval_counter = 0;
-    int const interval = 1000;
-    if (++eval_counter / interval) {
-        eval_counter = 0;
-        if (solver->timeExceeded()) {
-            return AMICI_MAX_TIME_EXCEEDED;
-        }
+    if (solver->timeExceeded(500)) {
+        return AMICI_MAX_TIME_EXCEEDED;
     }
 
     model->fxBdot(t, x, xB, xBdot);

--- a/src/solver_idas.cpp
+++ b/src/solver_idas.cpp
@@ -1045,8 +1045,14 @@ int fxdot(realtype t, N_Vector x, N_Vector dx, N_Vector xdot,
     auto solver = dynamic_cast<IDASolver const*>(typed_udata->second);
     Expects(model);
 
-    if(solver->timeExceeded()) {
-        return AMICI_MAX_TIME_EXCEEDED;
+    // Avoid expensive syscalls by checking only every N rhs evaluations
+    static int eval_counter = 0;
+    int const interval = 1000;
+    if (++eval_counter / interval) {
+        eval_counter = 0;
+        if (solver->timeExceeded()) {
+            return AMICI_MAX_TIME_EXCEEDED;
+        }
     }
 
     if (t > 1e200
@@ -1082,8 +1088,14 @@ int fxBdot(realtype t, N_Vector x, N_Vector dx, N_Vector xB,
     auto solver = dynamic_cast<IDASolver const*>(typed_udata->second);
     Expects(model);
 
-    if(solver->timeExceeded()) {
-        return AMICI_MAX_TIME_EXCEEDED;
+    // Avoid expensive syscalls by checking only every N rhs evaluations
+    static int eval_counter = 0;
+    int const interval = 1000;
+    if (++eval_counter / interval) {
+        eval_counter = 0;
+        if (solver->timeExceeded()) {
+            return AMICI_MAX_TIME_EXCEEDED;
+        }
     }
 
     model->fxBdot(t, x, dx, xB, dxB, xBdot);
@@ -1111,7 +1123,6 @@ int fqBdot(realtype t, N_Vector x, N_Vector dx, N_Vector xB,
 
     model->fqBdot(t, x, dx, xB, dxB, qBdot);
     return model->checkFinite(gsl::make_span(qBdot), ModelQuantity::qBdot);
-
 }
 
 

--- a/src/solver_idas.cpp
+++ b/src/solver_idas.cpp
@@ -1045,14 +1045,8 @@ int fxdot(realtype t, N_Vector x, N_Vector dx, N_Vector xdot,
     auto solver = dynamic_cast<IDASolver const*>(typed_udata->second);
     Expects(model);
 
-    // Avoid expensive syscalls by checking only every N rhs evaluations
-    static int eval_counter = 0;
-    int const interval = 1000;
-    if (++eval_counter / interval) {
-        eval_counter = 0;
-        if (solver->timeExceeded()) {
-            return AMICI_MAX_TIME_EXCEEDED;
-        }
+    if (solver->timeExceeded(500)) {
+        return AMICI_MAX_TIME_EXCEEDED;
     }
 
     if (t > 1e200
@@ -1088,14 +1082,8 @@ int fxBdot(realtype t, N_Vector x, N_Vector dx, N_Vector xB,
     auto solver = dynamic_cast<IDASolver const*>(typed_udata->second);
     Expects(model);
 
-    // Avoid expensive syscalls by checking only every N rhs evaluations
-    static int eval_counter = 0;
-    int const interval = 1000;
-    if (++eval_counter / interval) {
-        eval_counter = 0;
-        if (solver->timeExceeded()) {
-            return AMICI_MAX_TIME_EXCEEDED;
-        }
+    if (solver->timeExceeded(500)) {
+        return AMICI_MAX_TIME_EXCEEDED;
     }
 
     model->fxBdot(t, x, dx, xB, dxB, xBdot);

--- a/tests/cpp/steadystate/tests1.cpp
+++ b/tests/cpp/steadystate/tests1.cpp
@@ -121,6 +121,10 @@ TEST(ExampleSteadystate, Maxtime)
     amici::hdf5::readSolverSettingsFromHDF5(
         NEW_OPTION_FILE, *solver, "/model_steadystate/nosensi/options");
 
+    // Ensure the solver needs sufficiently many steps that time is checked
+    // at least once during integration
+    solver->setRelativeTolerance(1e-14);
+
     auto rdata = runAmiciSimulation(*solver, nullptr, *model);
     ASSERT_EQ(amici::AMICI_SUCCESS, rdata->status);
 


### PR DESCRIPTION
* Don't check `clock()` on every rhs evaluation, but only every 500.
* Avoid `clock()` completely, if there is no max time specified.
