### PR TITLE
fix equilibraton status discrepancy

### DIFF
--- a/src/steadystateproblem.cpp
+++ b/src/steadystateproblem.cpp
@@ -103,11 +103,19 @@ void SteadystateProblem::findSteadyState(
     Solver const& solver, Model& model, int it
 ) {
     steady_state_status_.resize(3, SteadyStateStatus::not_run);
-    bool turnOffNewton = model.getSteadyStateSensitivityMode() ==
+    /* Turn off Newton's method if newton_maxsteps is set to 0 or 
+    if 'integrationOnly' approach is chosen for sensitivity computation 
+    in combination with forward sensitivities approach. The latter is necessary 
+    as numerical integration of the model ODEs and corresponding 
+    forward sensitivities ODEs is coupled. If 'integrationOnly' approach is 
+    chosen for sensitivity computation it is enforced that steady state is 
+    computed only be numerical integration as well. */
+    bool turnOffNewton = solver.getNewtonMaxSteps() == 0 || ( 
+        model.getSteadyStateSensitivityMode() ==
         SteadyStateSensitivityMode::integrationOnly &&
         ((it == -1 && solver.getSensitivityMethodPreequilibration() ==
          SensitivityMethod::forward) || solver.getSensitivityMethod() ==
-        SensitivityMethod::forward);
+        SensitivityMethod::forward));
 
     /* First, try to run the Newton solver */
     if (!turnOffNewton)

--- a/src/steadystateproblem.cpp
+++ b/src/steadystateproblem.cpp
@@ -109,7 +109,7 @@ void SteadystateProblem::findSteadyState(
     as numerical integration of the model ODEs and corresponding 
     forward sensitivities ODEs is coupled. If 'integrationOnly' approach is 
     chosen for sensitivity computation it is enforced that steady state is 
-    computed only be numerical integration as well. */
+    computed only by numerical integration as well. */
     bool turnOffNewton = solver.getNewtonMaxSteps() == 0 || ( 
         model.getSteadyStateSensitivityMode() ==
         SteadyStateSensitivityMode::integrationOnly &&


### PR DESCRIPTION
Turn off Newton's method if newton_maxsteps is set to 0, so that in that case the resulting status will be `[0 1 0]` ([Did not run; Successful run; Did not run]) if numerical integration was successful. Before the status was `[-2 1 0]` ([Error: The method did not converge to a steady state within the maximum number of steps (Newton's method or simulation). ; Successful run; Did not run]). 

Overall Newton's method is turned off if newton_maxsteps is set to 0 or if 'integrationOnly' approach is chosen for sensitivity computation in combination with forward sensitivities approach. The latter is necessary as numerical integration of the model ODEs and corresponding forward sensitivities ODEs is coupled. If 'integrationOnly' approach is chosen for sensitivity computation it is enforced that steady state is computed only be numerical integration as well.