### PR TITLE
CMake: raise minimum required version to 3.15

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,15 +1,7 @@
 #
 # Build AMICI library
 #
-cmake_minimum_required(VERSION 3.3)
-
-if(POLICY CMP0077)
-  cmake_policy(SET CMP0077 NEW)
-endif(POLICY CMP0077)
-if(POLICY CMP0074)
-  # Use package_ROOT environment variables
-  cmake_policy(SET CMP0074 NEW)
-endif(POLICY CMP0074)
+cmake_minimum_required(VERSION 3.15)
 
 project(amici)
 

--- a/python/CMakeLists.txt
+++ b/python/CMakeLists.txt
@@ -1,11 +1,7 @@
 if(DEFINED ENV{PYTHON_EXECUTABLE})
   set(Python3_EXECUTABLE $ENV{PYTHON_EXECUTABLE})
 endif()
-if(${CMAKE_VERSION} VERSION_LESS "3.12.0")
-  find_package(PythonInterp 3.8 REQUIRED)
-else()
-  find_package(Python3 COMPONENTS Interpreter)
-endif()
+find_package(Python3 COMPONENTS Interpreter)
 
 add_custom_target(
   install-python

--- a/python/tests/test_misc.py
+++ b/python/tests/test_misc.py
@@ -2,7 +2,7 @@
 
 import os
 import subprocess
-
+from pathlib import Path
 import pytest
 import sympy as sp
 
@@ -56,9 +56,13 @@ def test_cmake_compilation(sbml_example_presimulation_module):
     Python tests"""
 
     source_dir = os.path.dirname(sbml_example_presimulation_module.__path__[0])
-
-    cmd = f"set -e; cmake -S {source_dir} -B '{source_dir}/build'; "\
-          f"cmake --build '{source_dir}/build'"
+    build_dir = f"{source_dir}/build"
+    # path hint for amici base installation, in case CMake configuration has
+    #  not been exported
+    amici_dir = (Path(__file__).parents[2] / 'build').absolute()
+    cmd = f"set -e; " \
+          f"cmake -S {source_dir} -B '{build_dir}' -DAmici_DIR={amici_dir};" \
+          f"cmake --build '{source_dir}'"
 
     try:
         subprocess.run(cmd, shell=True, check=True,

--- a/python/tests/test_misc.py
+++ b/python/tests/test_misc.py
@@ -61,8 +61,8 @@ def test_cmake_compilation(sbml_example_presimulation_module):
     #  not been exported
     amici_dir = (Path(__file__).parents[2] / 'build').absolute()
     cmd = f"set -e; " \
-          f"cmake -S {source_dir} -B '{build_dir}' -DAmici_DIR={amici_dir};" \
-          f"cmake --build '{source_dir}'"
+          f"cmake -S {source_dir} -B '{build_dir}' -DAmici_DIR={amici_dir}; " \
+          f"cmake --build '{build_dir}'"
 
     try:
         subprocess.run(cmd, shell=True, check=True,

--- a/python/tests/test_misc.py
+++ b/python/tests/test_misc.py
@@ -57,11 +57,16 @@ def test_cmake_compilation(sbml_example_presimulation_module):
 
     source_dir = os.path.dirname(sbml_example_presimulation_module.__path__[0])
 
-    cmd = f"set -e; cd {source_dir}; mkdir -p build; cd build; "\
-          "cmake ..; make"
+    cmd = f"set -e; cmake -S {source_dir} -B '{source_dir}/build'; "\
+          f"cmake --build '{source_dir}/build'"
 
-    subprocess.run(cmd, shell=True, check=True,
-                   stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+    try:
+        subprocess.run(cmd, shell=True, check=True,
+                       stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+    except subprocess.CalledProcessError as e:
+        print(e.stdout.decode())
+        print(e.stderr.decode())
+        raise
 
 
 @skip_on_valgrind

--- a/src/CMakeLists.template.cmake
+++ b/src/CMakeLists.template.cmake
@@ -1,15 +1,4 @@
-cmake_minimum_required(VERSION 3.3)
-
-if(POLICY CMP0060)
-  cmake_policy(SET CMP0060 NEW)
-endif(POLICY CMP0060)
-if(POLICY CMP0065)
-  cmake_policy(SET CMP0065 NEW)
-endif(POLICY CMP0065)
-if(POLICY CMP0074)
-  # Use package_ROOT environment variables
-  cmake_policy(SET CMP0074 NEW)
-endif(POLICY CMP0074)
+cmake_minimum_required(VERSION 3.15)
 
 project(TPL_MODELNAME)
 

--- a/src/CMakeLists.template.cmake
+++ b/src/CMakeLists.template.cmake
@@ -19,7 +19,7 @@ foreach(FLAG ${MY_CXX_FLAGS})
     endif()
 endforeach(FLAG)
 
-find_package(Amici TPL_AMICI_VERSION HINTS ${CMAKE_CURRENT_LIST_DIR}/../../build)
+find_package(Amici TPL_AMICI_VERSION REQUIRED HINTS ${CMAKE_CURRENT_LIST_DIR}/../../build)
 message(STATUS "Found AMICI ${Amici_DIR}")
 
 set(MODEL_DIR ${CMAKE_CURRENT_LIST_DIR})

--- a/swig/CMakeLists_model.cmake
+++ b/swig/CMakeLists_model.cmake
@@ -1,16 +1,4 @@
-cmake_minimum_required(VERSION 3.8) # swig_add_library
-
-if(POLICY CMP0078)
-  cmake_policy(SET CMP0078 NEW)
-endif(POLICY CMP0078)
-if(POLICY CMP0074)
-  # Use package_ROOT environment variables
-  cmake_policy(SET CMP0074 NEW)
-endif(POLICY CMP0074)
-if(POLICY CMP0086)
-  cmake_policy(SET CMP0086 NEW)
-endif(POLICY CMP0086)
-
+cmake_minimum_required(VERSION 3.15)
 
 find_package(SWIG REQUIRED)
 include(${SWIG_USE_FILE})
@@ -18,16 +6,10 @@ include(${SWIG_USE_FILE})
 if(DEFINED ENV{PYTHON_EXECUTABLE})
     set(Python3_EXECUTABLE $ENV{PYTHON_EXECUTABLE})
 endif()
-if(${CMAKE_VERSION} VERSION_LESS "3.12.0")
-    find_package(PythonLibs REQUIRED)
-    include_directories(${PYTHON_INCLUDE_DIRS})
-    set(Python3_LIBRARIES ${PYTHON_LIBRARIES})
-else()
-    # We don't need "Interpreter" here, but without that, FindPython3 will
-    # ignore the Python version selected via $Python3_EXECUTABLE
-    find_package(Python3 COMPONENTS Interpreter Development)
-    include_directories(${Python3_INCLUDE_DIRS})
-endif()
+# We don't need "Interpreter" here, but without that, FindPython3 will
+# ignore the Python version selected via $Python3_EXECUTABLE
+find_package(Python3 COMPONENTS Interpreter Development)
+include_directories(${Python3_INCLUDE_DIRS})
 
 set(SWIG_LIBRARY_NAME _${PROJECT_NAME})
 set(CMAKE_SWIG_FLAGS "")


### PR DESCRIPTION
Seems fair to require a CMake version not older than 3 years+

Simplifies CMake files, and some newer features will be required for #1992.