### PR TITLE
Fix SuiteSparse Makefiles for compiler-paths

### DIFF
--- a/ThirdParty/SuiteSparse/AMD/Demo/Makefile
+++ b/ThirdParty/SuiteSparse/AMD/Demo/Makefile
@@ -9,7 +9,7 @@ gak:
 
 include ../../SuiteSparse_config/SuiteSparse_config.mk
 
-C = $(CC) $(CF) -I../../include
+C = "$(CC)" $(CF) -I../../include
 
 LIB2 = $(LDFLAGS) -L../../lib -lamd -lsuitesparseconfig $(LDLIBS)
 

--- a/ThirdParty/SuiteSparse/AMD/Lib/Makefile
+++ b/ThirdParty/SuiteSparse/AMD/Lib/Makefile
@@ -17,7 +17,7 @@ LDLIBS += -lsuitesparseconfig
 library:
 	$(MAKE) install INSTALL=$(SUITESPARSE)
 
-C = $(CC) $(CF) -I../Include -I../../SuiteSparse_config
+C = "$(CC)" $(CF) -I../Include -I../../SuiteSparse_config
 
 #-------------------------------------------------------------------------------
 # source files
@@ -87,7 +87,7 @@ $(INSTALL_LIB)/$(SO_TARGET): $(OBJ)
 	@mkdir -p $(INSTALL_LIB)
 	@mkdir -p $(INSTALL_INCLUDE)
 	@mkdir -p $(INSTALL_DOC)
-	$(CC) $(SO_OPTS) $^ -o $@ $(LDLIBS)
+	"$(CC)" $(SO_OPTS) $^ -o $@ $(LDLIBS)
 	( cd $(INSTALL_LIB) ; ln -sf $(SO_TARGET) $(SO_PLAIN) )
 	( cd $(INSTALL_LIB) ; ln -sf $(SO_TARGET) $(SO_MAIN) )
 	$(CP) ../Include/amd.h $(INSTALL_INCLUDE)

--- a/ThirdParty/SuiteSparse/BTF/Lib/Makefile
+++ b/ThirdParty/SuiteSparse/BTF/Lib/Makefile
@@ -22,7 +22,7 @@ library:
 # for testing only:
 # TEST = -DTESTING
 
-C = $(CC) $(CF)
+C = "$(CC)" $(CF)
 
 INC = ../Include/btf.h ../Include/btf_internal.h
 
@@ -72,7 +72,7 @@ $(INSTALL_LIB)/$(SO_TARGET): $(OBJ)
 	@mkdir -p $(INSTALL_LIB)
 	@mkdir -p $(INSTALL_INCLUDE)
 	@mkdir -p $(INSTALL_DOC)
-	$(CC) $(SO_OPTS) $^ -o $@ $(LDLIBS)
+	"$(CC)" $(SO_OPTS) $^ -o $@ $(LDLIBS)
 	( cd $(INSTALL_LIB) ; ln -sf $(SO_TARGET) $(SO_PLAIN) )
 	( cd $(INSTALL_LIB) ; ln -sf $(SO_TARGET) $(SO_MAIN) )
 	$(CP) ../Include/btf.h $(INSTALL_INCLUDE)

--- a/ThirdParty/SuiteSparse/CAMD/Demo/Makefile
+++ b/ThirdParty/SuiteSparse/CAMD/Demo/Makefile
@@ -6,7 +6,7 @@ default: camd_simple camd_demo camd_demo2 camd_l_demo
 
 include ../../SuiteSparse_config/SuiteSparse_config.mk
 
-C = $(CC) $(CF) -I../../include
+C = "$(CC)" $(CF) -I../../include
 
 LIB2 = $(LDFLAGS) -L../../lib -lcamd -lsuitesparseconfig $(LDLIBS) 
 

--- a/ThirdParty/SuiteSparse/CAMD/Lib/Makefile
+++ b/ThirdParty/SuiteSparse/CAMD/Lib/Makefile
@@ -17,7 +17,7 @@ LDLIBS += -lsuitesparseconfig
 library:
 	$(MAKE) install INSTALL=$(SUITESPARSE)
 
-C = $(CC) $(CF) -I../Include -I../../SuiteSparse_config
+C = "$(CC)" $(CF) -I../Include -I../../SuiteSparse_config
 
 #-------------------------------------------------------------------------------
 # source files
@@ -68,7 +68,7 @@ $(INSTALL_LIB)/$(SO_TARGET): $(OBJ)
 	@mkdir -p $(INSTALL_LIB)
 	@mkdir -p $(INSTALL_INCLUDE)
 	@mkdir -p $(INSTALL_DOC)
-	$(CC) $(SO_OPTS) $^ -o $@ $(LDLIBS)
+	"$(CC)" $(SO_OPTS) $^ -o $@ $(LDLIBS)
 	( cd $(INSTALL_LIB) ; ln -sf $(SO_TARGET) $(SO_PLAIN) )
 	( cd $(INSTALL_LIB) ; ln -sf $(SO_TARGET) $(SO_MAIN) )
 	$(CP) ../Include/camd.h $(INSTALL_INCLUDE)

--- a/ThirdParty/SuiteSparse/COLAMD/Demo/Makefile
+++ b/ThirdParty/SuiteSparse/COLAMD/Demo/Makefile
@@ -8,7 +8,7 @@ include ../../SuiteSparse_config/SuiteSparse_config.mk
 
 I = -I../../include
 
-C = $(CC) $(CF) $(I)
+C = "$(CC)" $(CF) $(I)
 
 LIB2 = $(LDFLAGS) -L../../lib -lcolamd -lsuitesparseconfig $(LDLIBS)
 

--- a/ThirdParty/SuiteSparse/COLAMD/Lib/Makefile
+++ b/ThirdParty/SuiteSparse/COLAMD/Lib/Makefile
@@ -26,10 +26,10 @@ SRC = ../Source/colamd.c
 OBJ = colamd.o colamd_l.o
 
 colamd.o: $(SRC) $(INC)
-	$(CC) $(CF) $(I) -c ../Source/colamd.c
+	"$(CC)" $(CF) $(I) -c ../Source/colamd.c
 
 colamd_l.o: $(SRC) $(INC)
-	$(CC) $(CF) $(I) -c ../Source/colamd.c -DDLONG -o colamd_l.o
+	"$(CC)" $(CF) $(I) -c ../Source/colamd.c -DDLONG -o colamd_l.o
 
 # creates libcolamd.a, a C-callable COLAMD library
 static: $(AR_TARGET)
@@ -55,7 +55,7 @@ $(INSTALL_LIB)/$(SO_TARGET): $(OBJ)
 	@mkdir -p $(INSTALL_LIB)
 	@mkdir -p $(INSTALL_INCLUDE)
 	@mkdir -p $(INSTALL_DOC)
-	$(CC) $(SO_OPTS) $^ -o $@ $(LDLIBS)
+	"$(CC)" $(SO_OPTS) $^ -o $@ $(LDLIBS)
 	( cd $(INSTALL_LIB) ; ln -sf $(SO_TARGET) $(SO_PLAIN) )
 	( cd $(INSTALL_LIB) ; ln -sf $(SO_TARGET) $(SO_MAIN) )
 	$(CP) ../Include/colamd.h $(INSTALL_INCLUDE)

--- a/ThirdParty/SuiteSparse/KLU/Demo/Makefile
+++ b/ThirdParty/SuiteSparse/KLU/Demo/Makefile
@@ -52,12 +52,12 @@ clean:
 	- $(RM) -r $(CLEAN)
 
 kludemo: kludemo.c Makefile
-	$(CC) $(CF) $(I) kludemo.c -o kludemo $(CLIB) $(CHOLMOD)
+	"$(CC)" $(CF) $(I) kludemo.c -o kludemo $(CLIB) $(CHOLMOD)
 
 kluldemo: kludemo.c Makefile
-	$(CC) $(CF) $(I) kluldemo.c -o kluldemo $(CLIB) $(CHOLMOD)
+	"$(CC)" $(CF) $(I) kluldemo.c -o kluldemo $(CLIB) $(CHOLMOD)
 
 klu_simple: klu_simple.c Makefile
-	$(CC) $(CF) $(I) klu_simple.c -o klu_simple $(CLIB)
+	"$(CC)" $(CF) $(I) klu_simple.c -o klu_simple $(CLIB)
 	- ./klu_simple
 

--- a/ThirdParty/SuiteSparse/KLU/Lib/Makefile
+++ b/ThirdParty/SuiteSparse/KLU/Lib/Makefile
@@ -22,7 +22,7 @@ library:
 # for testing only:
 # TEST = -DTESTING
 
-C = $(CC) $(CF)
+C = "$(CC)" $(CF)
 
 INC = ../Include/klu.h ../Include/klu_internal.h ../Include/klu_version.h \
     ../../SuiteSparse_config/SuiteSparse_config.h
@@ -269,7 +269,7 @@ $(INSTALL_LIB)/$(SO_TARGET): $(OBJ)
 	@mkdir -p $(INSTALL_LIB)
 	@mkdir -p $(INSTALL_INCLUDE)
 	@mkdir -p $(INSTALL_DOC)
-	$(CC) $(SO_OPTS) $^ -o $@ $(LDLIBS)
+	"$(CC)" $(SO_OPTS) $^ -o $@ $(LDLIBS)
 	( cd $(INSTALL_LIB) ; ln -sf $(SO_TARGET) $(SO_PLAIN) )
 	( cd $(INSTALL_LIB) ; ln -sf $(SO_TARGET) $(SO_MAIN) )
 	$(CP) ../Include/klu.h $(INSTALL_INCLUDE)

--- a/ThirdParty/SuiteSparse/KLU/Tcov/Makefile
+++ b/ThirdParty/SuiteSparse/KLU/Tcov/Makefile
@@ -22,7 +22,7 @@ CF = -Wall -W -Wshadow -Wmissing-prototypes -Wstrict-prototypes \
  	-ansi -g -ftest-coverage -fprofile-arcs -fexceptions \
 	-fopenmp
 
-C = $(CC) $(CF)
+C = "$(CC)" $(CF)
 
 LDLIBS = -L../../lib -lamd -lcolamd -lcholmod -lcamd -lccolamd \
     -lmetis -lsuitesparseconfig \

--- a/ThirdParty/SuiteSparse/KLU/User/Makefile
+++ b/ThirdParty/SuiteSparse/KLU/User/Makefile
@@ -9,7 +9,7 @@ I = -I../../CHOLMOD/Include -I../../SuiteSparse_config \
     -I../../BTF/Include -I../../COLAMD/Include
 
 libklu_cholmod.a:  library klu_cholmod.c klu_cholmod.h
-	$(CC) $(CF) $(I) -c klu_cholmod.c
+	"$(CC)" $(CF) $(I) -c klu_cholmod.c
 	$(ARCHIVE)  libklu_cholmod.a klu_cholmod.o
 	- $(RANLIB) libklu_cholmod.a
 

--- a/ThirdParty/SuiteSparse/SuiteSparse_config/Makefile
+++ b/ThirdParty/SuiteSparse/SuiteSparse_config/Makefile
@@ -25,7 +25,7 @@ library: $(AR_TARGET)
 OBJ = SuiteSparse_config.o
 
 SuiteSparse_config.o: SuiteSparse_config.c SuiteSparse_config.h
-	$(CC) $(CF) -c SuiteSparse_config.c
+	"$(CC)" $(CF) -c SuiteSparse_config.c
 
 static: $(AR_TARGET)
 
@@ -50,7 +50,7 @@ $(INSTALL_LIB)/$(SO_TARGET): $(OBJ)
 	@mkdir -p $(INSTALL_LIB)
 	@mkdir -p $(INSTALL_INCLUDE)
 	@mkdir -p $(INSTALL_DOC)
-	$(CC) $(SO_OPTS) $^ -o $@ $(LDLIBS)
+	"$(CC)" $(SO_OPTS) $^ -o $@ $(LDLIBS)
 	( cd $(INSTALL_LIB) ; ln -sf $(SO_TARGET) $(SO_PLAIN) )
 	( cd $(INSTALL_LIB) ; ln -sf $(SO_TARGET) $(SO_MAIN) )
 	$(CP) SuiteSparse_config.h $(INSTALL_INCLUDE)

--- a/ThirdParty/SuiteSparse/SuiteSparse_config/xerbla/Makefile
+++ b/ThirdParty/SuiteSparse/SuiteSparse_config/xerbla/Makefile
@@ -24,7 +24,7 @@ endif
 include ../SuiteSparse_config.mk
 
 ifeq ($(USE_FORTRAN),0)
-    COMPILE = $(CC) $(CF) -c xerbla.c
+    COMPILE = "$(CC)" $(CF) -c xerbla.c
     DEPENDS = xerbla.c xerbla.h
 else
     COMPILE = $(F77) $(F77FLAGS) -c xerbla.f
@@ -51,7 +51,7 @@ $(INSTALL_LIB)/$(SO_TARGET): $(DEPENDS)
 	@mkdir -p $(INSTALL_INCLUDE)
 	@mkdir -p $(INSTALL_DOC)
 	$(COMPILE)
-	$(CC) $(SO_OPTS) xerbla.o -o $@
+	"$(CC)" $(SO_OPTS) xerbla.o -o $@
 	- $(RM) xerbla.o
 	( cd $(INSTALL_LIB) ; ln -sf $(SO_TARGET) $(SO_PLAIN) )
 	( cd $(INSTALL_LIB) ; ln -sf $(SO_TARGET) $(SO_MAIN) )


### PR DESCRIPTION
Fix SuiteSparse Makefiles for compiler-paths containing blanks, parentheses, ... which is the case for default MSVC installations.

`find ThirdParty/SuiteSparse/ -name Makefile -exec sed -ri 's/([ \t])(\$\(CC\)) /\1"\2" /' {} \;`