### PR TITLE
don't pass `-py3` to swig after 4.1.0

### DIFF
--- a/python/sdist/amici/setuptools.py
+++ b/python/sdist/amici/setuptools.py
@@ -237,12 +237,13 @@ def generate_swig_interface_files(swig_outdir: str = None,
     swig_args = [
         '-c++',
         '-python',
-        '-py3',
         '-threads',
         '-Wall',
         f'-Iamici{os.sep}swig',
         f'-Iamici{os.sep}include',
     ]
+    if swig_version < (4, 1, 0):
+        swig_args.insert(2, '-py3')
 
     print(f"Found SWIG version {swig_version}")
 


### PR DESCRIPTION
https://github.com/swig/swig/blob/a55e429bf297d7daddf0bef3a3dc5832f433aef0/CHANGES#L611

fixes #2006 