### PR TITLE
Matlab: If mex fails, print mex arguments

### DIFF
--- a/matlab/@amimodel/compileAndLinkModel.m
+++ b/matlab/@amimodel/compileAndLinkModel.m
@@ -127,10 +127,15 @@ function compileAndLinkModel(modelname, modelSourceFolder, coptim, debug, funs, 
         sources = cellfun(@(x) ['"' fullfile(modelSourceFolder,[modelname '_' x '.cpp']) '"'],funsForRecompile,'UniformOutput',false);
         sources = strjoin(sources,' ');
 
-        eval(['mex ' DEBUG COPT ...
+        cmd = ['mex ' DEBUG COPT ...
             ' -c -outdir "' modelObjectFolder '" ' ...
-            sources ' ' ...
-            includesstr ]);
+            sources ' ' includesstr];
+        try
+            eval(cmd);
+        catch ME
+            disp(cmd);
+            rethrow(ME);
+        end
         cellfun(@(x) updateFileHashSource(modelSourceFolder, modelObjectFolder, [modelname '_' x]),funsForRecompile,'UniformOutput',false);
     end
 
@@ -156,10 +161,17 @@ function compileAndLinkModel(modelname, modelSourceFolder, coptim, debug, funs, 
 
     % compile the wrapfunctions object
     fprintf('wrapfunctions | ');
-    eval(['mex ' DEBUG COPT ...
+    cmd = ['mex ' DEBUG COPT ...
         ' -c -outdir "' modelObjectFolder '" "' ...
         fullfile(modelSourceFolder,'wrapfunctions.cpp') '" ' model_cpp ...
-        includesstr]);
+        includesstr];
+    try
+        eval(cmd);
+    catch ME
+        disp(cmd);
+        rethrow(ME);
+    end
+
     objectsstr = [objectsstr, ' "' fullfile(modelObjectFolder,['wrapfunctions' objectFileSuffix]) '" ' model_cpp_obj];
 
     % now we have compiled everything model-specific, so we can replace hashes.mat to prevent recompilation
@@ -186,8 +198,15 @@ function compileAndLinkModel(modelname, modelSourceFolder, coptim, debug, funs, 
     end
 
     mexFilename = fullfile(modelSourceFolder,['ami_' modelname]);
-    eval(['mex ' DEBUG ' ' COPT ' ' CLIBS ...
-        ' -output "' mexFilename '" ' objectsstr])
+    cmd = ['mex ' DEBUG ' ' COPT ' ' CLIBS ...
+        ' -output "' mexFilename '" ' objectsstr];
+    try
+        eval(cmd);
+    catch ME
+        disp(cmd);
+        rethrow(ME);
+    end
+
 end
 
 function [objectStrAmici] = compileAmiciBase(amiciRootPath, objectFolder, objectFileSuffix, includesstr, DEBUG, COPT)
@@ -217,8 +236,15 @@ function [objectStrAmici] = compileAmiciBase(amiciRootPath, objectFolder, object
             baseFilename = fullfile(amiciSourcePath, sourcesForRecompile{j});
             sourceStr  = [sourceStr, ' "', baseFilename, '.cpp"'];
         end
-        eval(['mex ' DEBUG COPT ' -c -outdir "' objectFolder '" ' ...
-            includesstr ' ' sourceStr]);
+        cmd = ['mex ' DEBUG COPT ' -c -outdir "' objectFolder '" ' ...
+            includesstr ' ' sourceStr];
+        try
+            eval(cmd);
+        catch ME
+            disp(cmd);
+            rethrow(ME);
+        end
+
         cellfun(@(x) updateFileHashSource(amiciSourcePath, objectFolder, x), sourcesForRecompile);
         updateHeaderFileHashes(amiciIncludePath, objectFolder);
     end

--- a/matlab/auxiliary/compileAMICIDependencies.m
+++ b/matlab/auxiliary/compileAMICIDependencies.m
@@ -48,9 +48,15 @@ function [objectsstr, includesstr] = compileAMICIDependencies(dependencyPath, ob
 
     % compile
     if(~strcmp(sourcesToCompile, ''))
-        eval(['mex ' DEBUG ' ' COPT ' -c -outdir "' ...
+        cmd = ['mex ' DEBUG ' ' COPT ' -c -outdir "' ...
             objectFolder '" ' ...
-            includesstr ' ' sourcesToCompile ]);
+            includesstr ' ' sourcesToCompile];
+        try
+            eval(cmd);
+        catch ME
+            disp(cmd);
+            rethrow(ME);
+        end
     end
 
     % only write versions.txt if we are done compiling


### PR DESCRIPTION
For all mex calls, catch exception, print mex invocation, rethrow. Will make bug reports way more informative and simplify debugging.

Resolves #913