### PR TITLE
Simplify OpenBLAS installation on Windows

### DIFF
--- a/.github/workflows/test_windows.yml
+++ b/.github/workflows/test_windows.yml
@@ -15,7 +15,11 @@ jobs:
     env:
       AMICI_SKIP_CMAKE_TESTS: "TRUE"
       openBLAS_version: "0.3.19"
-      AMICI_DLL_DIRS: "C:\\BLAS\\bin"
+      AMICI_DLL_DIRS: "C:\\BLAS\\OpenBLAS\\bin"
+      LIB: "C:/BLAS/OpenBLAS/lib"
+      CFLAGS: "-nologo"
+      CXXFLAGS: "-nologo"
+      LDFLAGS: "-nologo"
 
     strategy:
       matrix:
@@ -33,11 +37,11 @@ jobs:
     - shell: bash
       run: echo "AMICI_DIR=$(pwd)" >> $GITHUB_ENV
     - shell: bash
-      run: echo "C:\\BLAS\\bin" >> $GITHUB_PATH
+      run: echo "C:\\BLAS\\OpenBLAS\\bin" >> $GITHUB_PATH
     - shell: bash
-      run: echo "BLAS_LIBS=/LIBPATH:C:/BLAS/lib openblas.lib" >> $GITHUB_ENV
+      run: echo "BLAS_LIBS=-LIBPATH:C:/BLAS/OpenBLAS/lib openblas.lib" >> $GITHUB_ENV
     - shell: bash
-      run: echo "BLAS_CFLAGS=-IC:/BLAS/OpenBLAS-${openBLAS_version}/OpenBLAS-${openBLAS_version}" >> $GITHUB_ENV
+      run: echo "BLAS_CFLAGS=-IC:/BLAS/OpenBLAS/include/openblas/" >> $GITHUB_ENV
 
     # Developer Command Prompt for Microsoft Visual C++
     - uses: ilammy/msvc-dev-cmd@v1
@@ -52,6 +56,11 @@ jobs:
     - name: Install OpenBLAS
       shell: powershell
       run: scripts/installOpenBLAS
+
+    - uses: actions/upload-artifact@v3
+      with:
+        name: OpenBLAS
+        path: C:\BLAS\OpenBLAS
 
     - name: Create sdist
       working-directory: python/sdist

--- a/scripts/compileBLAS.cmd
+++ b/scripts/compileBLAS.cmd
@@ -1,13 +1,14 @@
 echo compileBLAS.cmd started for openBLAS version %1
 cd /D "C:\BLAS\OpenBLAS-%1\OpenBLAS-%1"
 call "C:\Program Files (x86)\Microsoft Visual Studio\2019\BuildTools\VC\Auxiliary\Build\vcvars64.bat"
-cmake -G "Ninja" ^
+cmake -S . -B build ^
+    -G "Ninja" ^
     -DBUILD_DOUBLE=1 ^
     -DBUILD_SHARED_LIBS=ON ^
-    -DCMAKE_INSTALL_PREFIX:PATH="C:\BLAS\OpenBLAS-%1\OpenBLAS-%1\out\install\x64-Release" ^
+    -DCMAKE_INSTALL_PREFIX:PATH="C:/BLAS/OpenBLAS" ^
     -DCMAKE_C_COMPILER:FILEPATH=cl ^
     -DCMAKE_BUILD_TYPE=Release ^
-    -DCMAKE_MAKE_PROGRAM=ninja ^
-    "C:\BLAS\OpenBLAS-%1\OpenBLAS-%1"
-cmake --build "C:\BLAS\OpenBLAS-%1\OpenBLAS-%1" --parallel 2
+    -DCMAKE_MAKE_PROGRAM=ninja
+cmake --build build --parallel 2
+cmake --install build
 echo compileBLAS.cmd completed

--- a/scripts/installOpenBLAS.ps1
+++ b/scripts/installOpenBLAS.ps1
@@ -9,13 +9,10 @@ $webclient = New-Object System.Net.WebClient
 $webclient.DownloadFile($uri,"$output")
 Expand-Archive -Path "C:\BLAS\v$version.zip" -DestinationPath "C:\BLAS\OpenBLAS-$version" -Force # expand zip file
 cmd /c "scripts\compileBLAS.cmd $version"
-cmd /c dumpbin /DEPENDENTS "C:\BLAS\OpenBLAS-$version\OpenBLAS-$version\lib\openblas.dll"
-New-Item -Path 'C:\BLAS\lib' -ItemType Directory -Force # create directory
-Copy-Item "C:\BLAS\OpenBLAS-$version\OpenBLAS-$version\lib\Release\openblas.lib" -Destination "C:\BLAS\lib" -Recurse
-New-Item -Path 'C:\BLAS\bin' -ItemType Directory -Force # create directory
-Copy-Item "C:\BLAS\OpenBLAS-$version\OpenBLAS-$version\lib\openblas.dll" -Destination "C:\BLAS\bin" -Recurse
+cmd /c dumpbin /DEPENDENTS "C:\BLAS\OpenBLAS\bin\openblas.dll"
 Get-ChildItem -Path "C:\BLAS" -Include "openblas.lib" -Recurse # check for file
 Get-ChildItem -Path "C:\BLAS" -Include "openblas.dll" -Recurse # check for file
+Get-ChildItem -Path "C:\BLAS" -Include "cblas.h" -Recurse # check for file
 Get-Item -Path Env:BLAS_* # check environment variables
 $VerbosePreference = "SilentlyContinue" # don't display verbose messages
 Write-Host 'script installOpenBLAS.ps1 completed'


### PR DESCRIPTION
* Use cmake-install instead of funny manual copying
* Build parallel
* Upload build artifacts for debugging
* Silence stupid MSVC copyright messages