### PR TITLE
Fix CPU time tracking with multi-threading (partially)

### DIFF
--- a/.github/workflows/test_python_cplusplus.yml
+++ b/.github/workflows/test_python_cplusplus.yml
@@ -56,6 +56,7 @@ jobs:
             g++ \
             libatlas-base-dev \
             libboost-serialization-dev \
+            libboost-chrono-dev \
             libhdf5-serial-dev \
             python3-venv \
             swig \

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -99,6 +99,7 @@ endif()
 include(GNUInstallDirs)
 
 find_package(OpenMP)
+find_package(Boost COMPONENTS chrono)
 
 if(ENABLE_HDF5)
   find_package(
@@ -278,6 +279,9 @@ if("$ENV{ENABLE_AMICI_DEBUGGING}"
   endforeach()
 endif()
 
+target_compile_definitions(
+    ${PROJECT_NAME} PRIVATE $<$<BOOL:${Boost_CHRONO_FOUND}>:HAS_BOOST_CHRONO>)
+
 target_link_libraries(
   ${PROJECT_NAME}
   PUBLIC SUNDIALS::generic_static
@@ -298,6 +302,7 @@ target_link_libraries(
          SUNDIALS::cvodes_static
          SUNDIALS::idas_static
          ${BLAS_LIBRARIES}
+         $<$<BOOL:${Boost_CHRONO_FOUND}>:Boost::chrono>
          $<$<BOOL:${OpenMP_FOUND}>:OpenMP::OpenMP_CXX>
          ${CMAKE_DL_LIBS}
   PRIVATE

--- a/cmake/AmiciConfig.cmake
+++ b/cmake/AmiciConfig.cmake
@@ -44,6 +44,10 @@ set_target_properties(SUNDIALS::KLU PROPERTIES INTERFACE_INCLUDE_DIRECTORIES
 find_package(SUNDIALS REQUIRED PATHS
              "@CMAKE_SOURCE_DIR@/ThirdParty/sundials/build/lib/cmake/sundials/")
 
+if(@Boost_CHRONO_FOUND@)
+  find_package(Boost COMPONENTS chrono REQUIRED)
+endif()
+
 if(@HDF5_FOUND@)
   find_package(
     HDF5

--- a/container/Dockerfile
+++ b/container/Dockerfile
@@ -5,6 +5,9 @@ FROM ubuntu:22.04
 RUN apt-get update && apt-get install -y \
     g++ \
     libatlas-base-dev \
+    libboost-serialization-dev \
+    libboost-chrono-dev \
+    libhdf5-serial-dev \
     python-is-python3 \
     python3 \
     python3-dev \

--- a/include/amici/misc.h
+++ b/include/amici/misc.h
@@ -13,6 +13,10 @@
 #include <functional>
 #include <ctime>
 
+#ifdef HAS_BOOST_CHRONO
+#include <boost/chrono/thread_clock.hpp>
+#endif
+
 #include <gsl/gsl-lite.hpp>
 
 namespace amici {
@@ -242,6 +246,47 @@ bool is_equal(T const& a, T const& b) {
     return true;
 }
 
+#ifdef BOOST_CHRONO_HAS_THREAD_CLOCK
+/** Tracks elapsed CPU time. */
+class CpuTimer {
+    using clock = boost::chrono::thread_clock;
+    using time_point = boost::chrono::thread_clock::time_point;
+    using d_seconds = boost::chrono::duration<double>;
+    using d_milliseconds = boost::chrono::duration<double, boost::milli>;
+  public:
+    /**
+     * @brief Constructor
+     */
+    CpuTimer() : start_(clock::now()){}
+
+    /**
+     * @brief Reset the timer
+     */
+    void reset() { start_ = clock::now(); }
+
+    /**
+     * @brief Get elapsed CPU time in seconds since initialization or last reset
+     * @return CPU time in seconds
+     */
+    double elapsed_seconds() const {
+        return boost::chrono::duration_cast<d_seconds>(
+                   clock::now() - start_).count();
+    }
+
+    /**
+     * @brief Get elapsed CPU time in milliseconds since initialization or last
+     * reset
+     * @return CPU time in milliseconds
+     */
+    double elapsed_milliseconds() const {
+        return boost::chrono::duration_cast<d_milliseconds>(
+                   clock::now() - start_).count();
+    }
+  private:
+    /** Start time */
+    time_point start_;
+};
+#else
 /** Tracks elapsed CPU time. */
 class CpuTimer {
   public:
@@ -275,6 +320,7 @@ class CpuTimer {
     /** Start time */
     std::clock_t start_;
 };
+#endif
 
 } // namespace amici
 

--- a/include/amici/rdata.h
+++ b/include/amici/rdata.h
@@ -224,8 +224,9 @@ class ReturnData: public ModelDimensions {
      * @brief computation time of forward solve [ms]
      *
      * .. warning::
-     *      This tracks the CPU-time of the current process. Therefore,
-     *      in a multi-threaded context, this value may be incorrect.
+     *      If AMICI was built without boost, this tracks the CPU-time of the
+     *      current process. Therefore, in a multi-threaded context, this value
+     *      may be incorrect.
      *
      */
     double cpu_time = 0.0;
@@ -234,8 +235,9 @@ class ReturnData: public ModelDimensions {
      * @brief computation time of backward solve [ms]
      *
      * .. warning::
-     *      This tracks the CPU-time of the current process. Therefore,
-     *      in a multi-threaded context, this value may be incorrect.
+     *      If AMICI was built without boost, this tracks the CPU-time of the
+     *      current process. Therefore, in a multi-threaded context, this value
+     *      may be incorrect.
      *
      */
     double cpu_timeB = 0.0;
@@ -244,8 +246,9 @@ class ReturnData: public ModelDimensions {
      * @brief total CPU time from entering runAmiciSimulation until exiting [ms]
      *
      * .. warning::
-     *      This tracks the CPU-time of the current process. Therefore,
-     *      in a multi-threaded context, this value may be incorrect.
+     *      If AMICI was built without boost, this tracks the CPU-time of the
+     *      current process. Therefore, in a multi-threaded context, this value
+     *      may be incorrect.
      *
      */
     double cpu_time_total = 0.0;
@@ -258,8 +261,9 @@ class ReturnData: public ModelDimensions {
      * (preequilibration)
      *
      * .. warning::
-     *      This tracks the CPU-time of the current process. Therefore,
-     *      in a multi-threaded context, this value may be incorrect.
+     *      If AMICI was built without boost, this tracks the CPU-time of the
+     *      current process. Therefore, in a multi-threaded context, this value
+     *      may be incorrect.
      *
      */
     double preeq_cpu_time = 0.0;
@@ -269,8 +273,9 @@ class ReturnData: public ModelDimensions {
      * problem [ms] (preequilibration)
      *
      * .. warning::
-     *      This tracks the CPU-time of the current process. Therefore,
-     *      in a multi-threaded context, this value may be incorrect.
+     *      If AMICI was built without boost, this tracks the CPU-time of the
+     *      current process. Therefore, in a multi-threaded context, this value
+     *      may be incorrect.
      *
      */
     double preeq_cpu_timeB = 0.0;
@@ -283,8 +288,9 @@ class ReturnData: public ModelDimensions {
      * (postequilibration)
      *
      * .. warning::
-     *      This tracks the CPU-time of the current process. Therefore,
-     *      in a multi-threaded context, this value may be incorrect.
+     *      If AMICI was built without boost, this tracks the CPU-time of the
+     *      current process. Therefore, in a multi-threaded context, this value
+     *      may be incorrect.
      *
      */
     double posteq_cpu_time = 0.0;
@@ -294,8 +300,9 @@ class ReturnData: public ModelDimensions {
      * problem [ms] (postequilibration)
      *
      * .. warning::
-     *      This tracks the CPU-time of the current process. Therefore,
-     *      in a multi-threaded context, this value may be incorrect.
+     *      If AMICI was built without boost, this tracks the CPU-time of the
+     *      current process. Therefore, in a multi-threaded context, this value
+     *      may be incorrect.
      *
      */
     double posteq_cpu_timeB = 0.0;

--- a/src/solver.cpp
+++ b/src/solver.cpp
@@ -874,8 +874,8 @@ bool Solver::timeExceeded(int interval) const
         return false;
 
     eval_counter = 0;
-    return std::chrono::duration<double>(simulation_timer_.elapsed_seconds())
-           > maxtime_;
+    auto elapsed_s = simulation_timer_.elapsed_seconds();
+    return std::chrono::duration<double>(elapsed_s) > maxtime_;
 }
 
 void Solver::setMaxSteps(const long int maxsteps) {


### PR DESCRIPTION
Track thread-specific CPU time in case `boost::chrono` is available (package `libboost-chrono-dev` on Ubuntu).