### PR TITLE
Fix performance test / `AMICI_CXXFLAGS` and `AMICI_LDFLAGS` handling

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -85,13 +85,16 @@ endif()
 
 # Legacy environment variables from Python-sdist times
 if(DEFINED ENV{AMICI_CXXFLAGS})
-  string(APPEND CMAKE_CXX_FLAGS " $ENV{AMICI_CXXFLAGS}")
+  message(STATUS "Appending flags from AMICI_CXXFLAGS: $ENV{AMICI_CXXFLAGS}")
+  add_compile_options("$ENV{AMICI_CXXFLAGS}")
 endif()
 if(DEFINED ENV{AMICI_LDFLAGS})
-  string(APPEND CMAKE_EXE_LINKER_FLAGS " $ENV{AMICI_LDFLAGS}")
+  message(STATUS "Appending flags from AMICI_LDFLAGS: $ENV{AMICI_LDFLAGS}")
+  link_libraries("$ENV{AMICI_LDFLAGS}")
 endif()
 
 if(DEFINED ENV{SWIG})
+  message(STATUS "Setting SWIG_EXECUTABLE to $ENV{SWIG} ($SWIG)")
   set(SWIG_EXECUTABLE $ENV{SWIG})
 endif()
 

--- a/src/CMakeLists.template.cmake
+++ b/src/CMakeLists.template.cmake
@@ -20,6 +20,15 @@ foreach(flag ${MY_CXX_FLAGS})
   endif()
 endforeach()
 
+if(DEFINED ENV{AMICI_CXXFLAGS})
+  message(STATUS "Appending flags from AMICI_CXXFLAGS: $ENV{AMICI_CXXFLAGS}")
+  add_compile_options("$ENV{AMICI_CXXFLAGS}")
+endif()
+if(DEFINED ENV{AMICI_LDFLAGS})
+  message(STATUS "Appending flags from AMICI_LDFLAGS: $ENV{AMICI_LDFLAGS}")
+  link_libraries("$ENV{AMICI_LDFLAGS}")
+endif()
+
 find_package(Amici TPL_AMICI_VERSION REQUIRED HINTS
              ${CMAKE_CURRENT_LIST_DIR}/../../build)
 message(STATUS "Found AMICI ${Amici_DIR}")
@@ -69,13 +78,6 @@ endif()
 if($ENV{ENABLE_GCOV_COVERAGE})
   string(APPEND CMAKE_CXX_FLAGS_DEBUG " --coverage")
   string(APPEND CMAKE_EXE_LINKER_FLAGS_DEBUG " --coverage")
-endif()
-
-if($ENV{AMICI_CXXFLAGS})
-  string(APPEND CMAKE_CXX_FLAGS "$ENV{AMICI_CXXFLAGS}")
-endif()
-if($ENV{AMICI_LDFLAGS})
-  string(APPEND CMAKE_EXE_LINKER_FLAGS "$ENV{AMICI_LDFLAGS}")
 endif()
 
 # SWIG

--- a/tests/performance/test.py
+++ b/tests/performance/test.py
@@ -17,6 +17,7 @@ def parse_args():
     if '_' in arg and re.match(r'O[0-2]', arg.split("_")[-1]):
         optim = arg.split("_")[-1]
         os.environ['AMICI_CXXFLAGS'] = f'-{optim}'
+        print(f"{os.environ['AMICI_CXXFLAGS']=}")
         suffix = f'_{optim}'
         arg = '_'.join(arg.split("_")[:-1])
     else:
@@ -64,9 +65,9 @@ def compile_model(model_dir_source: Path, model_dir_compiled: Path):
     if model_dir_source != model_dir_compiled:
         shutil.copytree(model_dir_source, model_dir_compiled)
 
-    subprocess.run(['python', 'setup.py',
-                    'build_ext', '--build-lib=.', '--force'],
-                   cwd=model_dir_compiled)
+    cmd = ['python', 'setup.py', 'build_ext', '--build-lib=.', '--force']
+    print("Running:", " ".join(cmd))
+    subprocess.run(cmd, cwd=model_dir_compiled, check=True)
 
 
 def prepare_simulation(arg, model, solver, edata):


### PR DESCRIPTION
`AMICI_CXXFLAGS` and `AMICI_LDFLAGS` were inserted in the wrong position, so that e.g.  `-O0` in `AMICI_CXXFLAGS` would have been overridden by `CMAKE_CXX_FLAGS_RELEASE`.