### PR TITLE
Fix HDF5 ambiguous overload 

### DIFF
--- a/src/hdf5.cpp
+++ b/src/hdf5.cpp
@@ -946,14 +946,17 @@ void readSolverSettingsFromHDF5(H5::H5File const& file, Solver &solver,
 
 void readSolverSettingsFromHDF5(const std::string &hdffile, Solver &solver,
                                 const std::string &datasetPath) {
-    H5::H5File file(hdffile.c_str(), H5F_ACC_RDONLY, H5P_DEFAULT);
+    H5::H5File file(hdffile.c_str(), H5F_ACC_RDONLY, H5P_DEFAULT, H5::FileAccPropList::DEFAULT);
 
     readSolverSettingsFromHDF5(file, solver, datasetPath);
 }
 
 void readModelDataFromHDF5(const std::string &hdffile, Model &model,
                            const std::string &datasetPath) {
-    H5::H5File file(hdffile.c_str(), H5F_ACC_RDONLY, H5P_DEFAULT);
+    H5::H5File file(hdffile.c_str(), H5F_ACC_RDONLY, H5P_DEFAULT, H5::FileAccPropList::DEFAULT);
+
+
+      
 
     readModelDataFromHDF5(file, model, datasetPath);
 }

--- a/src/hdf5.cpp
+++ b/src/hdf5.cpp
@@ -946,17 +946,16 @@ void readSolverSettingsFromHDF5(H5::H5File const& file, Solver &solver,
 
 void readSolverSettingsFromHDF5(const std::string &hdffile, Solver &solver,
                                 const std::string &datasetPath) {
-    H5::H5File file(hdffile.c_str(), H5F_ACC_RDONLY, H5P_DEFAULT, H5::FileAccPropList::DEFAULT);
+    H5::H5File file(hdffile.c_str(), H5F_ACC_RDONLY, H5P_DEFAULT,
+                    H5::FileAccPropList::DEFAULT);
 
     readSolverSettingsFromHDF5(file, solver, datasetPath);
 }
 
 void readModelDataFromHDF5(const std::string &hdffile, Model &model,
                            const std::string &datasetPath) {
-    H5::H5File file(hdffile.c_str(), H5F_ACC_RDONLY, H5P_DEFAULT, H5::FileAccPropList::DEFAULT);
-
-
-      
+    H5::H5File file(hdffile.c_str(), H5F_ACC_RDONLY, H5P_DEFAULT,
+                    H5::FileAccPropList::DEFAULT);
 
     readModelDataFromHDF5(file, model, datasetPath);
 }


### PR DESCRIPTION

reported by @dilpath: 
> Fails with HDF5 1.14.0, 1.13.3. Works with 1.12.1

```
      amici/src/hdf5.cpp:949:65: error: call of overloaded ‘H5File(const char*, unsigned int, int)’ is ambiguous
        949 |     H5::H5File file(hdffile.c_str(), H5F_ACC_RDONLY, H5P_DEFAULT);
```
