### PR TITLE
Fix PEtab test suite branch

### DIFF
--- a/.github/workflows/test_petab_test_suite.yml
+++ b/.github/workflows/test_petab_test_suite.yml
@@ -62,7 +62,7 @@ jobs:
       # retrieve test models
       - name: Download and install PEtab test suite
         run: |
-          git clone --depth 1 --branch develop \
+          git clone --depth 1 --branch main \
             https://github.com/PEtab-dev/petab_test_suite \
             && source ./build/venv/bin/activate \
             && cd petab_test_suite && pip3 install -e .
@@ -75,7 +75,6 @@ jobs:
 
       # run test models
       - name: Run PEtab test suite
-        # git clone --depth 1 https://github.com/petab-dev/petab_test_suite
         run: |
           source ./build/venv/bin/activate \
           && AMICI_PARALLEL_COMPILE=2 pytest -v \

--- a/python/tests/test_petab_simulate.py
+++ b/python/tests/test_petab_simulate.py
@@ -13,7 +13,9 @@ from amici.testing import skip_on_valgrind
 def petab_problem() -> petab.Problem:
     """Create a PEtab problem for use in tests."""
     test_case = '0001'
-    test_case_dir = Path(petabtests.SBML_DIR) / test_case
+    test_case_dir = petabtests.get_case_dir(
+        id_=test_case, format_="sbml", version="v1.0.0"
+    )
     petab_yaml_path = test_case_dir / petabtests.problem_yaml_name(test_case)
     return petab.Problem.from_yaml(str(petab_yaml_path))
 

--- a/tests/petab_test_suite/conftest.py
+++ b/tests/petab_test_suite/conftest.py
@@ -31,8 +31,9 @@ def parse_selection(selection_str: str) -> List[int]:
 def pytest_addoption(parser):
     """Add pytest CLI options"""
     parser.addoption("--petab-cases", help="Test cases to run")
-    parser.addoption("--only-pysb", help="Run only PySB tests",
-                     action="store_true")
+    # TODO: re-enable in #1800
+    # parser.addoption("--only-pysb", help="Run only PySB tests",
+    #                  action="store_true")
     parser.addoption("--only-sbml", help="Run only SBML tests",
                      action="store_true", )
 
@@ -54,14 +55,25 @@ def pytest_generate_tests(metafunc):
             test_numbers = None
 
         if metafunc.config.getoption("--only-sbml"):
-            test_numbers = test_numbers if test_numbers else get_cases("sbml")
-            argvalues = [(case, 'sbml') for case in test_numbers]
-        elif metafunc.config.getoption("--only-pysb"):
-            test_numbers = test_numbers if test_numbers else get_cases("pysb")
-            argvalues = [(case, 'pysb') for case in test_numbers]
+            argvalues = [
+                (case, 'sbml', version)
+                for version in ('v1.0.0', )
+                for case in (test_numbers if test_numbers
+                             else get_cases("sbml", version=version))
+            ]
+        # TODO: re-enable in #1800
+        # elif metafunc.config.getoption("--only-pysb"):
+        #     argvalues = [
+        #         (case, 'pysb', "v1.0.0")
+        #         for case in (test_numbers if test_numbers
+        #                      else get_cases("pysb", version="v1.0.0"))
+        #     ]
         else:
             argvalues = []
-            for format in ('sbml', 'pysb'):
-                argvalues.extend((case, format)
-                                 for case in test_numbers or get_cases(format))
-        metafunc.parametrize("case,model_type", argvalues)
+            for version in ('v1.0.0',):
+                for format in ('sbml',):
+                    argvalues.extend(
+                        (case, format, version)
+                        for case in test_numbers or get_cases(format, version)
+                    )
+        metafunc.parametrize("case,model_type,version", argvalues)

--- a/tests/petab_test_suite/test_petab_suite.py
+++ b/tests/petab_test_suite/test_petab_suite.py
@@ -24,10 +24,10 @@ stream_handler = logging.StreamHandler()
 logger.addHandler(stream_handler)
 
 
-def test_case(case, model_type):
+def test_case(case, model_type, version):
     """Wrapper for _test_case for handling test outcomes"""
     try:
-        _test_case(case, model_type)
+        _test_case(case, model_type, version)
     except Exception as e:
         if isinstance(e, NotImplementedError) \
                 or "Timepoint-specific parameter overrides" in str(e):
@@ -39,33 +39,21 @@ def test_case(case, model_type):
             raise e
 
 
-def _test_case(case, model_type):
+def _test_case(case, model_type, version):
     """Run a single PEtab test suite case"""
     case = petabtests.test_id_str(case)
-    logger.debug(f"Case {case} [{model_type}]")
+    logger.debug(f"Case {case} [{model_type}] [{version}]")
 
     # load
-    if model_type == "sbml":
-        case_dir = petabtests.SBML_DIR / case
-        # import petab problem
-        yaml_file = case_dir / petabtests.problem_yaml_name(case)
-        problem = petab.Problem.from_yaml(yaml_file)
-    elif model_type == "pysb":
-        import pysb
-        pysb.SelfExporter.cleanup()
-        pysb.SelfExporter.do_export = True
-        case_dir = petabtests.PYSB_DIR / case
-        # import petab problem
-        yaml_file = case_dir / petabtests.problem_yaml_name(case)
-        problem = PysbPetabProblem.from_yaml(yaml_file,
-                                             flatten=case.startswith('0006'))
-    else:
-        raise ValueError(f"Unsupported model_type: {model_type}")
+    case_dir = petabtests.get_case_dir(case, model_type, version)
+    yaml_file = case_dir / petabtests.problem_yaml_name(case)
+    problem = petab.Problem.from_yaml(yaml_file)
 
     # compile amici model
     if case.startswith('0006') and model_type != "pysb":
         petab.flatten_timepoint_specific_output_overrides(problem)
-    model_name = f"petab_{model_type}_test_case_{case}"
+    model_name = f"petab_{model_type}_test_case_{case}"\
+                 f"_{version.replace('.', '_')}"
     model_output_dir = f'amici_models/{model_name}'
     model = import_petab_problem(
         petab_problem=problem,
@@ -92,7 +80,7 @@ def _test_case(case, model_type):
     simulation_df = simulation_df.rename(
         columns={petab.MEASUREMENT: petab.SIMULATION})
     simulation_df[petab.TIME] = simulation_df[petab.TIME].astype(int)
-    solution = petabtests.load_solution(case, model_type)
+    solution = petabtests.load_solution(case, model_type, version=version)
     gt_chi2 = solution[petabtests.CHI2]
     gt_llh = solution[petabtests.LLH]
     gt_simulation_dfs = solution[petabtests.SIMULATION_DFS]
@@ -173,22 +161,24 @@ def check_derivatives(
 
 def run():
     """Run the full PEtab test suite"""
-
     n_success = 0
     n_skipped = 0
-    cases = petabtests.get_cases('sbml')
-    for case in cases:
-        try:
-            test_case(case, 'sbml')
-            n_success += 1
-        except Skipped:
-            n_skipped += 1
-        except Exception as e:
-            # run all despite failures
-            logger.error(f"Case {case} failed.")
-            logger.error(e)
+    n_total = 0
+    for version in ("v1.0.0",):
+        cases = petabtests.get_cases('sbml', version=version)
+        n_total += len(cases)
+        for case in cases:
+            try:
+                test_case(case, 'sbml', version=version)
+                n_success += 1
+            except Skipped:
+                n_skipped += 1
+            except Exception as e:
+                # run all despite failures
+                logger.error(f"Case {case} failed.")
+                logger.error(e)
 
-    logger.info(f"{n_success} / {len(cases)} successful, "
+    logger.info(f"{n_success} / {n_total} successful, "
                 f"{n_skipped} skipped")
     if n_success != len(cases):
         sys.exit(1)


### PR DESCRIPTION
Adapt to changed test suite file structure.

Disables PEtab-PySB test cases, as they don't officially exist in PEtab 1.0 - will be re-added in #1800.

