### PR TITLE
Fix varying cmake libdir lib(64)/

### DIFF
--- a/python/sdist/amici/setup.template.py
+++ b/python/sdist/amici/setup.template.py
@@ -30,7 +30,8 @@ def get_extension() -> CMakeExtension:
         cmake_configure_options=[
             "-DCMAKE_VERBOSE_MAKEFILE=ON",
             "-DCMAKE_MODULE_PATH="
-            f"{prefix_path.as_posix()}/lib/cmake/SuiteSparse",
+            f"{prefix_path.as_posix()}/lib/cmake/SuiteSparse;"
+            f"{prefix_path.as_posix()}/lib64/cmake/SuiteSparse",
             f"-DKLU_ROOT={prefix_path.as_posix()}",
             "-DAMICI_PYTHON_BUILD_EXT_ONLY=ON",
         ],


### PR DESCRIPTION
Some systems use lib/, some lib64/. 

Just adding the amici package base dir to CMAKE_PREFIX_PATH doesn't suffice to find `FindSuiteSparse_config.cmake`.