### PR TITLE
Doc: Update Windows/MSVC installation instructions

### DIFF
--- a/documentation/python_installation.rst
+++ b/documentation/python_installation.rst
@@ -116,6 +116,8 @@ need to be included:
   This is part of multiple packages, including Desktop Development with C++.
 * Windows Universal C Runtime.
   This is an individual component and installs some DLLs that we need.
+* cmake
+   This is need to build OpenBLAS. Available at https://cmake.org/download/
 
 OpenBLAS
 ^^^^^^^^
@@ -133,27 +135,30 @@ The first script needs to be called in Powershell, and it needs to call
 
     cmd /c "scripts\compileBLAS.cmd $version"
 
+Additionally, in ``compileBLAS.cmd`` make sure that you point to your Visual Studio installation  on line 3. 
+Newer installations could be located under ``C:\Program Files\Microsoft Visual Studio\...\VC\Auxiliary\Build\vcvars64.bat"``.
+
 so that it matches your directory structure.
 This will download OpenBLAS and compile it, creating
 
-    C:\\BLAS\\lib\\openblas.lib
-    C:\\BLAS\\bin\\openblas.dll
+    C:\\BLAS\\OpenBLAS\\lib\\openblas.lib
+    C:\\BLAS\\OpenBLAS\\bin\\openblas.dll
 
 You will also need to define two environment variables:
 
 .. code-block:: text
 
-   BLAS_LIBS="/LIBPATH:C:\BLAS\lib openblas.lib"
-   BLAS_CFLAGS="/IC:/BLAS/OpenBLAS-0.3.19/OpenBLAS-0.3.19"
+   BLAS_LIBS="/LIBPATH:C:/BLAS/OpenBLAS/lib openblas.lib"
+   BLAS_CFLAGS="/IC:/BLAS/OpenBLAS"
 
 One way to do that is to run a PowerShell script with the following commands:
 
 .. code-block:: text
 
-   [System.Environment]::SetEnvironmentVariable("BLAS_LIBS", "/LIBPATH:C:/BLAS/lib openblas.lib", [System.EnvironmentVariableTarget]::User)
-   [System.Environment]::SetEnvironmentVariable("BLAS_LIBS", "/LIBPATH:C:/BLAS/lib openblas.lib", [System.EnvironmentVariableTarget]::Process)
-   [System.Environment]::SetEnvironmentVariable("BLAS_CFLAGS", "-IC:/BLAS/OpenBLAS-0.3.19/OpenBLAS-0.3.19", [System.EnvironmentVariableTarget]::User)
-   [System.Environment]::SetEnvironmentVariable("BLAS_CFLAGS", "-IC:/BLAS/OpenBLAS-0.3.19/OpenBLAS-0.3.19", [System.EnvironmentVariableTarget]::Process)
+   [System.Environment]::SetEnvironmentVariable("BLAS_LIBS", "/LIBPATH:C:/BLAS/OpenBLAS/lib openblas.lib", [System.EnvironmentVariableTarget]::User)
+   [System.Environment]::SetEnvironmentVariable("BLAS_LIBS", "/LIBPATH:C:/BLAS/OpenBLAS/lib openblas.lib", [System.EnvironmentVariableTarget]::Process)
+   [System.Environment]::SetEnvironmentVariable("BLAS_CFLAGS", "-IC:/BLAS/OpenBLAS/include/openblas", [System.EnvironmentVariableTarget]::User)
+   [System.Environment]::SetEnvironmentVariable("BLAS_CFLAGS", "-IC:/BLAS/OpenBLAS/include/openblas", [System.EnvironmentVariableTarget]::Process)
 
 The call ending in ``Process`` sets the environment variable in the current
 process, and it is no longer in effect in the next process. The call ending in
@@ -163,7 +168,7 @@ Now you need to make sure that all required DLLs are within the scope of the
 ``PATH`` variable. In particular, the following directories need to be included
 in ``PATH``:
 
-    C:\\BLAS\\bin
+    C:\\BLAS\\OpenBLAS\\bin
     C:\\Program Files (x86)\\Windows Kits\\10\\Redist\\ucrt\\DLLs\\x64
 
 The first one is needed for ``openblas.dll`` and the second is needed for the
@@ -205,10 +210,10 @@ by MSVC (see Visual Studio above). ``KERNEL32.dll`` is part of Windows and in
 
         import os
         # directory containing `openblas.dll`
-        os.add_dll_directory("C:\\BLAS\\bin")
+        os.add_dll_directory("C:\\BLAS\\OpenBLAS\\bin")
         import amici
 
-    or via the environment variable ``AMICI_DLL_DIRS``.
+    or via the environment variable ``AMICI_DLL_DIRS="C:\BLAS\OpenBLAS\bin"``.
 
 If Python returns the following error upon ``import amici``, try updating to the latest Python version.
 

--- a/documentation/python_installation.rst
+++ b/documentation/python_installation.rst
@@ -217,9 +217,6 @@ by MSVC (see Visual Studio above). ``KERNEL32.dll`` is part of Windows and in
 
     or via the environment variable ``AMICI_DLL_DIRS="C:\BLAS\OpenBLAS\bin"``.
 
-If Python returns the following error upon ``import amici``, try updating to the latest Python version.
-
-    OSError: [WinError 87] The parameter is incorrect: ''
 
 Further topics
 ++++++++++++++

--- a/documentation/python_installation.rst
+++ b/documentation/python_installation.rst
@@ -106,8 +106,6 @@ Some general remarks:
 Using the Microsoft Visual Studio
 ---------------------------------
 
-.. note:: Support for MSVC is experimental.
-
 We assume that Visual Studio (not to be confused with Visual Studio Code)
 is already installed. Using Visual Studio Installer, the following components
 need to be included:
@@ -116,14 +114,16 @@ need to be included:
   This is part of multiple packages, including Desktop Development with C++.
 * Windows Universal C Runtime.
   This is an individual component and installs some DLLs that we need.
-* cmake
-   This is need to build OpenBLAS. Available at https://cmake.org/download/
 
 OpenBLAS
 ^^^^^^^^
 
 There are prebuilt OpenBLAS binaries available, but they did not seem to work
-well here. Therefore, we recommend building OpenBLAS from scratch.
+well here. Therefore, we recommend building OpenBLAS from scratch. This
+requires an installation of CMake. CMake can be installed from
+https://cmake.org/download/ (system-wide), or via ``pip install cmake``
+(in the current Python environment).
+
 
 To build OpenBLAS, download the following scripts from the AMICI repository:
 
@@ -135,8 +135,10 @@ The first script needs to be called in Powershell, and it needs to call
 
     cmd /c "scripts\compileBLAS.cmd $version"
 
-Additionally, in ``compileBLAS.cmd`` make sure that you point to your Visual Studio installation  on line 3. 
-Newer installations could be located under ``C:\Program Files\Microsoft Visual Studio\...\VC\Auxiliary\Build\vcvars64.bat"``.
+Additionally, in ``compileBLAS.cmd`` make sure that you point to your
+Visual Studio installation on line 3.
+Newer installations could be located under
+``C:\Program Files\Microsoft Visual Studio\...\VC\Auxiliary\Build\vcvars64.bat``.
 
 so that it matches your directory structure.
 This will download OpenBLAS and compile it, creating

--- a/swig/amici.i
+++ b/swig/amici.i
@@ -86,7 +86,7 @@ import_array();
 %pythoncode %{
 def __repr__(self):
     return self.this.__repr__()[:-1] + '; ' + repr(np.asarray(self, dtype=np.float64)) + ' >'
-    
+
 %}
 };
 %template(IntVector) std::vector<int>;
@@ -330,13 +330,13 @@ def __repr__(self):
 import sys
 import os
 
-if sys.platform == 'win32' and os.environ.get('AMICI_DLL_DIRS', ''):
-    for dll_dir in os.environ.get("AMICI_DLL_DIRS", "").split(os.pathsep):
+if sys.platform == 'win32' and (dll_dirs := os.environ.get('AMICI_DLL_DIRS')):
+    for dll_dir in dll_dirs.split(os.pathsep):
         os.add_dll_directory(dll_dir)
 
 %}
 
-// import additional types for typehintsn
+// import additional types for typehints
 // also import np for use in __repr__ functions
 %pythonbegin %{
 from typing import TYPE_CHECKING, Iterable, List, Tuple, Sequence

--- a/swig/amici.i
+++ b/swig/amici.i
@@ -330,7 +330,7 @@ def __repr__(self):
 import sys
 import os
 
-if sys.platform == 'win32':
+if sys.platform == 'win32' and os.environ.get('AMICI_DLL_DIRS', ''):
     for dll_dir in os.environ.get("AMICI_DLL_DIRS", "").split(os.pathsep):
         os.add_dll_directory(dll_dir)
 


### PR DESCRIPTION
Updated the description for installation on Windows following installation of AMICI, on Windows 10 running python 3.9. Partly relating to #2012.
- Added cmake to required softwares
- Added a notation that `compileBLAS.cmd`  needs to point to the Visual Studio installation
- Paths to the OpenBLAS installation were updated to be able to set the environmental variables correctly
- Updated faulty paths for OpenBLAS enviromental variables
- Updated faulty paths for `AMICI_DLL_DIRS` enviromental variable

Additionally, added a check in `amici.i` if `AMICI_DLL_DIRS` enviromental variable is present 