### PR TITLE
SBML import: Fix check for required packages

### DIFF
--- a/python/sdist/amici/sbml_import.py
+++ b/python/sdist/amici/sbml_import.py
@@ -481,13 +481,12 @@ class SbmlImporter:
             # the "required" attribute is only available in SBML Level 3
             for i_plugin in range(self.sbml.getNumPlugins()):
                 plugin = self.sbml.getPlugin(i_plugin)
-                if plugin.getPackageName() in ('layout',):
-                    # 'layout' plugin does not have the 'required' attribute
-                    continue
-                if hasattr(plugin, 'getRequired') and not plugin.getRequired():
+                if self.sbml_doc.getPkgRequired(plugin.getPackageName()) \
+                        is False:
                     # if not "required", this has no impact on model
                     #  simulation, and we can safely ignore it
                     continue
+
                 # Check if there are extension elements. If not, we can safely
                 #  ignore the enabled package
                 if plugin.getListOfAllElements():
@@ -633,7 +632,7 @@ class SbmlImporter:
                 continue
             self.add_local_symbol(
                 r.getId(),
-                self._sympy_from_sbml_math(r.getKineticLaw())
+                self._sympy_from_sbml_math(r.getKineticLaw() or sp.Float(0))
             )
 
     def add_local_symbol(self, key: str, value: sp.Expr):
@@ -961,7 +960,9 @@ class SbmlImporter:
             if reaction.isSetId():
                 sym_math = self._local_symbols[reaction.getId()]
             else:
-                sym_math = self._sympy_from_sbml_math(reaction.getKineticLaw())
+                sym_math = self._sympy_from_sbml_math(
+                    reaction.getKineticLaw() or sp.Float(0)
+                )
 
             self.flux_vector[reaction_index] = sym_math
             if any(

--- a/python/sdist/amici/sbml_import.py
+++ b/python/sdist/amici/sbml_import.py
@@ -485,6 +485,22 @@ class SbmlImporter:
                         is False:
                     # if not "required", this has no impact on model
                     #  simulation, and we can safely ignore it
+
+                    if plugin.getPackageName() == "fbc" \
+                            and plugin.getListOfAllElements():
+                        # fbc is labeled not-required, but in fact it is.
+                        # we don't care about the extra attributes of core
+                        # elements, such as fbc:chemicalFormula, but we can't
+                        # do anything meaningful with fbc:objective or
+                        # fbc:fluxBounds
+                        raise SBMLException(
+                            "The following fbc extension elements are "
+                            "currently not supported: "
+                            + ', '.join(
+                                list(map(str, plugin.getListOfAllElements()))
+                            )
+                        )
+
                     continue
 
                 # Check if there are extension elements. If not, we can safely

--- a/tests/testSBMLSuite.py
+++ b/tests/testSBMLSuite.py
@@ -261,11 +261,11 @@ def get_amount_and_variables(settings):
 
 def apply_settings(settings, solver, model):
     """Apply model and solver settings as specified in the test case"""
-
-    ts = np.linspace(float(settings['start']),
-                     float(settings['start'])
-                     + float(settings['duration']),
-                     int(settings['steps']) + 1)
+    # start/duration/steps may be empty
+    ts = np.linspace(float(settings['start'] or 0),
+                     float(settings['start'] or 0)
+                     + float(settings['duration'] or 0),
+                     int(settings['steps'] or 0) + 1)
     atol = float(settings['absolute'])
     rtol = float(settings['relative'])
 
@@ -324,7 +324,7 @@ def read_settings_file(current_test_path: Path, test_id: str):
         for line in f:
             if line != '\n':
                 (key, val) = line.split(':')
-                settings[key] = val
+                settings[key] = val.strip()
     return settings
 
 


### PR DESCRIPTION
getRequired needs to be checked on XXXSBMLDocumentPlugin, not on XXXPlugin.

Also:
* don't try to sympify empty kinetic laws
* handling of empty SBML test suite settings

Enables importing models using the fbc extension (see #2061).

Tested via the following semantic test cases:
01186
01187
01188
01189
01190
01191
01192
01193
01194
01195
01196
01606
01607
01608
01609
01610
01611
01612
01613
01614
01615
01616
01617
01618
01619
01620
01621
01622
01623
01624
01625
01628
01629
01630

