### PR TITLE
Nan observables

### DIFF
--- a/include/amici/model_state.h
+++ b/include/amici/model_state.h
@@ -250,6 +250,11 @@ struct ModelStateDerived {
      * (dimension: `nx_solver` x `nplist`, row-major)
      */
     std::vector<realtype> sx_;
+    
+    /** temporary storage for sy,
+     * (dimension: `ny` x `nplist`, row-major)
+     */
+    std::vector<realtype> sy_;
 
     /** temporary storage for `x_rdata` (dimension: `nx_rdata`) */
     std::vector<realtype> x_rdata_;

--- a/src/model.cpp
+++ b/src/model.cpp
@@ -2410,7 +2410,7 @@ void Model::fdJzdp(const int ie, const int nroots, realtype t,
                         &derived_state_.dJrzdsigma_.at(izt * nz * nJ), nJ,
                         derived_state_.dsigmazdp_.data(), nz,
                         1.0, derived_state_.dJzdp_.data(), nJ);
-            
+
             setNaNtoZero(derived_state_.dJrzdz_);
             amici_dgemm(BLASLayout::colMajor, BLASTranspose::noTrans,
                         BLASTranspose::noTrans, nJ, nplist(), nz, 1.0,

--- a/src/model.cpp
+++ b/src/model.cpp
@@ -78,6 +78,15 @@ const std::map<ModelQuantity, std::string> model_quantity_to_str {
 
 };
 
+
+static void setNaNtoZero(std::vector<realtype> &vec) {
+    std::for_each(vec.begin(), vec.end(), [](double& val) {
+        if (std::isnan(val)) {
+            val = 0.0;
+        }
+    });
+}
+
 /**
  * @brief local helper function to get parameters
  * @param ids vector of name/ids of (fixed)Parameters
@@ -97,10 +106,6 @@ static realtype getValueById(std::vector<std::string> const &ids,
 
     throw AmiException("Could not find %s with specified %s", variable_name,
                        id_name);
-}
-
-static void setNaNtoZero(std::vector<realtype> &v) {
-    std::for_each(v.begin(), v.end(), [](realtype &f){return std::isnan(f) ? 0.0 : f;});
 }
 
 /**
@@ -909,6 +914,7 @@ void Model::getObservableSensitivity(gsl::span<realtype> sy, const realtype t,
     //        M  K                 K  N                     M  N
     //        lda                  ldb                      ldc
     setNaNtoZero(derived_state_.dydx_);
+    setNaNtoZero(derived_state_.sx_);
     amici_dgemm(BLASLayout::colMajor, BLASTranspose::noTrans,
                 BLASTranspose::noTrans, ny, nplist(), nx_solver, 1.0,
                 derived_state_.dydx_.data(), ny,
@@ -945,10 +951,12 @@ void Model::getObservableSigmaSensitivity(gsl::span<realtype> ssigmay,
         //             M  N                      M  K          K  N
         //             ldc                       lda           ldb
         setNaNtoZero(derived_state_.dsigmaydy_);
+        derived_state_.sy_.assign(sy.begin(), sy.end());
+        setNaNtoZero(derived_state_.sy_);
         amici_dgemm(BLASLayout::colMajor, BLASTranspose::noTrans,
                     BLASTranspose::noTrans, ny, nplist(), ny, 1.0,
                     derived_state_.dsigmaydy_.data(), ny,
-                    sy.data(), ny, 1.0, ssigmay.data(), ny);
+                    derived_state_.sy_.data(), ny, 1.0, ssigmay.data(), ny);
     }
 
     if (always_check_finite_)
@@ -993,6 +1001,7 @@ void Model::addObservableObjectiveSensitivity(std::vector<realtype> &sllh,
 
     // C := alpha*op(A)*op(B) + beta*C,
     setNaNtoZero(derived_state_.dJydx_);
+    setNaNtoZero(derived_state_.sx_);
     amici_dgemm(BLASLayout::colMajor, BLASTranspose::noTrans,
                 BLASTranspose::noTrans, nJ, nplist(), nx_solver, 1.0,
                 derived_state_.dJydx_.data(), nJ,
@@ -1045,6 +1054,7 @@ void Model::getEventSensitivity(gsl::span<realtype> sz, const int ie,
         //        M  K                 K  N                     M  N
         //        lda                  ldb                      ldc
         setNaNtoZero(derived_state_.dzdx_);
+        setNaNtoZero(derived_state_.sx_);
         amici_dgemm(BLASLayout::colMajor, BLASTranspose::noTrans,
                     BLASTranspose::noTrans, nz, nplist(), nx_solver, 1.0,
                     derived_state_.dzdx_.data(), nz,
@@ -1100,6 +1110,7 @@ void Model::getEventRegularizationSensitivity(gsl::span<realtype> srz,
         //         M  K                 K  N                      M  N
         //         lda                  ldb                       ldc
         setNaNtoZero(derived_state_.drzdx_);
+        setNaNtoZero(derived_state_.sx_);
         amici_dgemm(BLASLayout::colMajor, BLASTranspose::noTrans,
                     BLASTranspose::noTrans, nz, nplist(), nx_solver, 1.0,
                     derived_state_.drzdx_.data(), nz,
@@ -1198,6 +1209,7 @@ void Model::addEventObjectiveSensitivity(std::vector<realtype> &sllh,
 
     // C := alpha*op(A)*op(B) + beta*C,
     setNaNtoZero(derived_state_.dJzdx_);
+    setNaNtoZero(derived_state_.sx_);
     amici_dgemm(BLASLayout::colMajor, BLASTranspose::noTrans,
                 BLASTranspose::noTrans, nJ, nplist(), nx_solver, 1.0,
                 derived_state_.dJzdx_.data(), nJ,
@@ -1994,6 +2006,8 @@ void Model::fdJydy(const int it, const AmiVector &x, const ExpData &edata) {
         fdsigmaydy(it, &edata);
         SUNMatrixWrapper tmp_dense(nJ, ny);
 
+        setNaNtoZero(derived_state_.dJydsigma_);
+        setNaNtoZero(derived_state_.dsigmaydy_);
         for (int iyt = 0; iyt < nytrue; iyt++) {
             if (!derived_state_.dJydy_.at(iyt).capacity())
                 continue;
@@ -2014,7 +2028,6 @@ void Model::fdJydy(const int it, const AmiVector &x, const ExpData &edata) {
             // C(nJ,ny)  A(nJ,ny)  * B(ny,ny)
             // sparse    dense       dense
             tmp_dense.zero();
-            setNaNtoZero(derived_state_.dJydsigma_);
             amici_dgemm(BLASLayout::colMajor, BLASTranspose::noTrans,
                         BLASTranspose::noTrans, nJ, ny, ny, 1.0,
                         &derived_state_.dJydsigma_.at(iyt * nJ * ny), nJ,
@@ -2100,6 +2113,8 @@ void Model::fdJydp(const int it, const AmiVector &x, const ExpData &edata) {
     fdJydsigma(it, x, edata);
     fdsigmaydp(it, &edata);
 
+    setNaNtoZero(derived_state_.dJydsigma_);
+    setNaNtoZero(derived_state_.dsigmaydp_);
     for (int iyt = 0; iyt < nytrue; ++iyt) {
         if (!edata.isSetObservedData(it, iyt))
             continue;
@@ -2119,7 +2134,6 @@ void Model::fdJydp(const int it, const AmiVector &x, const ExpData &edata) {
                         1.0, derived_state_.dJydp_.data(), nJ);
         }
         // dJydp = 1.0 * dJydp +  1.0 * dJydsigma * dsigmaydp
-        setNaNtoZero(derived_state_.dJydsigma_);
         amici_dgemm(BLASLayout::colMajor, BLASTranspose::noTrans,
                     BLASTranspose::noTrans, nJ, nplist(), ny, 1.0,
                     &derived_state_.dJydsigma_.at(iyt * nJ * ny), nJ,
@@ -2380,20 +2394,25 @@ void Model::fdJzdp(const int ie, const int nroots, realtype t,
 
     derived_state_.dJzdp_.assign(nJ * nplist(), 0.0);
 
-    fdJzdz(ie, nroots, t, x, edata);
     fdzdp(ie, t, x);
-
-    fdJzdsigma(ie, nroots, t, x, edata);
     fdsigmazdp(ie, nroots, t, &edata);
+    fdJzdz(ie, nroots, t, x, edata);
+    fdJrzdz(ie, nroots, t, x, edata);
+    fdJzdsigma(ie, nroots, t, x, edata);
+    fdJrzdsigma(ie, nroots, t, x, edata);
 
+    setNaNtoZero(derived_state_.dzdp_);
+    setNaNtoZero(derived_state_.dsigmazdp_);
+    setNaNtoZero(derived_state_.dJzdz_);
+    setNaNtoZero(derived_state_.dJrzdz_);
+    setNaNtoZero(derived_state_.dJzdsigma_);
+    setNaNtoZero(derived_state_.dJrzdsigma_);
     for (int izt = 0; izt < nztrue; ++izt) {
         if (!edata.isSetObservedEvents(nroots, izt))
             continue;
 
         if (t < edata.getTimepoint(edata.nt() - 1)) {
             // with z
-            fdJzdz(ie, nroots, t, x, edata);
-            setNaNtoZero(derived_state_.dJzdz_);
             amici_dgemm(BLASLayout::colMajor, BLASTranspose::noTrans,
                         BLASTranspose::noTrans, nJ, nplist(), nz, 1.0,
                         &derived_state_.dJzdz_.at(izt * nz * nJ), nJ,
@@ -2401,17 +2420,12 @@ void Model::fdJzdp(const int ie, const int nroots, realtype t,
                         derived_state_.dJzdp_.data(), nJ);
         } else {
             // with rz
-            fdJrzdz(ie, nroots, t, x, edata);
-            fdJrzdsigma(ie, nroots, t, x, edata);
-
-            setNaNtoZero(derived_state_.dJrzdsigma_);
             amici_dgemm(BLASLayout::colMajor, BLASTranspose::noTrans,
                         BLASTranspose::noTrans, nJ, nplist(), nz, 1.0,
                         &derived_state_.dJrzdsigma_.at(izt * nz * nJ), nJ,
                         derived_state_.dsigmazdp_.data(), nz,
                         1.0, derived_state_.dJzdp_.data(), nJ);
 
-            setNaNtoZero(derived_state_.dJrzdz_);
             amici_dgemm(BLASLayout::colMajor, BLASTranspose::noTrans,
                         BLASTranspose::noTrans, nJ, nplist(), nz, 1.0,
                         &derived_state_.dJrzdz_.at(izt * nz * nJ), nJ,
@@ -2419,7 +2433,6 @@ void Model::fdJzdp(const int ie, const int nroots, realtype t,
                         derived_state_.dJzdp_.data(), nJ);
         }
 
-        setNaNtoZero(derived_state_.dJzdsigma_);
         amici_dgemm(BLASLayout::colMajor, BLASTranspose::noTrans,
                     BLASTranspose::noTrans, nJ, nplist(), nz, 1.0,
                     &derived_state_.dJzdsigma_.at(izt * nz * nJ), nJ,
@@ -2439,6 +2452,14 @@ void Model::fdJzdx(const int ie, const int nroots, const realtype t,
     derived_state_.dJzdx_.assign(nJ * nx_solver, 0.0);
 
     fdJzdz(ie, nroots, t, x, edata);
+    fdJrzdz(ie, nroots, t, x, edata);
+    fdzdx(ie, t, x);
+    fdrzdx(ie, t, x);
+    
+    setNaNtoZero(derived_state_.dJzdz_);
+    setNaNtoZero(derived_state_.dJrzdz_);
+    setNaNtoZero(derived_state_.dzdx_);
+    setNaNtoZero(derived_state_.drzdx_);
 
     for (int izt = 0; izt < nztrue; ++izt) {
         if (!edata.isSetObservedEvents(nroots, izt))
@@ -2446,8 +2467,6 @@ void Model::fdJzdx(const int ie, const int nroots, const realtype t,
 
         if (t < edata.getTimepoint(edata.nt() - 1)) {
             // z
-            fdzdx(ie, t, x);
-            setNaNtoZero(derived_state_.dJzdz_);
             amici_dgemm(BLASLayout::colMajor, BLASTranspose::noTrans,
                         BLASTranspose::noTrans, nJ, nx_solver, nz, 1.0,
                         &derived_state_.dJzdz_.at(izt * nz * nJ), nJ,
@@ -2455,9 +2474,6 @@ void Model::fdJzdx(const int ie, const int nroots, const realtype t,
                         derived_state_.dJzdx_.data(), nJ);
         } else {
             // rz
-            fdJrzdz(ie, nroots, t, x, edata);
-            fdrzdx(ie, t, x);
-            setNaNtoZero(derived_state_.dJrzdz_);
             amici_dgemm(BLASLayout::colMajor, BLASTranspose::noTrans,
                         BLASTranspose::noTrans, nJ, nx_solver, nz, 1.0,
                         &derived_state_.dJrzdz_.at(izt * nz * nJ), nJ,


### PR DESCRIPTION
zeroes all nans before matrix multiplications via `dgemm` to avoid propagation of nan values. Only happens for (event) observables, so we don't have to worry about performance implications too much.

good testcase for this is Schwen model, but will defer adding testcases to #1548 