### PR TITLE
Revert "GHA: Remove documentation tests (#2057)"

### DIFF
--- a/.github/workflows/test_doc.yml
+++ b/.github/workflows/test_doc.yml
@@ -56,7 +56,7 @@ jobs:
 
     strategy:
       matrix:
-        python-version: [ 3.8 ]
+        python-version: [ "3.11" ]
 
     steps:
       - name: Set up Python ${{ matrix.python-version }}

--- a/.github/workflows/test_doc.yml
+++ b/.github/workflows/test_doc.yml
@@ -1,0 +1,94 @@
+name: Documentation Tests
+on:
+  push:
+    branches:
+      - develop
+      - master
+  pull_request:
+    branches:
+      - develop
+      - master
+  merge_group:
+  workflow_dispatch:
+  schedule:
+    - cron:  '48 4 * * *'
+
+jobs:
+  doxygen:
+    name: Test Doxygen
+
+    runs-on: ubuntu-22.04
+
+    strategy:
+      matrix:
+        python-version: [3.8]
+
+    steps:
+    - name: Set up Python ${{ matrix.python-version }}
+      uses: actions/setup-python@v4
+      with:
+        python-version: ${{ matrix.python-version }}
+
+    - uses: actions/checkout@v3
+    - run: git fetch --prune --unshallow
+
+    - name: apt
+      run: |
+        sudo apt-get update \
+          && sudo apt-get install -y \
+          bison \
+          ragel \
+          graphviz \
+          texlive-latex-extra
+
+    - name: Build doxygen
+      run: |
+        sudo scripts/downloadAndBuildDoxygen.sh
+
+    - name: Run doxygen
+      run: |
+        scripts/run-doxygen.sh
+
+  sphinx:
+    name: Test Sphinx
+
+    runs-on: ubuntu-22.04
+
+    strategy:
+      matrix:
+        python-version: [ 3.8 ]
+
+    steps:
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v4
+        with:
+          python-version: ${{ matrix.python-version }}
+
+      - uses: actions/checkout@v3
+      - run: git fetch --prune --unshallow
+
+      - run: echo "AMICI_DIR=$(pwd)" >> $GITHUB_ENV
+      - run: echo "SWIG=${AMICI_DIR}/ThirdParty/swig-4.1.1/install/bin/swig" >> $GITHUB_ENV
+
+      - name: Build doxygen
+        run: |
+          sudo scripts/downloadAndBuildDoxygen.sh
+
+      # install amici dependencies
+      - name: apt
+        run: |
+          sudo apt-get update \
+            && sudo apt-get install -y \
+              g++ \
+              libatlas-base-dev \
+              libboost-serialization-dev \
+              pandoc \
+              python3-venv \
+
+      - name: Build swig
+        run: |
+          sudo scripts/downloadAndBuildSwig.sh
+
+      - name: sphinx
+        run: |
+          scripts/run-sphinx.sh

--- a/.github/workflows/test_doc.yml
+++ b/.github/workflows/test_doc.yml
@@ -56,7 +56,7 @@ jobs:
 
     strategy:
       matrix:
-        python-version: [ "3.11" ]
+        python-version: [ "3.10" ]
 
     steps:
       - name: Set up Python ${{ matrix.python-version }}

--- a/scripts/run-sphinx.sh
+++ b/scripts/run-sphinx.sh
@@ -6,7 +6,7 @@ AMICI_PATH=$(cd $SCRIPT_PATH/.. && pwd)
 
 python3 -m venv ${AMICI_PATH}/doc-venv --clear
 source ${AMICI_PATH}/doc-venv/bin/activate
-python -m pip install --upgrade --no-cache-dir pip
+python -m pip install --upgrade --no-cache-dir pip setuptools wheel
 (cd ${AMICI_PATH}/ && python -m pip install --exists-action=w --no-cache-dir -r documentation/rtd_requirements.txt)
 (cd ${AMICI_PATH}/ && python -m pip install --exists-action=w --no-cache-dir -r documentation/rtd_requirements2.txt)
 


### PR DESCRIPTION
As we cannot use RTD to check on `merge_queue` events...

This reverts commit 0974d89c2cb18a5af9ae9298b4bca5bd7043c464.

And runs on Python3.10 and fixes some issues with the default setuptools.

