### PR TITLE
Fix ReturnData::{preeq_wrms,posteq_wrms} with FSA and check_sensi_steadystate_conv_=True

### DIFF
--- a/src/steadystateproblem.cpp
+++ b/src/steadystateproblem.cpp
@@ -707,7 +707,8 @@ void SteadystateProblem::runSteadystateSimulation(
             if (wrms_ < conv_thresh && check_sensi_conv_ &&
                 sensitivityFlag == SensitivityMethod::forward) {
                 updateSensiSimulation(solver);
-                wrms_ = getWrmsFSA(model);
+                if (getWrmsFSA(model) < conv_thresh)
+                    break; // converged
             }
         }
 


### PR DESCRIPTION
Documentation says, that ReturnData::{preeq_wrms,posteq_wrms} refers to the `weighted root-mean-square of the rhs when steadystate was reached`, independent of `Solver::check_sensi_steadystate_conv_`, but this wasn't what happened. Now it is.