### PR TITLE
CMake: Fix choosing SWIG via env variable

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -95,6 +95,8 @@ endif()
 
 if(DEFINED ENV{SWIG})
   message(STATUS "Setting SWIG_EXECUTABLE to $ENV{SWIG} ($SWIG)")
+  unset(SWIG_VERSION CACHE)
+  unset(SWIG_DIR CACHE)
   set(SWIG_EXECUTABLE $ENV{SWIG})
 endif()
 


### PR DESCRIPTION
Only changing SWIG_EXECUTABLE will lead to inconsistent settings. Need to unset version and directory, so FindSWIG will try to set them according to SWIG_EXECUTABLE.