### PR TITLE
Fix unquoted filename

### DIFF
--- a/cmake/version.cmake
+++ b/cmake/version.cmake
@@ -3,7 +3,7 @@ if(Git_FOUND)
   execute_process(
     COMMAND
       sh -c
-      "${GIT_EXECUTABLE} describe --abbrev=4 --dirty=-dirty --always --tags  | cut -c 2- | tr -d '\n' | sed s/-/./"
+      "'${GIT_EXECUTABLE}' describe --abbrev=4 --dirty=-dirty --always --tags  | cut -c 2- | tr -d '\n' | sed s/-/./"
     WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
     OUTPUT_VARIABLE PROJECT_VERSION_GIT)
 endif()


### PR DESCRIPTION
Fixes issues with paths containing blanks:
`sh: line 1: C:/Program: No such file or directory` https://github.com/AMICI-dev/AMICI/actions/runs/5054632314/jobs/9069784824?pr=2104