### PR TITLE
[petab] fix pysb pattern matching

### DIFF
--- a/python/sdist/amici/petab_util.py
+++ b/python/sdist/amici/petab_util.py
@@ -58,6 +58,11 @@ def get_states_in_condition_table(
             return states
         import pysb.pattern
 
+        if not petab_problem.model.model.species:
+            import pysb.bng
+
+            pysb.bng.generate_equations(petab_problem.model.model)
+
         try:
             spm = pysb.pattern.SpeciesPatternMatcher(
                 model=petab_problem.model.model

--- a/tests/benchmark-models/benchmark_models.yaml
+++ b/tests/benchmark-models/benchmark_models.yaml
@@ -23,7 +23,7 @@ Borghans_BiophysChem1997:
   llh: 83.3237191357272
   t_sim: 0.005
   t_fwd: 0.5
-  t_adj: 0.1
+  t_adj: 0.2
   note: benchmark collection reference value matches up to sign when applying log10-correction +sum(log(meas*log(10)) / 2
 
 Brannmark_JBC2010:


### PR DESCRIPTION
can't assume equations have been generated and `SpeciesPatternMatcher` won't work otherwise.