### PR TITLE
Fix PEtab deprecation warning

### DIFF
--- a/python/tests/splines_utils.py
+++ b/python/tests/splines_utils.py
@@ -263,7 +263,7 @@ def create_petab_problem(
     folder = os.path.abspath(folder)
     os.makedirs(folder, exist_ok=True)
     problem.to_files(
-        sbml_file=os.path.join(folder, f"{model_name}_model.xml"),
+        model_file=os.path.join(folder, f"{model_name}_model.xml"),
         condition_file=os.path.join(folder, f"{model_name}_conditions.tsv"),
         measurement_file=os.path.join(folder, f"{model_name}_measurements.tsv"),
         parameter_file=os.path.join(folder, f"{model_name}_parameters.tsv"),


### PR DESCRIPTION
Fixes `/home/runner/work/AMICI/AMICI/python/tests/splines_utils.py:265: DeprecationWarning: The `sbml_file` argument is deprecated and will be removed in a future version. Use `model_file` instead.`