### PR TITLE
GHA pypa/gh-action-pypi-publish@master -> @release/v1

### DIFF
--- a/.github/workflows/deploy_release.yml
+++ b/.github/workflows/deploy_release.yml
@@ -36,11 +36,11 @@ jobs:
         scripts/buildSdist.sh
 
     - name: Publish a Python distribution to PyPI
-      uses: pypa/gh-action-pypi-publish@master
+      uses: pypa/gh-action-pypi-publish@release/v1
       with:
         user: __token__
         password: ${{ secrets.pypi_password }}
-        packages_dir: python/sdist/dist
+        packages-dir: python/sdist/dist
 
   bioSimulatorsUpdateCliAndDockerImage:
     name: Release to BioSimulators


### PR DESCRIPTION
https://github.com/pypa/gh-action-pypi-publish/ :
> The master branch version has been sunset. Please, change the GitHub Action version you use from master to release/v1 or use an exact tag, or a full Git commit SHA.