### PR TITLE
Add min version for pandas

### DIFF
--- a/python/sdist/setup.cfg
+++ b/python/sdist/setup.cfg
@@ -35,7 +35,7 @@ install_requires =
     numpy; python_version>='3.12'
     python-libsbml
     h5py
-    pandas
+    pandas>=2.0.2
     wurlitzer
     toposort
     setuptools>=48


### PR DESCRIPTION
This line is currently a tuple, which is supported by the latest pandas version (2.0.2), but not some earlier versions (e.g. 1.5.3).

https://github.com/AMICI-dev/AMICI/blob/0fc51c0ddcac0661a83931e8b1c4a59f0c6db85c/python/sdist/amici/petab_objective.py#L821