### PR TITLE
Fix sympy DeprecationWarning

### DIFF
--- a/python/sdist/amici/sbml_import.py
+++ b/python/sdist/amici/sbml_import.py
@@ -18,6 +18,7 @@ from typing import Any, Callable, Dict, Iterable, List, Optional, Set, Tuple, Un
 import libsbml as sbml
 import numpy as np
 import sympy as sp
+from sympy.logic.boolalg import BooleanFalse, BooleanTrue
 
 from . import has_clibs
 from .constants import SymbolId
@@ -1047,7 +1048,12 @@ class SbmlImporter:
                     reaction.getKineticLaw() or sp.Float(0)
                 )
 
-            self.flux_vector[reaction_index] = sym_math
+            self.flux_vector[reaction_index] = sym_math.subs(
+                {
+                    BooleanTrue(): sp.Float(1.0),
+                    BooleanFalse(): sp.Float(0.0),
+                }
+            )
             if any(
                 str(symbol) in reaction_ids
                 for symbol in self.flux_vector[reaction_index].free_symbols

--- a/python/sdist/amici/sbml_import.py
+++ b/python/sdist/amici/sbml_import.py
@@ -2205,7 +2205,12 @@ class SbmlImporter:
         try:
             try:
                 formula = sp.sympify(
-                    _parse_logical_operators(math_string), locals=self._local_symbols
+                    _parse_logical_operators(math_string),
+                    locals={
+                        "true": sp.Float(1.0),
+                        "false": sp.Float(0.0),
+                        **self._local_symbols,
+                    },
                 )
             except TypeError as err:
                 if str(err) == "BooleanAtom not allowed in this context.":

--- a/python/sdist/amici/sbml_import.py
+++ b/python/sdist/amici/sbml_import.py
@@ -2211,12 +2211,7 @@ class SbmlImporter:
         try:
             try:
                 formula = sp.sympify(
-                    _parse_logical_operators(math_string),
-                    locals={
-                        "true": sp.Float(1.0),
-                        "false": sp.Float(0.0),
-                        **self._local_symbols,
-                    },
+                    _parse_logical_operators(math_string), locals=self._local_symbols
                 )
             except TypeError as err:
                 if str(err) == "BooleanAtom not allowed in this context.":


### PR DESCRIPTION
During SBML test case 01288 when handling `true`/`false`:

```
E       sympy.utilities.exceptions.SymPyDeprecationWarning:
E
E       non-Expr objects in a Matrix is deprecated. Matrix represents
E       a mathematical matrix. To represent a container of non-numeric
E       entities, Use a list of lists, TableForm, NumPy array, or some
E       other data structure instead.
E
E       See https://docs.sympy.org/latest/explanation/active-deprecations.html#deprecated-non-expr-in-matrix
E       for details.
E
E       This has been deprecated since SymPy version 1.9. It
E       will be removed in a future version of SymPy.
```