### PR TITLE
Fix steadystate sensitivity mode for performance test 

### DIFF
--- a/tests/performance/test.py
+++ b/tests/performance/test.py
@@ -36,12 +36,19 @@ def check_results(rdata):
         "numerrtestfailsB",
         "numnonlinsolvconvfails",
         "numnonlinsolvconvfailsB",
+        "preeq_status",
+        "preeq_numsteps",
+        "preeq_numstepsB",
         "preeq_cpu_time",
         "preeq_cpu_timeB",
+        "cpu_time_total",
         "cpu_time",
         "cpu_timeB",
+        "posteq_status",
         "posteq_cpu_time",
         "posteq_cpu_timeB",
+        "posteq_numsteps",
+        "posteq_numstepsB",
     ]
     for d in diagnostics:
         print(d, rdata[d])

--- a/tests/performance/test.py
+++ b/tests/performance/test.py
@@ -121,6 +121,7 @@ def prepare_simulation(arg, model, solver, edata):
         model.setParameters([0.1 for _ in tmp_par])
         solver.setSensitivityMethod(amici.SensitivityMethod.forward)
         solver.setSensitivityOrder(amici.SensitivityOrder.first)
+        model.setSteadyStateSensitivityMode(amici.SteadyStateSensitivityMode.newtonOnly)
         edata.setTimepoints([float("inf")])
     elif arg == "adjoint_steadystate_sensitivities_non_optimal_parameters":
         tmp_par = model.getParameters()


### PR DESCRIPTION
In https://github.com/AMICI-dev/AMICI/pull/2074, the default steadystate sensitivity mode was changed, leading to test [failures ](https://github.com/AMICI-dev/AMICI/pull/2074#issuecomment-1617449196). Those are fixed by not relying on the default, but setting  `newtonOnly` explicitly.  

Additionally, some more output is added.

