### PR TITLE
prevent the second run of newton's method in case simulation was turn…

### DIFF
--- a/src/steadystateproblem.cpp
+++ b/src/steadystateproblem.cpp
@@ -147,7 +147,7 @@ void SteadystateProblem::findSteadyState(
         findSteadyStateBySimulation(solver, model, it);
 
     /* Simulation didn't work, retry the Newton solver from last sim state. */
-    if (!turnOffNewton && !checkSteadyStateSuccess())
+    if (!turnOffNewton && !turnOffSimulation && !checkSteadyStateSuccess())
         findSteadyStateByNewtonsMethod(model, true);
 
     /* Nothing worked, throw an as informative error as possible */


### PR DESCRIPTION
…ed off

The second attempt only makes sense if simulation was attempted before and the starting point changed 