### PR TITLE
Fix SBML import for events with trigger functions depending on parame…

### DIFF
--- a/python/sdist/amici/sbml_import.py
+++ b/python/sdist/amici/sbml_import.py
@@ -549,9 +549,9 @@ class SbmlImporter:
         self._process_species()
         self._process_reactions()
         self._process_rules()
+        self._process_events()
         self._process_initial_assignments()
         self._process_species_references()
-        self._process_events()
 
     def check_support(self) -> None:
         """


### PR DESCRIPTION
Fix SBML import for events with trigger functions depending on parameters that are initial assignment targets.

I.e. given the current way of processing initial assignments, events have to be processed first. Otherwise model compilation fails with `use of undeclared identifier`, because the respective parameter was replaced by its initial assignment value.


Credits to @LeaSeep for triggering that issue. 