### PR TITLE
Evaluate and plot symbolic expressions based on simulation results

### DIFF
--- a/python/examples/example_steadystate/ExampleSteadystate.ipynb
+++ b/python/examples/example_steadystate/ExampleSteadystate.ipynb
@@ -2045,10 +2045,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.7.7",
-   "nbsphinx": {
-    "execute": "always"
-   }
+   "version": "3.7.7"
   },
   "toc": {
    "base_numbering": 1,
@@ -2062,6 +2059,9 @@
    "toc_position": {},
    "toc_section_display": true,
    "toc_window_display": false
+  },
+  "nbsphinx": {
+   "execute": "always"
   }
  },
  "nbformat": 4,

--- a/python/examples/example_steadystate/ExampleSteadystate.ipynb
+++ b/python/examples/example_steadystate/ExampleSteadystate.ipynb
@@ -2045,7 +2045,10 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.7.7"
+   "version": "3.7.7",
+   "nbsphinx": {
+    "execute": "always"
+   }
   },
   "toc": {
    "base_numbering": 1,

--- a/python/examples/example_steadystate/ExampleSteadystate.ipynb
+++ b/python/examples/example_steadystate/ExampleSteadystate.ipynb
@@ -354,7 +354,7 @@
    "source": [
     "### Importing the module and loading the model\n",
     "\n",
-    "If everything went well, we need to add the previously selected model output directory to our PYTHON_PATH and are then ready to load newly generated model:"
+    "If everything went well, we can now import the newly generated Python module containing our model:"
    ]
   },
   {
@@ -392,7 +392,7 @@
    "source": [
     "model = model_module.getModel()\n",
     "\n",
-    "print(\"Model name:\", model.getName())\n",
+    "print(\"Model name:      \", model.getName())\n",
     "print(\"Model parameters:\", model.getParameterIds())\n",
     "print(\"Model outputs:   \", model.getObservableIds())\n",
     "print(\"Model states:    \", model.getStateIds())"

--- a/python/examples/example_steadystate/ExampleSteadystate.ipynb
+++ b/python/examples/example_steadystate/ExampleSteadystate.ipynb
@@ -920,9 +920,31 @@
    "source": [
     "import amici.plotting\n",
     "\n",
-    "amici.plotting.plotStateTrajectories(rdata, model=None)\n",
-    "amici.plotting.plotObservableTrajectories(rdata, model=None)"
+    "amici.plotting.plot_state_trajectories(rdata, model=None)\n",
+    "amici.plotting.plot_observable_trajectories(rdata, model=None)"
    ]
+  },
+  {
+   "cell_type": "markdown",
+   "source": [
+    "We can also evaluate symbolic expressions of model quantities using `amici.numpy.evaluate`, or directly plot the results using  `amici.plotting.plot_expressions`:"
+   ],
+   "metadata": {
+    "collapsed": false
+   }
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "outputs": [],
+   "source": [
+    "amici.plotting.plot_expressions(\n",
+    "    \"observable_x1 + observable_x2 + observable_x3\", rdata=rdata\n",
+    ")"
+   ],
+   "metadata": {
+    "collapsed": false
+   }
   },
   {
    "cell_type": "markdown",

--- a/python/sdist/amici/plotting.py
+++ b/python/sdist/amici/plotting.py
@@ -6,15 +6,12 @@ Plotting related functions
 from typing import Iterable, Optional, Sequence, Union
 
 import matplotlib.pyplot as plt
-import numpy as np
 import pandas as pd
 import seaborn as sns
-import sympy as sp
 from matplotlib.axes import Axes
 
 from . import Model, ReturnDataView
-
-StrOrExpr = Union[str, sp.Expr]
+from .numpy import StrOrExpr, evaluate
 
 
 def plot_state_trajectories(
@@ -119,31 +116,6 @@ def plot_jacobian(rdata: ReturnDataView):
 # backwards compatibility
 plotStateTrajectories = plot_state_trajectories
 plotObservableTrajectories = plot_observable_trajectories
-
-
-def evaluate(expr: StrOrExpr, rdata: ReturnDataView) -> np.array:
-    """Evaluate a symbolic expression based on the given simulation outputs.
-
-    :param expr:
-        A symbolic expression, e.g. a sympy expression or a string that can be sympified.
-        Can include state variable, expression, and observable IDs, depending on whether
-        the respective data is available in the simulation results.
-        Parameters are not yet supported.
-    :param rdata:
-        The simulation results.
-
-    :return:
-        The evaluated expression for the simulation output timepoints.
-    """
-    from sympy.utilities.lambdify import lambdify
-
-    if isinstance(expr, str):
-        expr = sp.sympify(expr)
-
-    arg_names = list(sorted(expr.free_symbols, key=lambda x: x.name))
-    func = lambdify(arg_names, expr, "numpy")
-    args = [rdata.by_id(arg.name) for arg in arg_names]
-    return func(*args)
 
 
 def plot_expressions(

--- a/python/sdist/amici/plotting.py
+++ b/python/sdist/amici/plotting.py
@@ -6,6 +6,7 @@ Plotting related functions
 from typing import Iterable, Optional, Sequence, Union
 
 import matplotlib.pyplot as plt
+import numpy as np
 import pandas as pd
 import seaborn as sns
 import sympy as sp
@@ -120,7 +121,7 @@ plotStateTrajectories = plot_state_trajectories
 plotObservableTrajectories = plot_observable_trajectories
 
 
-def evaluate(expr: StrOrExpr, rdata: ReturnDataView) -> "numpy.array":
+def evaluate(expr: StrOrExpr, rdata: ReturnDataView) -> np.array:
     """Evaluate a symbolic expression based on the given simulation outputs.
 
     :param expr:

--- a/python/sdist/amici/plotting.py
+++ b/python/sdist/amici/plotting.py
@@ -131,7 +131,7 @@ def plot_expressions(
     :param rdata:
         The simulation results.
     """
-    if not isinstance(exprs, Sequence):
+    if not isinstance(exprs, Sequence) or isinstance(exprs, str):
         exprs = [exprs]
 
     for expr in exprs:

--- a/python/sdist/amici/plotting.py
+++ b/python/sdist/amici/plotting.py
@@ -136,4 +136,6 @@ def plot_expressions(
 
     for expr in exprs:
         plt.plot(rdata.t, evaluate(expr, rdata), label=str(expr))
+
     plt.legend()
+    plt.gca().set_xlabel("$t$")

--- a/python/tests/test_rdata.py
+++ b/python/tests/test_rdata.py
@@ -2,7 +2,8 @@
 import amici
 import numpy as np
 import pytest
-from numpy.testing import assert_array_equal
+from amici.numpy import evaluate
+from numpy.testing import assert_almost_equal, assert_array_equal
 
 
 @pytest.fixture(scope="session")
@@ -38,4 +39,28 @@ def test_rdata_by_id(rdata_by_id_fixture):
 
     assert_array_equal(
         rdata.by_id(model.getStateIds()[1], "sx", model), rdata.sx[:, :, 1]
+    )
+
+
+def test_evaluate(rdata_by_id_fixture):
+    # get IDs of model components
+    model, rdata = rdata_by_id_fixture
+    expr0_id = model.getExpressionIds()[0]
+    state1_id = model.getStateIds()[1]
+    observable0_id = model.getObservableIds()[0]
+
+    # ensure `evaluate` works for atoms
+    expr0 = rdata.by_id(expr0_id)
+    assert_array_equal(expr0, evaluate(expr0_id, rdata=rdata))
+
+    state1 = rdata.by_id(state1_id)
+    assert_array_equal(state1, evaluate(state1_id, rdata=rdata))
+
+    observable0 = rdata.by_id(observable0_id)
+    assert_array_equal(observable0, evaluate(observable0_id, rdata=rdata))
+
+    # ensure `evaluate` works for expressions
+    assert_almost_equal(
+        expr0 + state1 * observable0,
+        evaluate(f"{expr0_id} + {state1_id} * {observable0_id}", rdata=rdata),
     )


### PR DESCRIPTION
Adds functions `amici.numpy.evaluate` and `amici.plotting.plot_expressions` to evaluate or directly plot symbolic expressions of model quantities, respectively.

Demo: see end of this section https://amici--2152.org.readthedocs.build/en/2152/ExampleSteadystate.html#Plotting-trajectories