### PR TITLE
Cleanup includes in hdf5.cpp

### DIFF
--- a/src/hdf5.cpp
+++ b/src/hdf5.cpp
@@ -16,18 +16,6 @@
 
 #include <hdf5_hl.h>
 
-#include <algorithm>
-#include <cassert>
-#include <cstring>
-#ifdef AMI_HDF5_H_DEBUG
-#ifndef __APPLE__
-#include <cexecinfo>
-#else
-#include <execinfo.h>
-#endif
-#endif
-#include <cmath>
-#include <unistd.h>
 
 namespace amici {
 namespace hdf5 {


### PR DESCRIPTION
Remove unused includes. Leftovers from the early beginnings, it seems ...

In particular, don't use unistd.h for Windows-compatibility #2151