### PR TITLE
Fix SBML import for event-assigned parameters with non-float initial assignments

### DIFF
--- a/python/sdist/amici/sbml_import.py
+++ b/python/sdist/amici/sbml_import.py
@@ -1060,7 +1060,7 @@ class SbmlImporter:
             for par in settings["var"]:
                 self.symbols[partype][_get_identifier_symbol(par)] = {
                     "name": par.getName() if par.isSetName() else par.getId(),
-                    "value": par.getValue(),
+                    "value": sp.Float(par.getValue()),
                 }
 
         # Parameters that need to be turned into expressions

--- a/python/sdist/amici/sbml_import.py
+++ b/python/sdist/amici/sbml_import.py
@@ -1388,7 +1388,7 @@ class SbmlImporter:
             # targets of events.
             self.symbols[SymbolId.SPECIES][parameter_target] = {
                 "name": parameter_def["name"],
-                "init": sp.Float(parameter_def["value"]),
+                "init": sp.sympify(parameter_def["value"]),
                 # 'compartment': None,  # can ignore for amounts
                 "constant": False,
                 "amount": True,

--- a/python/sdist/amici/sbml_import.py
+++ b/python/sdist/amici/sbml_import.py
@@ -1382,7 +1382,7 @@ class SbmlImporter:
                 ia_init = self._get_element_initial_assignment(par.getId())
                 parameter_def = {
                     "name": par.getName() if par.isSetName() else par.getId(),
-                    "value": par.getValue() if ia_init is None else ia_init,
+                    "value": sp.Float(par.getValue()) if ia_init is None else ia_init,
                 }
             # Fixed parameters are added as species such that they can be
             # targets of events.

--- a/python/sdist/amici/sbml_import.py
+++ b/python/sdist/amici/sbml_import.py
@@ -1388,7 +1388,7 @@ class SbmlImporter:
             # targets of events.
             self.symbols[SymbolId.SPECIES][parameter_target] = {
                 "name": parameter_def["name"],
-                "init": sp.sympify(parameter_def["value"]),
+                "init": parameter_def["value"],
                 # 'compartment': None,  # can ignore for amounts
                 "constant": False,
                 "amount": True,


### PR DESCRIPTION
Currently it is incorrectly assumed that the initial value of an event-assigned parameter
is (convertible to) a float. Therefore, SBML import fails if the initial assignment
contains a symbolic expression that can't be floatified.
    
Fixes #2149.
