### PR TITLE
Set CMake policies for cmake 3.27

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,6 +2,7 @@
 # Build AMICI library
 #
 cmake_minimum_required(VERSION 3.15)
+cmake_policy(VERSION 3.15...3.27)
 
 project(amici)
 

--- a/python/sdist/setup.py
+++ b/python/sdist/setup.py
@@ -130,6 +130,9 @@ def get_extensions():
         source_dir="amici",
         cmake_configure_options=[
             *global_cmake_configure_options,
+            "-Werror=dev"
+            if "GITHUB_ACTIONS" in os.environ
+            else "-Wno-error=dev",
             "-DAMICI_PYTHON_BUILD_EXT_ONLY=ON",
             f"-DPython3_EXECUTABLE={Path(sys.executable).as_posix()}",
         ],
@@ -142,7 +145,9 @@ def main():
     # Readme as long package description to go on PyPi
     # (https://pypi.org/project/amici/)
     with open(
-        os.path.join(os.path.dirname(__file__), "README.md"), "r", encoding="utf-8"
+        os.path.join(os.path.dirname(__file__), "README.md"),
+        "r",
+        encoding="utf-8",
     ) as fh:
         long_description = fh.read()
 

--- a/src/CMakeLists.template.cmake
+++ b/src/CMakeLists.template.cmake
@@ -1,5 +1,6 @@
 # Build AMICI model
 cmake_minimum_required(VERSION 3.15)
+cmake_policy(VERSION 3.15...3.27)
 
 project(TPL_MODELNAME)
 


### PR DESCRIPTION
* Use NEW version for any policy introduced up until 3.27. (Closes #2158)
* Error on CMake dev warnings on GHA