### PR TITLE
CMake: fix scope for -DHAS_BOOST_CHRONO

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -296,7 +296,7 @@ if("$ENV{ENABLE_AMICI_DEBUGGING}"
 endif()
 
 target_compile_definitions(
-  ${PROJECT_NAME} PRIVATE $<$<BOOL:${Boost_CHRONO_FOUND}>:HAS_BOOST_CHRONO>)
+  ${PROJECT_NAME} PUBLIC $<$<BOOL:${Boost_CHRONO_FOUND}>:HAS_BOOST_CHRONO>)
 
 target_link_libraries(
   ${PROJECT_NAME}

--- a/include/amici/misc.h
+++ b/include/amici/misc.h
@@ -258,7 +258,7 @@ template <class T> bool is_equal(T const& a, T const& b) {
 /** Tracks elapsed CPU time. */
 class CpuTimer {
     using clock = boost::chrono::thread_clock;
-    using time_point = boost::chrono::thread_clock::time_point;
+    using time_point = clock::time_point;
     using d_seconds = boost::chrono::duration<double>;
     using d_milliseconds = boost::chrono::duration<double, boost::milli>;
 
@@ -279,8 +279,7 @@ class CpuTimer {
      * @return CPU time in seconds
      */
     double elapsed_seconds() const {
-        return boost::chrono::duration_cast<d_seconds>(clock::now() - start_)
-            .count();
+        return d_seconds(clock::now() - start_).count();
     }
 
     /**
@@ -289,10 +288,7 @@ class CpuTimer {
      * @return CPU time in milliseconds
      */
     double elapsed_milliseconds() const {
-        return boost::chrono::duration_cast<d_milliseconds>(
-                   clock::now() - start_
-        )
-            .count();
+        return d_milliseconds(clock::now() - start_).count();
     }
 
   private:

--- a/include/amici/misc.h
+++ b/include/amici/misc.h
@@ -255,7 +255,7 @@ template <class T> bool is_equal(T const& a, T const& b) {
 }
 
 #ifdef BOOST_CHRONO_HAS_THREAD_CLOCK
-/** Tracks elapsed CPU time. */
+/** Tracks elapsed CPU time using boost::chrono::thread_clock. */
 class CpuTimer {
     using clock = boost::chrono::thread_clock;
     using time_point = clock::time_point;
@@ -291,12 +291,14 @@ class CpuTimer {
         return d_milliseconds(clock::now() - start_).count();
     }
 
+    static const bool uses_thread_clock = true;
+
   private:
     /** Start time */
     time_point start_;
 };
 #else
-/** Tracks elapsed CPU time. */
+/** Tracks elapsed CPU time using std::clock. */
 class CpuTimer {
   public:
     /**
@@ -327,6 +329,8 @@ class CpuTimer {
         return static_cast<double>(std::clock() - start_) * 1000.0
                / CLOCKS_PER_SEC;
     }
+
+    static const bool uses_thread_clock = false;
 
   private:
     /** Start time */

--- a/swig/CMakeLists.txt
+++ b/swig/CMakeLists.txt
@@ -112,6 +112,10 @@ if(${SWIG_VERSION} VERSION_LESS 4.1.0)
     PROPERTY SWIG_COMPILE_OPTIONS -py3)
 endif()
 
+# NOTE: No public definitions of any dependency are forwarded to swig,
+# they are only used for compiling the swig-generated source file.
+# Any definition that are relevant for swig-code generation, need to be
+# forwarded manually.
 target_link_libraries(_amici amici Python3::Python)
 if(WIN32)
   add_custom_command(

--- a/tests/cpp/unittests/testMisc.cpp
+++ b/tests/cpp/unittests/testMisc.cpp
@@ -727,7 +727,7 @@ TEST(CpuTimer, CpuTimer)
 {
     amici::CpuTimer timer;
     auto elapsed = timer.elapsed_seconds();
-    EXPECT_LT(0.0, elapsed);
+    EXPECT_LE(0.0, elapsed);
     EXPECT_GT(1.0, elapsed);
 
     elapsed = timer.elapsed_milliseconds();;

--- a/tests/cpp/unittests/testMisc.cpp
+++ b/tests/cpp/unittests/testMisc.cpp
@@ -723,4 +723,16 @@ TEST(SpanEqual, SpanEqual)
     EXPECT_FALSE(is_equal(a, b));
 }
 
+TEST(CpuTimer, CpuTimer)
+{
+    amici::CpuTimer timer;
+    auto elapsed = timer.elapsed_seconds();
+    EXPECT_LT(0.0, elapsed);
+    EXPECT_GT(1.0, elapsed);
+
+    elapsed = timer.elapsed_milliseconds();;
+    EXPECT_LT(0.0, elapsed);
+    EXPECT_GT(1000.0, elapsed);
+}
+
 } // namespace

--- a/tests/cpp/unittests/testMisc.cpp
+++ b/tests/cpp/unittests/testMisc.cpp
@@ -730,7 +730,7 @@ TEST(CpuTimer, CpuTimer)
     EXPECT_LE(0.0, elapsed);
     EXPECT_GT(1.0, elapsed);
 
-    elapsed = timer.elapsed_milliseconds();;
+    elapsed = timer.elapsed_milliseconds();
     EXPECT_LT(0.0, elapsed);
     EXPECT_GT(1000.0, elapsed);
 }


### PR DESCRIPTION
Fixes the issue of potentially mixing boost and non-boost versions of CpuTimer.

~~Previously, this could lead to invalid writes and segfaults, because the base library would have a boost version of CpuTimer, and the model extension would have or assume a non-boost version of CpuTimer. I don't know whether or how it is defined which definition would be used. I only found one environment where this would happen (segfaults on gcc/12.2.0, boost/1.82.0 (e.g. `valgrind python -c "import SomeModel as m; model = m.getModel(); model.getSolver()"`); no problems with gcc/12.3.0 boost/1.74.0).~~

Turns out the segfaults were caused by a broken boost installation (it seems when building boost-1.8{1,2}.0 with cxxstd=98, at least chrono is broken).