### PR TITLE
Remove setuptools<64 restriction

### DIFF
--- a/.github/workflows/test_python_cplusplus.yml
+++ b/.github/workflows/test_python_cplusplus.yml
@@ -135,7 +135,7 @@ jobs:
         -d ${AMICI_DIR}/build/CMakeFiles/amici.dir/src \
         -b ${AMICI_DIR} -c -o coverage_cpp.info \
         && lcov --compat-libtool --no-external \
-        -d ${AMICI_DIR}/python/sdist/build/$(python -c "import sys, sysconfig; print(f'temp.{sysconfig.get_platform()}-{sys.implementation.cache_tag}_amici')")/CMakeFiles/amici.dir/src \
+        -d ${AMICI_DIR}/python/sdist/build/temp_amici/CMakeFiles/amici.dir/src \
         -b ${AMICI_DIR}/python/sdist -c -o coverage_py.info \
         && lcov -a coverage_cpp.info -a coverage_py.info -o coverage.info
 

--- a/python/sdist/amici/custom_commands.py
+++ b/python/sdist/amici/custom_commands.py
@@ -178,3 +178,9 @@ class AmiciBuildCMakeExtension(BuildExtension):
         super().build_extension(ext)
 
         print("-" * 30, ext.name, "-" * 30, file=sys.stderr)
+
+    def finalize_options(self):
+        super().finalize_options()
+
+        if os.getenv("AMICI_BUILD_TEMP"):
+            self.build_temp = os.getenv("AMICI_BUILD_TEMP")

--- a/python/sdist/amici/custom_commands.py
+++ b/python/sdist/amici/custom_commands.py
@@ -126,6 +126,16 @@ class AmiciBuildPy(build_py):
 
 
 class AmiciBuildCMakeExtension(BuildExtension):
+    def finalize_options(self):
+        # Allow overriding the - since setuptools version 64 randomly named -
+        #  setuptools/distutils temporary build directory via environment variable.
+        # This is useful for CI builds where we need the files in this directory
+        #  for code coverage analysis.
+        if os.getenv("AMICI_BUILD_TEMP"):
+            self.build_temp = os.getenv("AMICI_BUILD_TEMP")
+
+        super().finalize_options()
+
     def run(self):
         """Copy the generated clibs to the extensions folder to be included in
         the wheel
@@ -178,9 +188,3 @@ class AmiciBuildCMakeExtension(BuildExtension):
         super().build_extension(ext)
 
         print("-" * 30, ext.name, "-" * 30, file=sys.stderr)
-
-    def finalize_options(self):
-        super().finalize_options()
-
-        if os.getenv("AMICI_BUILD_TEMP"):
-            self.build_temp = os.getenv("AMICI_BUILD_TEMP")

--- a/scripts/installAmiciSource.sh
+++ b/scripts/installAmiciSource.sh
@@ -27,7 +27,6 @@ else
     source ${AMICI_PATH}/build/venv/bin/activate
 fi
 
-pip install -U "setuptools<64"
 pip install --upgrade pip wheel
 pip install --upgrade pip scipy matplotlib coverage pytest \
   pytest-cov cmake_build_extension numpy

--- a/scripts/installAmiciSource.sh
+++ b/scripts/installAmiciSource.sh
@@ -31,5 +31,5 @@ pip install --upgrade pip wheel
 pip install --upgrade pip scipy matplotlib coverage pytest \
   pytest-cov cmake_build_extension numpy
 pip install git+https://github.com/FFroehlich/pysb@fix_pattern_matching # pin to PR for SPM with compartments
-pip install --verbose -e ${AMICI_PATH}/python/sdist[petab,test,vis] --no-build-isolation
+AMICI_BUILD_TEMP="${AMICI_PATH}/python/sdist/build/temp" pip install --verbose -e ${AMICI_PATH}/python/sdist[petab,test,vis] --no-build-isolation
 deactivate


### PR DESCRIPTION
We had to require setuptools<64 because it change its temporary build directory from a known path to a randomly named temporary directory. However, setuptools<64 doesn't work with for Python3.12 (#2179). Therefore, this adds an option to change the setuptools temporary build directory, so we have those temp files in a known path for coverage analysis. Not meant to be used by users.