### PR TITLE
Fix misleading preequilibration failure messages

### DIFF
--- a/include/amici/steadystateproblem.h
+++ b/include/amici/steadystateproblem.h
@@ -208,8 +208,15 @@ class SteadystateProblem {
 
     /**
      * @brief Stores state and throws an exception if equilibration failed
+     * @param tried_newton_1 Whether any Newton step was attempted before
+     * simulation
+     * @param tried_simulation Whether simulation was attempted
+     * @param tried_newton_2 Whether any Newton step was attempted after
+     * simulation
      */
-    [[noreturn]] void handleSteadyStateFailure();
+    [[noreturn]] void handleSteadyStateFailure(
+        bool tried_newton_1, bool tried_simulation, bool tried_newton_2
+    );
 
     /**
      * @brief Assembles the error message to be thrown.


### PR DESCRIPTION
When preequilibration (or finding a steadystate in general) fails, `SteadystateProblem::handleSteadyStateFailure` produced `AMICI simulation failed: Steady state computation failed. First run of Newton solver failed. Simulation to steady state failed: No convergence was achieved. Second run of Newton solver failed.`, even in cases where no Newton solve or no simulation was attempted. This is confusing and is changed here, so that the message now reflects what has actually happened.

Closes #2178