### PR TITLE
Fix CMake cmake_minimum_required deprecation warning

### DIFF
--- a/tests/cpp/CMakeLists.txt.in
+++ b/tests/cpp/CMakeLists.txt.in
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8.12)
+cmake_minimum_required(VERSION 3.15)
 
 project(googletest-download NONE)
 


### PR DESCRIPTION
Fixes
```
CMake Deprecation Warning at CMakeLists.txt:1 (cmake_minimum_required):
  Compatibility with CMake < 3.5 will be removed from a future version of
  CMake.

  Update the VERSION argument <min> value or use a ...<max> suffix to tell
  CMake that the project does not need compatibility with older versions.
```