### PR TITLE
Nicer __repr__ for ReturnDataView

### DIFF
--- a/python/sdist/amici/numpy.py
+++ b/python/sdist/amici/numpy.py
@@ -297,6 +297,10 @@ class ReturnDataView(SwigPtrView):
 
         return super().__getitem__(item)
 
+    def __repr__(self):
+        status = amici.simulation_status_to_str(self._swigptr.status)
+        return f"<{self.__class__.__name__}(id={self._swigptr.id!r}, status={status})>"
+
     def by_id(
         self, entity_id: str, field: str = None, model: Model = None
     ) -> np.array:


### PR DESCRIPTION
Previously:

```
<ReturnDataView(<amici.amici.ReturnData; proxy of <Swig Object of type 'amici::ReturnData *' at 0x7f794a9ef8d0> >)>
```

Now:

```
<ReturnDataView(id='ctrl+basal_preeq', status=AMICI_SUCCESS)>
```