### PR TITLE
Easier access to timepoints via ExpDataView

### DIFF
--- a/python/sdist/amici/numpy.py
+++ b/python/sdist/amici/numpy.py
@@ -343,6 +343,7 @@ class ExpDataView(SwigPtrView):
     """
 
     _field_names = [
+        "ts",
         "observedData",
         "observedDataStdDev",
         "observedEvents",
@@ -363,7 +364,9 @@ class ExpDataView(SwigPtrView):
                 f"Unsupported pointer {type(edata)}, must be"
                 f"amici.ExpDataPtr!"
             )
-        self._field_dimensions = {  # observables
+        self._field_dimensions = {
+            "ts": [edata.nt()],
+            # observables
             "observedData": [edata.nt(), edata.nytrue()],
             "observedDataStdDev": [edata.nt(), edata.nytrue()],
             # event observables
@@ -378,6 +381,7 @@ class ExpDataView(SwigPtrView):
                 len(edata.fixedParametersPreequilibration)
             ],
         }
+        edata.ts = edata.ts_
         edata.observedData = edata.getObservedData()
         edata.observedDataStdDev = edata.getObservedDataStdDev()
         edata.observedEvents = edata.getObservedEvents()


### PR DESCRIPTION
ExpDataView provides convenient access to measurements and the like as numpy arrays. However, accessing the associated timepoints is currently only possible via `ExpDataView(...)._swigptr.ts_` which returns an amici.amici.DoubleVector. That's awkward.

Now:

```python
amici.ExpDataView(amici.ExpData(1, 2, 3, [4, 5, 6])).ts
Out[3]: array([4., 5., 6.])
```

Resolves #2191