### PR TITLE
Fix ExpData equality operator for Python

### DIFF
--- a/python/tests/test_swig_interface.py
+++ b/python/tests/test_swig_interface.py
@@ -442,3 +442,12 @@ def test_edata_repr():
             assert expected_str in repr(e)
     # avoid double delete!!
     edata_ptr.release()
+
+
+def test_edata_equality_operator():
+    e1 = amici.ExpData(1, 2, 3, [3])
+    e2 = amici.ExpData(1, 2, 3, [3])
+    assert e1 == e2
+    # check that comparison with other types works
+    # this is not implemented by swig by default
+    assert e1 != 1

--- a/swig/edata.i
+++ b/swig/edata.i
@@ -76,7 +76,7 @@ def __repr__(self):
     return _edata_repr(self)
 
 def __eq__(self, other):
-    return isinstance(other, self.__class__) and __eq__(self, other)
+    return other.__class__ == self.__class__ and __eq__(self, other)
 %}
 };
 %extend std::unique_ptr<amici::ExpData> {

--- a/swig/edata.i
+++ b/swig/edata.i
@@ -74,6 +74,9 @@ def _edata_repr(self: "ExpData"):
 %pythoncode %{
 def __repr__(self):
     return _edata_repr(self)
+
+def __eq__(self, other):
+    return isinstance(other, self.__class__) and __eq__(self, other)
 %}
 };
 %extend std::unique_ptr<amici::ExpData> {


### PR DESCRIPTION
Wasn't automatically handled by swig for unclear reasons. Works now. Fixes #2190.