### PR TITLE
Enable deepcopy for ExpData(View)

### DIFF
--- a/python/sdist/amici/numpy.py
+++ b/python/sdist/amici/numpy.py
@@ -137,7 +137,8 @@ class SwigPtrView(collections.abc.Mapping):
 
         :returns: SwigPtrView deep copy
         """
-        other = SwigPtrView(self._swigptr)
+        # We assume we have a copy-ctor for the swigptr object
+        other = self.__class__(copy.deepcopy(self._swigptr))
         other._field_names = copy.deepcopy(self._field_names)
         other._field_dimensions = copy.deepcopy(self._field_dimensions)
         other._cache = copy.deepcopy(self._cache)
@@ -150,6 +151,18 @@ class SwigPtrView(collections.abc.Mapping):
         :returns: string representation
         """
         return f"<{self.__class__.__name__}({self._swigptr})>"
+
+    def __eq__(self, other):
+        """
+        Equality check
+
+        :param other: other object
+
+        :returns: whether other object is equal to this object
+        """
+        if not isinstance(other, self.__class__):
+            return False
+        return self._swigptr == other._swigptr
 
 
 class ReturnDataView(SwigPtrView):
@@ -340,6 +353,9 @@ class ExpDataView(SwigPtrView):
     """
     Interface class for C++ Exp Data objects that avoids possibly costly
     copies of member data.
+
+    NOTE: This currently assumes that the underlying :class:`ExpData`
+    does not change after instantiating an :class:`ExpDataView`.
     """
 
     _field_names = [

--- a/python/tests/test_swig_interface.py
+++ b/python/tests/test_swig_interface.py
@@ -442,3 +442,12 @@ def test_edata_repr():
             assert expected_str in repr(e)
     # avoid double delete!!
     edata_ptr.release()
+
+
+def test_edata_equality_operator():
+    e1 = amici.ExpData(1, 2, 3, [3])
+    e2 = amici.ExpData(1, 2, 3, [3])
+    assert e1 == e2
+    # check that comparison with other types works
+    # this is not implemented by swig by default
+    assert e1 != 1

--- a/python/tests/test_swig_interface.py
+++ b/python/tests/test_swig_interface.py
@@ -7,6 +7,7 @@ import copy
 import numbers
 
 import amici
+import numpy as np
 
 
 def test_version_number(pysb_example_presimulation_module):
@@ -451,3 +452,21 @@ def test_edata_equality_operator():
     # check that comparison with other types works
     # this is not implemented by swig by default
     assert e1 != 1
+
+
+def test_expdata_and_expdataview_are_deepcopyable():
+    edata1 = amici.ExpData(3, 2, 3, range(4))
+    edata1.setObservedData(np.zeros((3, 4)).flatten())
+
+    # ExpData
+    edata2 = copy.deepcopy(edata1)
+    assert edata1 == edata2
+    assert edata1.this != edata2.this
+    edata2.setTimepoints([0])
+    assert edata1 != edata2
+
+    # ExpDataView
+    ev1 = amici.ExpDataView(edata1)
+    ev2 = copy.deepcopy(ev1)
+    assert ev2._swigptr.this != ev1._swigptr.this
+    assert ev1 == ev2

--- a/swig/edata.i
+++ b/swig/edata.i
@@ -74,6 +74,9 @@ def _edata_repr(self: "ExpData"):
 %pythoncode %{
 def __repr__(self):
     return _edata_repr(self)
+
+def __eq__(self, other):
+    return isinstance(other, self.__class__) and __eq__(self, other)
 %}
 };
 %extend std::unique_ptr<amici::ExpData> {

--- a/swig/edata.i
+++ b/swig/edata.i
@@ -77,6 +77,10 @@ def __repr__(self):
 
 def __eq__(self, other):
     return isinstance(other, self.__class__) and __eq__(self, other)
+
+def __deepcopy__(self, memo):
+    # invoke copy constructor
+    return type(self)(self)
 %}
 };
 %extend std::unique_ptr<amici::ExpData> {


### PR DESCRIPTION
Fixes a bug in `SwigPtrView.__deepcopy__` which did not produce a deep copy.

Add `SwigPtrView.__eq__` to allow for comparison. The view objects are considered equal if the underlying viewed objects are equal.

Fixes #2189.