### PR TITLE
GHA: test installation from pypi on python3.11

### DIFF
--- a/.github/workflows/test_pypi.yml
+++ b/.github/workflows/test_pypi.yml
@@ -11,7 +11,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: [3.9, 3.9, '3.10']
+        python-version: ["3.9", "3.10", "3.11"]
         os: [ubuntu-22.04, macos-latest]
 
     runs-on: ${{ matrix.os }}


### PR DESCRIPTION
... instead of twice on 3.9

Test: https://github.com/AMICI-dev/AMICI/actions/runs/6880046216