### PR TITLE
Allow subsetting simulation conditions in simulate_petab

### DIFF
--- a/python/sdist/amici/petab_objective.py
+++ b/python/sdist/amici/petab_objective.py
@@ -516,6 +516,7 @@ def create_parameter_mapping(
             observable_df=petab_problem.observable_df,
             mapping_df=petab_problem.mapping_df,
             model=petab_problem.model,
+            simulation_conditions=simulation_conditions,
             **dict(
                 default_parameter_mapping_kwargs, **parameter_mapping_kwargs
             ),


### PR DESCRIPTION
simulate_petab was mainly intended to simulate all conditions at once, but the `simulation_conditions` argument provides also an easy way to simulate only a subset of conditions. However, this currently fails, because the full parameter mapping is generated and then the wrong parameter mapping is used for the selected conditions (unless the subset matches the first N conditions of the full list).

This is fixed here. Also it saves a minuscule amount of time.