### PR TITLE
GHA: Cleanup custom swig usage

### DIFF
--- a/.github/actions/setup-swig/action.yml
+++ b/.github/actions/setup-swig/action.yml
@@ -1,0 +1,20 @@
+name: Set up SWIG
+description: |
+  Download and build SWIG and set the SWIG environment variable to the path of
+  the SWIG executable.
+
+inputs:
+  swig_version:
+    description: 'Swig version to build'
+    required: false
+    default: '4.1.1'
+
+runs:
+  using: "composite"
+  steps:
+    - name: Download and build SWIG
+      run: scripts/downloadAndBuildSwig.sh
+      shell: bash
+
+    - run: echo "SWIG=${AMICI_DIR}/ThirdParty/swig-${INPUT_SWIG_VERSION}/install/bin/swig" >> $GITHUB_ENV
+      shell: bash

--- a/.github/actions/setup-swig/action.yml
+++ b/.github/actions/setup-swig/action.yml
@@ -16,5 +16,5 @@ runs:
       run: scripts/downloadAndBuildSwig.sh
       shell: bash
 
-    - run: echo "SWIG=${AMICI_DIR}/ThirdParty/swig-${INPUT_SWIG_VERSION}/install/bin/swig" >> $GITHUB_ENV
+    - run: echo "SWIG=${AMICI_DIR}/ThirdParty/swig-${{ inputs.swig_version }}/install/bin/swig" >> $GITHUB_ENV
       shell: bash

--- a/.github/workflows/deploy_branch.yml
+++ b/.github/workflows/deploy_branch.yml
@@ -21,7 +21,8 @@ jobs:
       with:
         fetch-depth: 20
 
-    - uses: ./.github/actions/setup-swig
+    - name: Set up SWIG
+      uses: ./.github/actions/setup-swig
 
     - run: echo "AMICI_DIR=$(pwd)" >> $GITHUB_ENV
 

--- a/.github/workflows/deploy_branch.yml
+++ b/.github/workflows/deploy_branch.yml
@@ -21,12 +21,9 @@ jobs:
       with:
         fetch-depth: 20
 
-    - run: echo "AMICI_DIR=$(pwd)" >> $GITHUB_ENV
-    - run: echo "SWIG=${AMICI_DIR}/ThirdParty/swig-4.0.1/install/bin/swig" >> $GITHUB_ENV
+    - uses: ./.github/actions/setup-swig
 
-    - name: Build swig4
-      run: |
-        sudo scripts/downloadAndBuildSwig.sh
+    - run: echo "AMICI_DIR=$(pwd)" >> $GITHUB_ENV
 
     - name: Create AMICI sdist
       run: |

--- a/.github/workflows/deploy_release.yml
+++ b/.github/workflows/deploy_release.yml
@@ -24,12 +24,9 @@ jobs:
       with:
         fetch-depth: 20
 
-    - run: echo "AMICI_DIR=$(pwd)" >> $GITHUB_ENV
-    - run: echo "SWIG=${AMICI_DIR}/ThirdParty/swig-4.0.1/install/bin/swig" >> $GITHUB_ENV
+    - uses: ./.github/actions/setup-swig
 
-    - name: Build swig4
-      run: |
-        sudo scripts/downloadAndBuildSwig.sh
+    - run: echo "AMICI_DIR=$(pwd)" >> $GITHUB_ENV
 
     - name: sdist
       run: |

--- a/.github/workflows/deploy_release.yml
+++ b/.github/workflows/deploy_release.yml
@@ -24,7 +24,8 @@ jobs:
       with:
         fetch-depth: 20
 
-    - uses: ./.github/actions/setup-swig
+    - name: Set up SWIG
+      uses: ./.github/actions/setup-swig
 
     - run: echo "AMICI_DIR=$(pwd)" >> $GITHUB_ENV
 

--- a/.github/workflows/test_doc.yml
+++ b/.github/workflows/test_doc.yml
@@ -68,7 +68,6 @@ jobs:
       - run: git fetch --prune --unshallow
 
       - run: echo "AMICI_DIR=$(pwd)" >> $GITHUB_ENV
-      - run: echo "SWIG=${AMICI_DIR}/ThirdParty/swig-4.1.1/install/bin/swig" >> $GITHUB_ENV
 
       - name: Build doxygen
         run: |
@@ -85,9 +84,7 @@ jobs:
               pandoc \
               python3-venv \
 
-      - name: Build swig
-        run: |
-          sudo scripts/downloadAndBuildSwig.sh
+      - uses: ./.github/actions/setup-swig
 
       - name: sphinx
         run: |

--- a/scripts/downloadAndBuildSwig.sh
+++ b/scripts/downloadAndBuildSwig.sh
@@ -1,11 +1,13 @@
 #!/usr/bin/env bash
 # Download and build SWIG
-set -e
+#
+# Usage: downloadAndBuildSwig.sh [swig_version]
+set -euo pipefail
 
 SCRIPT_PATH=$(dirname "$BASH_SOURCE")
 AMICI_PATH=$(cd "$SCRIPT_PATH/.." && pwd)
 
-swig_version=4.1.1
+swig_version="${1:-"4.1.1"}"
 SWIG_ARCHIVE="swig-${swig_version}.tar.gz"
 SWIG_URL="http://downloads.sourceforge.net/project/swig/swig/swig-${swig_version}/${SWIG_ARCHIVE}"
 SWIG_DIR="swig-${swig_version}"


### PR DESCRIPTION
* Previously the newest swig was downloaded and built, but not used because of a wrong path. Fixed here.
* Make scripts/downloadAndBuildSwig.sh accept a version number argument
* Use composite action to make it more maintainable and avoid issues as fixed above