### PR TITLE
GHA: split into smaller jobs

### DIFF
--- a/.github/actions/setup-amici-cpp/action.yml
+++ b/.github/actions/setup-amici-cpp/action.yml
@@ -24,6 +24,15 @@ runs:
     - name: Install apt dependencies
       uses: ./.github/actions/install-apt-dependencies
 
+    - name: Install additional apt dependencies
+      run: |
+        sudo apt-get update \
+          && sudo apt-get install -y \
+            cmake \
+            python3-venv \
+            lcov
+      shell: bash
+
     - name: Build AMICI dependencies
       run: scripts/buildDependencies.sh
       shell: bash

--- a/.github/actions/setup-amici-cpp/action.yml
+++ b/.github/actions/setup-amici-cpp/action.yml
@@ -1,0 +1,35 @@
+name: Set up AMICI C++
+description: |
+  Build the AMICI C++ interface and set things for for coverage analysis.
+  (Currently ubuntu-only).
+
+runs:
+  using: "composite"
+  steps:
+    # BioNetGen Path
+    - run: echo "BNGPATH=${GITHUB_WORKSPACE}/ThirdParty/BioNetGen-2.7.0" >> $GITHUB_ENV
+      shell: bash
+
+    # use all available cores
+    - run: echo "AMICI_PARALLEL_COMPILE=" >> $GITHUB_ENV
+      shell: bash
+
+    # enable coverage
+    - run: echo "ENABLE_GCOV_COVERAGE=TRUE" >> $GITHUB_ENV
+      shell: bash
+
+    - name: Set up Sonar tools
+      uses: ./.github/actions/setup-sonar-tools
+
+    - name: Install apt dependencies
+      uses: ./.github/actions/install-apt-dependencies
+
+    - name: Build AMICI dependencies
+      run: scripts/buildDependencies.sh
+      shell: bash
+
+    - name: Build AMICI
+      run: scripts/buildAmici.sh
+      shell: bash
+      env:
+        CI_SONARCLOUD: "TRUE"

--- a/.github/workflows/test_python_cplusplus.yml
+++ b/.github/workflows/test_python_cplusplus.yml
@@ -207,33 +207,7 @@ jobs:
     - name: doc notebooks
       run: scripts/runNotebook.sh documentation/GettingStarted.ipynb
 
-    - name: Codecov Python
-      uses: codecov/codecov-action@v3.1.0
-      with:
-        token: ${{ secrets.CODECOV_TOKEN }}
-        file: build/coverage_py.xml
-        flags: python
-        fail_ci_if_error: true
-        verbose: true
-
-    - name: Capture coverage info (lcov)
-      run: |
-        lcov --compat-libtool --no-external \
-        -d ${AMICI_DIR}/build/CMakeFiles/amici.dir/src \
-        -b ${AMICI_DIR} -c -o coverage_cpp.info \
-        && lcov --compat-libtool --no-external \
-        -d ${AMICI_DIR}/python/sdist/build/temp_amici/CMakeFiles/amici.dir/src \
-        -b ${AMICI_DIR}/python/sdist -c -o coverage_py.info \
-        && lcov -a coverage_cpp.info -a coverage_py.info -o coverage.info
-
-    - name: Run sonar-scanner
-      env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
-      run: |
-        sonar-scanner \
-         -Dsonar.cfamily.build-wrapper-output=bw-output \
-         -Dsonar.projectVersion="$(git describe --abbrev=4 --dirty=-dirty --always --tags | tr -d '\n')"
+    # TODO: Include notebooks in coverage report
 
   osx:
     name: Tests OSX

--- a/.github/workflows/test_python_cplusplus.yml
+++ b/.github/workflows/test_python_cplusplus.yml
@@ -9,7 +9,7 @@ on:
 
 jobs:
   ubuntu-cpp-tests:
-    name: Tests Ubuntu
+    name: C++ tests Ubuntu
     runs-on: ubuntu-22.04
 
     strategy:
@@ -51,7 +51,7 @@ jobs:
          -Dsonar.projectVersion="$(git describe --abbrev=4 --dirty=-dirty --always --tags | tr -d '\n')"
 
   ubuntu-python-tests:
-    name: Tests Ubuntu
+    name: Python tests Ubuntu
     runs-on: ubuntu-22.04
 
     strategy:
@@ -136,7 +136,7 @@ jobs:
 
 
   ubuntu-notebook-tests:
-    name: Tests Ubuntu
+    name: Notebook tests Ubuntu
     runs-on: ubuntu-22.04
 
     strategy:

--- a/.github/workflows/test_python_cplusplus.yml
+++ b/.github/workflows/test_python_cplusplus.yml
@@ -8,8 +8,8 @@ on:
       - master
 
 jobs:
-  ubuntu-cpp-tests:
-    name: C++ tests Ubuntu
+  ubuntu-cpp-python-tests:
+    name: C++/Python tests Ubuntu
     runs-on: ubuntu-22.04
 
     strategy:
@@ -33,11 +33,59 @@ jobs:
     - name: C++ tests
       run: scripts/run-cpp-tests.sh
 
+
+    - name: Install python package
+      run: scripts/installAmiciSource.sh
+
+    - name: Python tests (part 1)
+      run: |
+        source build/venv/bin/activate \
+        && pytest \
+          --ignore-glob=*petab* \
+          --ignore-glob=*test_splines.py \
+          --ignore-glob=*test_splines_short.py \
+          --ignore-glob=*test_pysb.py \
+          --cov=amici \
+          --cov-report=xml:"${AMICI_DIR}/build/coverage_py.xml" \
+          --cov-append \
+          --durations=10 \
+          ${AMICI_DIR}/python/tests
+
+    - name: Python tests splines
+      if: ${{ github.base_ref == 'master' || github.event.merge_group.base_ref == 'master'}}
+      run: |
+        source build/venv/bin/activate \
+        && pytest \
+          --cov=amici \
+          --cov-report=xml:"${AMICI_DIR}/build/coverage_py.xml" \
+          --cov-append \
+          --durations=10 \
+          ${AMICI_DIR}/python/tests/test_splines.py
+
+    - name: Codecov Python
+      uses: codecov/codecov-action@v3.1.0
+      with:
+        token: ${{ secrets.CODECOV_TOKEN }}
+        file: build/coverage_py.xml
+        flags: python
+        fail_ci_if_error: true
+        verbose: true
+
+    - name: Capture coverage info (lcov)
+      run: |
+        lcov --compat-libtool --no-external \
+        -d ${AMICI_DIR}/build/CMakeFiles/amici.dir/src \
+        -b ${AMICI_DIR} -c -o coverage_cpp.info \
+        && lcov --compat-libtool --no-external \
+        -d ${AMICI_DIR}/python/sdist/build/temp_amici/CMakeFiles/amici.dir/src \
+        -b ${AMICI_DIR}/python/sdist -c -o coverage_py.info \
+        && lcov -a coverage_cpp.info -a coverage_py.info -o coverage.info
+
     - name: Codecov CPP
       uses: codecov/codecov-action@v3.1.0
       with:
         token: ${{ secrets.CODECOV_TOKEN }}
-        file: coverage.info
+        file: coverage_cpp.info
         flags: cpp
         fail_ci_if_error: true
 
@@ -79,24 +127,12 @@ jobs:
       run: |
         source build/venv/bin/activate \
         && pytest \
-          --ignore-glob=*petab* \
-          --ignore-glob=*test_splines.py \
           --cov=amici \
           --cov-report=xml:"${AMICI_DIR}/build/coverage_py.xml" \
           --cov-append \
           --durations=10 \
-          ${AMICI_DIR}/python/tests
-
-    - name: Python tests splines
-      if: ${{ github.base_ref == 'master' || github.event.merge_group.base_ref == 'master'}}
-      run: |
-        source build/venv/bin/activate \
-        && pytest \
-          --cov=amici \
-          --cov-report=xml:"${AMICI_DIR}/build/coverage_py.xml" \
-          --cov-append \
-          --durations=10 \
-          ${AMICI_DIR}/python/tests/test_splines.py
+          ${AMICI_DIR}/python/tests/test_pysb.py \
+          ${AMICI_DIR}/python/tests/test_splines_short.py
 
     - name: Codecov Python
       uses: codecov/codecov-action@v3.1.0
@@ -107,7 +143,7 @@ jobs:
         fail_ci_if_error: true
         verbose: true
 
-    - name: lcov
+    - name: Capture coverage info (lcov)
       run: |
         lcov --compat-libtool --no-external \
         -d ${AMICI_DIR}/build/CMakeFiles/amici.dir/src \
@@ -180,7 +216,7 @@ jobs:
         fail_ci_if_error: true
         verbose: true
 
-    - name: lcov
+    - name: Capture coverage info (lcov)
       run: |
         lcov --compat-libtool --no-external \
         -d ${AMICI_DIR}/build/CMakeFiles/amici.dir/src \

--- a/.github/workflows/test_python_cplusplus.yml
+++ b/.github/workflows/test_python_cplusplus.yml
@@ -8,20 +8,13 @@ on:
       - master
 
 jobs:
-  build:
+  ubuntu-cpp-tests:
     name: Tests Ubuntu
-
-    # TODO: prepare image with more deps preinstalled
     runs-on: ubuntu-22.04
-
-    env:
-      AMICI_PARALLEL_COMPILE: ""
-      ENABLE_GCOV_COVERAGE: "TRUE"
-      CI_SONARCLOUD: "TRUE"
 
     strategy:
       matrix:
-        python-version: [ 3.9 ]
+        python-version: [ "3.9" ]
 
     steps:
     - name: Set up Python ${{ matrix.python-version }}
@@ -33,31 +26,51 @@ jobs:
     - run: git fetch --prune --unshallow
 
     - run: echo "AMICI_DIR=$(pwd)" >> $GITHUB_ENV
-    - run: echo "BNGPATH=${GITHUB_WORKSPACE}/ThirdParty/BioNetGen-2.7.0" >> $GITHUB_ENV
 
-    - name: Set up Sonar tools
-      uses: ./.github/actions/setup-sonar-tools
-
-    - name: Install apt dependencies
-      uses: ./.github/actions/install-apt-dependencies
-
-    # install amici dependencies
-    - name: apt
-      run: |
-        sudo apt-get update \
-          && sudo apt-get install -y \
-            cmake \
-            python3-venv \
-            lcov
-
-    - name: Build AMICI dependencies
-      run: scripts/buildDependencies.sh
-
-    - name: Build AMICI
-      run: CI_SONARCLOUD=TRUE scripts/buildAmici.sh
+    - name: Set up AMICI C++ libraries
+      uses: ./.github/actions/setup-amici-cpp
 
     - name: C++ tests
       run: scripts/run-cpp-tests.sh
+
+    - name: Codecov CPP
+      uses: codecov/codecov-action@v3.1.0
+      with:
+        token: ${{ secrets.CODECOV_TOKEN }}
+        file: coverage.info
+        flags: cpp
+        fail_ci_if_error: true
+
+    - name: Run sonar-scanner
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
+      run: |
+        sonar-scanner \
+         -Dsonar.cfamily.build-wrapper-output=bw-output \
+         -Dsonar.projectVersion="$(git describe --abbrev=4 --dirty=-dirty --always --tags | tr -d '\n')"
+
+  ubuntu-python-tests:
+    name: Tests Ubuntu
+    runs-on: ubuntu-22.04
+
+    strategy:
+      matrix:
+        python-version: [ "3.9" ]
+
+    steps:
+    - name: Set up Python ${{ matrix.python-version }}
+      uses: actions/setup-python@v4
+      with:
+        python-version: ${{ matrix.python-version }}
+
+    - uses: actions/checkout@v3
+    - run: git fetch --prune --unshallow
+
+    - run: echo "AMICI_DIR=$(pwd)" >> $GITHUB_ENV
+
+    - name: Set up AMICI C++ libraries
+      uses: ./.github/actions/setup-amici-cpp
 
     - name: Install python package
       run: scripts/installAmiciSource.sh
@@ -74,7 +87,6 @@ jobs:
           --durations=10 \
           ${AMICI_DIR}/python/tests
 
-
     - name: Python tests splines
       if: ${{ github.base_ref == 'master' || github.event.merge_group.base_ref == 'master'}}
       run: |
@@ -85,6 +97,68 @@ jobs:
           --cov-append \
           --durations=10 \
           ${AMICI_DIR}/python/tests/test_splines.py
+
+    - name: Codecov Python
+      uses: codecov/codecov-action@v3.1.0
+      with:
+        token: ${{ secrets.CODECOV_TOKEN }}
+        file: build/coverage_py.xml
+        flags: python
+        fail_ci_if_error: true
+        verbose: true
+
+    - name: lcov
+      run: |
+        lcov --compat-libtool --no-external \
+        -d ${AMICI_DIR}/build/CMakeFiles/amici.dir/src \
+        -b ${AMICI_DIR} -c -o coverage_cpp.info \
+        && lcov --compat-libtool --no-external \
+        -d ${AMICI_DIR}/python/sdist/build/temp_amici/CMakeFiles/amici.dir/src \
+        -b ${AMICI_DIR}/python/sdist -c -o coverage_py.info \
+        && lcov -a coverage_cpp.info -a coverage_py.info -o coverage.info
+
+    - name: Codecov CPP
+      uses: codecov/codecov-action@v3.1.0
+      with:
+        token: ${{ secrets.CODECOV_TOKEN }}
+        file: coverage.info
+        flags: cpp_python
+        fail_ci_if_error: true
+
+    - name: Run sonar-scanner
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
+      run: |
+        sonar-scanner \
+         -Dsonar.cfamily.build-wrapper-output=bw-output \
+         -Dsonar.projectVersion="$(git describe --abbrev=4 --dirty=-dirty --always --tags | tr -d '\n')"
+
+
+  ubuntu-notebook-tests:
+    name: Tests Ubuntu
+    runs-on: ubuntu-22.04
+
+    strategy:
+      matrix:
+        python-version: [ "3.9" ]
+
+    steps:
+    - name: Set up Python ${{ matrix.python-version }}
+      uses: actions/setup-python@v4
+      with:
+        python-version: ${{ matrix.python-version }}
+
+    - uses: actions/checkout@v3
+    - run: git fetch --prune --unshallow
+
+    - run: echo "AMICI_DIR=$(pwd)" >> $GITHUB_ENV
+
+    - name: Set up AMICI C++ libraries
+      uses: ./.github/actions/setup-amici-cpp
+
+    - name: Install python package
+      run: scripts/installAmiciSource.sh
 
     - name: Install notebook dependencies
       run: |
@@ -115,14 +189,6 @@ jobs:
         -d ${AMICI_DIR}/python/sdist/build/temp_amici/CMakeFiles/amici.dir/src \
         -b ${AMICI_DIR}/python/sdist -c -o coverage_py.info \
         && lcov -a coverage_cpp.info -a coverage_py.info -o coverage.info
-
-    - name: Codecov CPP
-      uses: codecov/codecov-action@v3.1.0
-      with:
-        token: ${{ secrets.CODECOV_TOKEN }}
-        file: coverage.info
-        flags: cpp
-        fail_ci_if_error: true
 
     - name: Run sonar-scanner
       env:

--- a/.github/workflows/test_python_cplusplus.yml
+++ b/.github/workflows/test_python_cplusplus.yml
@@ -33,7 +33,6 @@ jobs:
     - name: C++ tests
       run: scripts/run-cpp-tests.sh
 
-
     - name: Install python package
       run: scripts/installAmiciSource.sh
 
@@ -85,7 +84,7 @@ jobs:
       uses: codecov/codecov-action@v3.1.0
       with:
         token: ${{ secrets.CODECOV_TOKEN }}
-        file: coverage_cpp.info
+        file: coverage.info
         flags: cpp
         fail_ci_if_error: true
 


### PR DESCRIPTION
Split current C++/Python/Notebook tests into three separate workflows: 
1. C++ + some Python
2. Slow pysb and spline tests
3. Notebooks

Closes #2195
Closes #2014

Note to self: When adding new jobs in a PR from a fork, those runs will only show up on the fork, not on the PR target.