### PR TITLE
Doc: Show typehints in description

### DIFF
--- a/documentation/conf.py
+++ b/documentation/conf.py
@@ -260,6 +260,7 @@ autodoc_default_options = {
 typehints_fully_qualified = True
 typehints_document_rtype = True
 set_type_checking_flag = True
+autodoc_typehints = "description"
 
 # hoverxref
 hoverxref_auto_ref = True


### PR DESCRIPTION
Instead of in the signature. Much more readable.