### PR TITLE
GHA: Fix OpenMP not found on macos

### DIFF
--- a/.github/workflows/test_python_cplusplus.yml
+++ b/.github/workflows/test_python_cplusplus.yml
@@ -62,6 +62,9 @@ jobs:
     - name: Install python package
       run: scripts/installAmiciSource.sh
 
+    - name: Check OpenMP support
+      run: source build/venv/bin/activate && python -c "import amici; import sys; sys.exit(not amici.compiledWithOpenMP())"
+
     - name: Python tests
       run: |
         source build/venv/bin/activate \
@@ -150,21 +153,23 @@ jobs:
     - run: echo "BNGPATH=${AMICI_DIR}/ThirdParty/BioNetGen-2.7.0" >> $GITHUB_ENV
     # Ensure CMake is using the python version that we will use for the python tests later on
     - run: echo "PYTHON_EXECUTABLE=${Python3_ROOT_DIR}/bin/python3" >> $GITHUB_ENV
+    - run: echo "OpenMP_ROOT=$(brew --prefix)/opt/libomp" >> $GITHUB_ENV
 
     # install amici dependencies
     - name: homebrew
       run: |
         brew install hdf5 swig gcc cppcheck libomp boost \
-          && brew ls -v boost \
-          && brew ls -v libomp \
-          && echo LDFLAGS="-L/usr/local/lib/ -L/usr/local/Cellar/boost/1.81.0_1/lib/" >> $GITHUB_ENV \
-          && echo CPPFLAGS="-I /usr/local/Cellar/boost/1.81.0_1/include/" >> $GITHUB_ENV
+          && echo LDFLAGS="-L/usr/local/lib/ -L$(brew --prefix)/opt/boost/lib/" >> $GITHUB_ENV \
+          && echo CPPFLAGS="-I $(brew --prefix)/opt/boost/include/" >> $GITHUB_ENV
 
     - name: Build AMICI
       run: scripts/buildAll.sh
 
     - name: Install python package
       run: scripts/installAmiciSource.sh
+
+    - name: Check OpenMP support
+      run: source build/venv/bin/activate && python -c "import amici; import sys; sys.exit(not amici.compiledWithOpenMP())"
 
     - name: cppcheck
       run: scripts/run-cppcheck.sh

--- a/.github/workflows/test_python_cplusplus.yml
+++ b/.github/workflows/test_python_cplusplus.yml
@@ -154,13 +154,11 @@ jobs:
     # Ensure CMake is using the python version that we will use for the python tests later on
     - run: echo "PYTHON_EXECUTABLE=${Python3_ROOT_DIR}/bin/python3" >> $GITHUB_ENV
     - run: echo "OpenMP_ROOT=$(brew --prefix)/opt/libomp" >> $GITHUB_ENV
+    - run: echo "BOOST_ROOT=$(brew --prefix)/opt/boost" >> $GITHUB_ENV
 
     # install amici dependencies
     - name: homebrew
-      run: |
-        brew install hdf5 swig gcc cppcheck libomp boost \
-          && echo LDFLAGS="-L/usr/local/lib/ -L$(brew --prefix)/opt/boost/lib/" >> $GITHUB_ENV \
-          && echo CPPFLAGS="-I $(brew --prefix)/opt/boost/include/" >> $GITHUB_ENV
+      run: brew install hdf5 swig gcc cppcheck libomp boost
 
     - name: Build AMICI
       run: scripts/buildAll.sh

--- a/documentation/python_installation.rst
+++ b/documentation/python_installation.rst
@@ -119,10 +119,14 @@ Install the AMICI dependencies using homebrew:
     brew install hdf5
 
     # optionally for parallel simulations:
-    brew install libomp && export OpenMP_ROOT=$(brew --prefix)/opt/libomp"
+    brew install libomp
+    # followed by either `brew link openmp` once,
+    # or `export OpenMP_ROOT=$(brew --prefix)/opt/libomp"` where `OpenMP_ROOT` will have to be set during every re-installation of AMICI or any new model import
 
     # optionally for boost support (thread-specific CPU times, extended math functions, serialization)
     brew install boost && export BOOST_ROOT=$(brew --prefix)/opt/boost
+    # followed by either `brew link boost` once,
+    # or `export BOOST_ROOT=$(brew --prefix)/opt/boost"` where `BOOST_ROOT` will have to be set during every re-installation of AMICI or any new model import
 
 Install AMICI:
 

--- a/documentation/python_installation.rst
+++ b/documentation/python_installation.rst
@@ -13,7 +13,7 @@ Installation of the AMICI Python package has the following prerequisites:
 * CBLAS compatible BLAS library
   (e.g., OpenBLAS, CBLAS, Atlas, Accelerate, Intel MKL)
 * a C++17 compatible C++ compiler and a C compiler
-  (e.g., g++, clang, Intel C++ compiler, mingw)
+  (e.g., g++>=9.1, clang>=12, Intel C++ compiler, mingw)
 
 If these requirements are fulfilled and all relevant paths are setup properly,
 AMICI can be installed using:
@@ -43,6 +43,9 @@ Install the AMICI dependencies via ``apt``
 
    # optionally for HDF5 support:
    sudo apt install libhdf5-serial-dev
+
+    # optionally for boost support (thread-specific CPU times, extended math functions, serialization)
+    libboost-chrono-dev libboost-math-dev libboost-serialization-dev
 
 Install AMICI:
 
@@ -88,13 +91,13 @@ Alternatively:
 
 .. code-block:: bash
 
-   sudo pacman -Si python swig openblas gcc hdf5 boost-libs 
+   sudo pacman -Si python swig openblas gcc hdf5 boost-libs
 
 2. Upgrade installed packages if required mininum versions are not satisfied for AMICI installation.
 
 .. code-block:: bash
 
-   sudo pacman -Su python swig openblas gcc hdf5 boost-libs 
+   sudo pacman -Su python swig openblas gcc hdf5 boost-libs
 
 3. Install AMICI:
 
@@ -116,7 +119,10 @@ Install the AMICI dependencies using homebrew:
     brew install hdf5
 
     # optionally for parallel simulations:
-    brew install libomp
+    brew install libomp && export OpenMP_ROOT=$(brew --prefix)/opt/libomp"
+
+    # optionally for boost support (thread-specific CPU times, extended math functions, serialization)
+    brew install boost && export BOOST_ROOT=$(brew --prefix)/opt/boost
 
 Install AMICI:
 


### PR DESCRIPTION
* Ensure cmake can find OpenMP
* Assert that amici was compiled with OpenMP support
* Update installation guide

Fixes #2182 