### PR TITLE
GHA: Fix actions for PRs from forks

### DIFF
--- a/.github/workflows/test_install.yml
+++ b/.github/workflows/test_install.yml
@@ -1,5 +1,5 @@
 name: Installation
-on: [push, merge_group, workflow_dispatch]
+on: [push, pull_request, merge_group, workflow_dispatch]
 
 jobs:
   archive:

--- a/.github/workflows/test_petab_test_suite.yml
+++ b/.github/workflows/test_petab_test_suite.yml
@@ -85,6 +85,7 @@ jobs:
             tests/petab_test_suite/
 
       - name: Codecov
+        if: github.event_name == 'pull_request'
         uses: codecov/codecov-action@v3.1.0
         with:
           token: ${{ secrets.CODECOV_TOKEN }}

--- a/.github/workflows/test_python_cplusplus.yml
+++ b/.github/workflows/test_python_cplusplus.yml
@@ -6,6 +6,7 @@ on:
   pull_request:
     branches:
       - master
+      - develop
 
 jobs:
   ubuntu-cpp-python-tests:
@@ -65,6 +66,7 @@ jobs:
           ${AMICI_DIR}/python/tests/test_splines.py
 
     - name: Codecov Python
+      if: github.event_name == 'pull_request'
       uses: codecov/codecov-action@v3.1.0
       with:
         token: ${{ secrets.CODECOV_TOKEN }}
@@ -84,6 +86,7 @@ jobs:
         && lcov -a coverage_cpp.info -a coverage_py.info -o coverage.info
 
     - name: Codecov CPP
+      if: github.event_name == 'pull_request'
       uses: codecov/codecov-action@v3.1.0
       with:
         token: ${{ secrets.CODECOV_TOKEN }}
@@ -137,6 +140,7 @@ jobs:
           ${AMICI_DIR}/python/tests/test_splines_short.py
 
     - name: Codecov Python
+      if: github.event_name == 'pull_request'
       uses: codecov/codecov-action@v3.1.0
       with:
         token: ${{ secrets.CODECOV_TOKEN }}
@@ -156,6 +160,7 @@ jobs:
         && lcov -a coverage_cpp.info -a coverage_py.info -o coverage.info
 
     - name: Codecov CPP
+      if: github.event_name == 'pull_request'
       uses: codecov/codecov-action@v3.1.0
       with:
         token: ${{ secrets.CODECOV_TOKEN }}

--- a/.github/workflows/test_sbml_semantic_test_suite.yml
+++ b/.github/workflows/test_sbml_semantic_test_suite.yml
@@ -54,6 +54,7 @@ jobs:
         path: tests/amici-semantic-results
 
     - name: Codecov SBMLSuite
+      if: github.event_name == 'pull_request'
       uses: codecov/codecov-action@v3.1.0
       with:
         token: ${{ secrets.CODECOV_TOKEN }}

--- a/.github/workflows/test_windows.yml
+++ b/.github/workflows/test_windows.yml
@@ -7,6 +7,7 @@ on:
     - cron:  '48 4 * * *'
   pull_request:
     branches:
+      - develop
       - master
 
 jobs:


### PR DESCRIPTION
* run codecov only on pull requests
* trigger relevant actions on `pull_request` instead of only on `push`

Closes #2218