### PR TITLE
Fix CMake using incorrect Python library for building model extension

### DIFF
--- a/python/sdist/amici/setup.template.py
+++ b/python/sdist/amici/setup.template.py
@@ -1,5 +1,6 @@
 """AMICI model package setup"""
 import os
+import sys
 from pathlib import Path
 
 from amici import _get_amici_path
@@ -33,6 +34,7 @@ def get_extension() -> CMakeExtension:
             f"{prefix_path.as_posix()}/lib64/cmake/SuiteSparse",
             f"-DKLU_ROOT={prefix_path.as_posix()}",
             "-DAMICI_PYTHON_BUILD_EXT_ONLY=ON",
+            f"-DPython3_EXECUTABLE={Path(sys.executable).as_posix()}",
         ],
     )
 


### PR DESCRIPTION
This fixes a bug where a model extension would be built for an incorrect Python version. If there is a newer Python version available than the one in use during model import, CMake would incorrectly used the newer version. This results in not so informative errors like:
```
Traceback (most recent call last):
  File "<string>", line 1, in <module>
  File "/model_name/model_name.py", line 12, in <module>
    import _model_name
ModuleNotFoundError: No module named '_model_name'
```

Fixed here by explicitly setting the Python executable that is used to find the matching libraries.