### PR TITLE
buildAmici.sh: Only try installing numpy if not yet available

### DIFF
--- a/scripts/buildAmici.sh
+++ b/scripts/buildAmici.sh
@@ -25,7 +25,7 @@ else
 fi
 
 # required for build swig interface
-python3 -m pip install numpy
+pip show numpy > /dev/null || python3 -m pip install numpy
 
 ${cmake} \
   -Wdev -DAMICI_CXX_OPTIONS="-Wall;-Wextra${extra_cxx_flags}" \


### PR DESCRIPTION
Makes buildAmici.sh work with system-python. Before, it would fail if we don't have write permissions to system-packages even if numpy was already installed.