### PR TITLE
Fix potential out-of-bounds read in Model::checkFinite

### DIFF
--- a/src/model.cpp
+++ b/src/model.cpp
@@ -1818,7 +1818,7 @@ int Model::checkFinite(SUNMatrix m, ModelQuantity model_quantity, realtype t)
         if (hasExpressionIds())
             row_id += " " + getExpressionIds()[row];
         if (hasParameterIds())
-            col_id += " " + getParameterIds()[plist(gsl::narrow<int>(col))];
+            col_id += " " + getParameterIds()[col];
         break;
     default:
         break;


### PR DESCRIPTION
Fix potential out-of-bounds read and incorrect parameter IDs in error messages in Model::checkFinite: `dwdp_` has size `nw` x `np`, not `nw` x `nplist`.