### PR TITLE
Make test_petab_model.py runnable from any directory

### DIFF
--- a/tests/benchmark-models/test_petab_model.py
+++ b/tests/benchmark-models/test_petab_model.py
@@ -9,6 +9,7 @@ import importlib
 import logging
 import os
 import sys
+from pathlib import Path
 
 import amici
 import numpy as np
@@ -100,7 +101,7 @@ def parse_cli_args():
 
 def main():
     """Simulate the model specified on the command line"""
-
+    script_dir = Path(__file__).parent.absolute()
     args = parse_cli_args()
     loglevel = logging.DEBUG if args.verbose else logging.INFO
     logger.setLevel(loglevel)
@@ -168,10 +169,7 @@ def main():
 
     times["np"] = sum(problem.parameter_df[petab.ESTIMATE])
 
-    pd.Series(times).to_csv(
-        f"./tests/benchmark-models/{args.model_name}_benchmark.csv"
-    )
-
+    pd.Series(times).to_csv(script_dir / f"{args.model_name}_benchmark.csv")
     for rdata in rdatas:
         assert (
             rdata.status == amici.AMICI_SUCCESS
@@ -201,9 +199,7 @@ def main():
                 ax.get_figure().savefig(fig_path, dpi=150)
 
     if args.check:
-        references_yaml = os.path.join(
-            os.path.dirname(__file__), "benchmark_models.yaml"
-        )
+        references_yaml = script_dir / "benchmark_models.yaml"
         with open(references_yaml) as f:
             refs = yaml.full_load(f)
 


### PR DESCRIPTION
So far, this file relied on `pwd == __file__`, changed that.