### PR TITLE
Set PEtab benchmark collection path via `$BENCHMARK_COLLECTION`

### DIFF
--- a/tests/benchmark-models/test_petab_benchmark.py
+++ b/tests/benchmark-models/test_petab_benchmark.py
@@ -1,5 +1,5 @@
 """Tests for simulate_petab on PEtab benchmark problems."""
-
+import os
 from pathlib import Path
 
 import amici
@@ -13,13 +13,13 @@ from amici.petab.petab_import import import_petab_problem
 ATOL: float = 1e-3
 RTOL: float = 1e-2
 
-benchmark_path = (
-    Path(__file__).parent.parent.parent
-    / "Benchmark-Models-PEtab"
-    / "Benchmark-Models"
-)
+repo_root = Path(__file__).parent.parent.parent
+benchmark_path = repo_root / "Benchmark-Models-PEtab" / "Benchmark-Models"
+if not benchmark_path.exists():
+    benchmark_path = Path(os.environ["BENCHMARK_COLLECTION"])
+
 # reuse compiled models from test_benchmark_collection.sh
-benchmark_outdir = Path(__file__).parent.parent.parent / "test_bmc"
+benchmark_outdir = repo_root / "test_bmc"
 models = [
     str(petab_path.stem)
     for petab_path in benchmark_path.glob("*")


### PR DESCRIPTION
More convenient to use locally. Avoids having multiple copies of the PEtab benchmark collection lying around for different projects.

