### PR TITLE
GHA: increased number of optimizations for ExampleSplinesSwameye2003.ipynb

### DIFF
--- a/python/examples/example_splines_swameye/ExampleSplinesSwameye2003.ipynb
+++ b/python/examples/example_splines_swameye/ExampleSplinesSwameye2003.ipynb
@@ -101,11 +101,11 @@
    "source": [
     "# If running as a GitHub action, just do the minimal amount of work required to check whether the code is working\n",
     "if os.getenv(\"GITHUB_ACTIONS\") is not None:\n",
-    "    n_starts = 15\n",
+    "    n_starts = 25\n",
     "    pypesto_optimizer = pypesto.optimize.FidesOptimizer(\n",
     "        verbose=logging.WARNING, options=dict(maxiter=10)\n",
     "    )\n",
-    "    pypesto_engine = pypesto.engine.SingleCoreEngine()"
+    "    pypesto_engine = pypesto.engine.MultiProcessEngine()"
    ]
   },
   {


### PR DESCRIPTION
... and use all available cores.

This example fails too frequently, see e.g. https://github.com/dweindl/AMICI/actions/runs/7193472391/job/19591997110

> Exception: All multistarts failed (n_starts is probably too small)! If this error occurred during CI, just run the workflow again.