### PR TITLE
Make solvers and SolverPtr deepcopyable

### DIFF
--- a/python/tests/test_swig_interface.py
+++ b/python/tests/test_swig_interface.py
@@ -475,9 +475,15 @@ def test_expdata_and_expdataview_are_deepcopyable():
 
 def test_solvers_are_deepcopyable():
     for solver_type in (amici.CVodeSolver, amici.IDASolver):
-        solver1 = solver_type()
-        solver2 = copy.deepcopy(solver1)
-        assert solver1.this != solver2.this
-        assert solver1.getRelativeTolerance() == solver2.getRelativeTolerance()
-        solver2.setRelativeTolerance(100 * solver2.getRelativeTolerance())
-        assert solver1.getRelativeTolerance() != solver2.getRelativeTolerance()
+        for solver1 in (solver_type(), amici.SolverPtr(solver_type())):
+            solver2 = copy.deepcopy(solver1)
+            assert solver1.this != solver2.this
+            assert (
+                solver1.getRelativeTolerance()
+                == solver2.getRelativeTolerance()
+            )
+            solver2.setRelativeTolerance(100 * solver2.getRelativeTolerance())
+            assert (
+                solver1.getRelativeTolerance()
+                != solver2.getRelativeTolerance()
+            )

--- a/python/tests/test_swig_interface.py
+++ b/python/tests/test_swig_interface.py
@@ -471,3 +471,13 @@ def test_expdata_and_expdataview_are_deepcopyable():
     ev2 = copy.deepcopy(ev1)
     assert ev2._swigptr.this != ev1._swigptr.this
     assert ev1 == ev2
+
+
+def test_solvers_are_deepcopyable():
+    for solver_type in (amici.CVodeSolver, amici.IDASolver):
+        solver1 = solver_type()
+        solver2 = copy.deepcopy(solver1)
+        assert solver1.this != solver2.this
+        assert solver1.getRelativeTolerance() == solver2.getRelativeTolerance()
+        solver2.setRelativeTolerance(100 * solver2.getRelativeTolerance())
+        assert solver1.getRelativeTolerance() != solver2.getRelativeTolerance()

--- a/swig/solver.i
+++ b/swig/solver.i
@@ -116,6 +116,12 @@ def __repr__(self):
 %}
 };
 
+%extend amici::Solver {
+%pythoncode %{
+def __deepcopy__(self, memo):
+    return self.clone()
+%}
+};
 
 %newobject amici::Solver::clone;
 // Process symbols in header

--- a/swig/solver.i
+++ b/swig/solver.i
@@ -113,6 +113,9 @@ def __repr__(self):
 %pythoncode %{
 def __repr__(self):
     return _solver_repr(self)
+
+def __deepcopy__(self, memo):
+    return self.clone()
 %}
 };
 

--- a/swig/std_unique_ptr.i
+++ b/swig/std_unique_ptr.i
@@ -6,8 +6,11 @@ namespace std {
   struct unique_ptr {
      typedef Type* pointer;
 
+     %apply SWIGTYPE *DISOWN { pointer Ptr };
      explicit unique_ptr( pointer Ptr );
+     %clear pointer Ptr;
      unique_ptr (unique_ptr&& Right);
+
      template<class Type2, Class Del2> unique_ptr( unique_ptr<Type2, Del2>&& Right );
      unique_ptr( const unique_ptr& Right) = delete;
 


### PR DESCRIPTION
Make solvers and SolverPtr deepcopyable, and fix a segfault when creating `SolverPtr`s from Python.