### PR TITLE
GHA: require antimony!=2.14

### DIFF
--- a/python/sdist/setup.cfg
+++ b/python/sdist/setup.cfg
@@ -54,7 +54,8 @@ test =
     shyaml
     antimony>=2.13
     # see https://github.com/sys-bio/antimony/issues/92
-    antimony!=2.14; platform_system=='Darwin' and platform_machine=='x86_64h'
+    #  unsupported x86_64 / x86_64h
+    antimony!=2.14; platform_system=='Darwin' and platform_machine in 'x86_64h'
 vis =
     matplotlib
     seaborn

--- a/python/sdist/setup.cfg
+++ b/python/sdist/setup.cfg
@@ -52,7 +52,9 @@ test =
     pytest-rerunfailures
     coverage
     shyaml
-    antimony
+    antimony>=2.13
+    # see https://github.com/sys-bio/antimony/issues/92
+    antimony!=2.14; platform_system=='Darwin' and platform_machine=='x86_64h'
 vis =
     matplotlib
     seaborn


### PR DESCRIPTION
Should fix current GHA macOS test failures (see https://github.com/sys-bio/antimony/issues/92).