### PR TITLE
Add ExpData::clear_observations

### DIFF
--- a/include/amici/edata.h
+++ b/include/amici/edata.h
@@ -390,6 +390,13 @@ class ExpData : public SimulationParameters {
     realtype const* getObservedEventsStdDevPtr(int ie) const;
 
     /**
+     * @brief Set all observations and their standard deviations to NaN.
+     *
+     * Useful, e.g., after calling ExpData::setTimepoints.
+     */
+    void clear_observations();
+
+    /**
      * @brief Arbitrary (not necessarily unique) identifier.
      */
     std::string id;

--- a/src/edata.cpp
+++ b/src/edata.cpp
@@ -338,6 +338,18 @@ realtype const* ExpData::getObservedEventsStdDevPtr(int ie) const {
     return nullptr;
 }
 
+void ExpData::clear_observations() {
+    std::fill(observed_data_.begin(), observed_data_.end(), getNaN());
+    std::fill(
+        observed_data_std_dev_.begin(), observed_data_std_dev_.end(), getNaN()
+    );
+    std::fill(observed_events_.begin(), observed_events_.end(), getNaN());
+    std::fill(
+        observed_events_std_dev_.begin(), observed_events_std_dev_.end(),
+        getNaN()
+    );
+}
+
 void ExpData::applyDimensions() {
     applyDataDimension();
     applyEventDimension();


### PR DESCRIPTION
Makes it more convenient to unset all measurements, e.g. if one wants to run a simulation for a given experimental condition but with additional output timepoints while ignoring previously set measuremnts.