### PR TITLE
Fix `SwigPtrView.__getattr__`

### DIFF
--- a/python/sdist/amici/numpy.py
+++ b/python/sdist/amici/numpy.py
@@ -80,7 +80,10 @@ class SwigPtrView(collections.abc.Mapping):
 
         :returns: value
         """
-        return self.__getitem__(item)
+        try:
+            return self.__getitem__(item)
+        except KeyError as e:
+            raise AttributeError(item) from e
 
     def __init__(self, swigptr):
         """

--- a/python/tests/test_swig_interface.py
+++ b/python/tests/test_swig_interface.py
@@ -6,6 +6,8 @@ Test getters, setters, etc.
 import copy
 import numbers
 
+import pytest
+
 import amici
 import numpy as np
 
@@ -500,3 +502,24 @@ def test_model_is_deepcopyable(pysb_example_presimulation_module):
         assert model1.t0() == model2.t0()
         model2.setT0(100 + model2.t0())
         assert model1.t0() != model2.t0()
+
+
+def test_rdataview(sbml_example_presimulation_module):
+    """Test some SwigPtrView functionality via ReturnDataView."""
+    model_module = sbml_example_presimulation_module
+    model = model_module.getModel()
+    rdata = amici.runAmiciSimulation(model, model.getSolver())
+
+    assert isinstance(rdata, amici.ReturnDataView)
+
+    # fields are accessible via dot notation and [] operator,
+    #  __contains__ and __getattr__ are implemented correctly
+    with pytest.raises(AttributeError):
+        _ = rdata.nonexisting_attribute
+
+    assert not hasattr(rdata, "nonexisting_attribute")
+    assert "x" in rdata
+    assert rdata.x == rdata["x"]
+
+    # field names are included by dir()
+    assert "x" in dir(rdata)

--- a/python/tests/test_swig_interface.py
+++ b/python/tests/test_swig_interface.py
@@ -509,13 +509,15 @@ def test_rdataview(sbml_example_presimulation_module):
     model_module = sbml_example_presimulation_module
     model = model_module.getModel()
     rdata = amici.runAmiciSimulation(model, model.getSolver())
-
     assert isinstance(rdata, amici.ReturnDataView)
 
     # fields are accessible via dot notation and [] operator,
     #  __contains__ and __getattr__ are implemented correctly
     with pytest.raises(AttributeError):
         _ = rdata.nonexisting_attribute
+
+    with pytest.raises(KeyError):
+        _ = rdata["nonexisting_attribute"]
 
     assert not hasattr(rdata, "nonexisting_attribute")
     assert "x" in rdata


### PR DESCRIPTION
`hasattr` didn't work with SwigPtrView, because calling `__getattr__` for a missing attribute resulted in a KeyError via `__missing__`. However, hasattr expects an attribute error in that case.