### PR TITLE
Fix swig shadow warning + other linting issues

### DIFF
--- a/include/amici/logging.h
+++ b/include/amici/logging.h
@@ -83,7 +83,7 @@ struct LogItem {
         , message(message){};
 
     /** Severity level */
-    LogSeverity severity;
+    LogSeverity severity = LogSeverity::error;
 
     /** Short identifier for the logged event */
     std::string identifier;

--- a/include/amici/model.h
+++ b/include/amici/model.h
@@ -1437,7 +1437,7 @@ class Model : public AbstractModel, public ModelDimensions {
     std::vector<int> const& getReinitializationStateIdxs() const;
 
     /** Flag indicating Matlab- or Python-based model generation */
-    bool pythonGenerated;
+    bool pythonGenerated = false;
 
     /**
      * @brief getter for dxdotdp (matlab generated)

--- a/include/amici/simulation_parameters.h
+++ b/include/amici/simulation_parameters.h
@@ -35,6 +35,11 @@ class SimulationParameters {
               this->parameters.size(), ParameterScaling::none
           )) {}
 
+#ifndef SWIGPYTHON
+    /*
+     * include/amici/simulation_parameters.h:71: Warning 509: Overloaded method amici::SimulationParameters::SimulationParameters(std::vector< amici::realtype,std::allocator< amici::realtype > >,std::vector< amici::realtype,std::allocator< amici::realtype > >,std::vector< amici::realtype,std::allocator< amici::realtype > >) effectively ignored,
+     * include/amici/simulation_parameters.h:54: Warning 509: as it is shadowed by amici::SimulationParameters::SimulationParameters(std::vector< amici::realtype,std::allocator< amici::realtype > >,std::vector< amici::realtype,std::allocator< amici::realtype > >,std::vector< int,std::allocator< int > >).
+     */
     /**
      * @brief Constructor
      * @param fixedParameters Model constants
@@ -69,6 +74,7 @@ class SimulationParameters {
               this->parameters.size(), ParameterScaling::none
           ))
         , ts_(std::move(timepoints)) {}
+#endif
 
     /**
      * @brief Set reinitialization of all states based on model constants for

--- a/src/steadystateproblem.cpp
+++ b/src/steadystateproblem.cpp
@@ -601,8 +601,6 @@ void SteadystateProblem::applyNewtonsMethod(Model& model, bool newton_retry) {
     int& i_newtonstep = numsteps_.at(newton_retry ? 2 : 0);
     i_newtonstep = 0;
     gamma_ = 1.0;
-    bool update_direction = true;
-    bool step_successful = false;
 
     if (model.nx_solver == 0)
         return;
@@ -613,6 +611,8 @@ void SteadystateProblem::applyNewtonsMethod(Model& model, bool newton_retry) {
     bool converged = false;
     wrms_ = getWrms(model, SensitivityMethod::none);
     converged = newton_retry ? false : wrms_ < conv_thresh;
+    bool update_direction = true;
+
     while (!converged && i_newtonstep < max_steps_) {
 
         /* If Newton steps are necessary, compute the initial search
@@ -634,7 +634,7 @@ void SteadystateProblem::applyNewtonsMethod(Model& model, bool newton_retry) {
         /* Compute new xdot and residuals */
         realtype wrms_tmp = getWrms(model, SensitivityMethod::none);
 
-        step_successful = wrms_tmp < wrms_;
+        bool step_successful = wrms_tmp < wrms_;
         if (step_successful) {
             /* If new residuals are smaller than old ones, update state */
             wrms_ = wrms_tmp;


### PR DESCRIPTION
Fixes swig warning
```
include/amici/simulation_parameters.h:71: Warning 509: Overloaded method amici::SimulationParameters::SimulationParameters(std::vector< amici::realtype,std::allocator< amici::realtype > >,std::vector< amici::realtype,std::allocator< amici::realtype > >,std::vector< amici::realtype,std::allocator< amici::realtype > >) effectively ignored,
include/amici/simulation_parameters.h:54: Warning 509: as it is shadowed by amici::SimulationParameters::SimulationParameters(std::vector< amici::realtype,std::allocator< amici::realtype > >,std::vector< amici::realtype,std::allocator< amici::realtype > >,std::vector< int,std::allocator< int > >).
```

and some other linting warnings.