### PR TITLE
Use PyPI trusted publishing

### DIFF
--- a/.github/workflows/deploy_release.yml
+++ b/.github/workflows/deploy_release.yml
@@ -14,6 +14,13 @@ jobs:
       matrix:
         python-version: [3.9]
 
+    environment:
+      name: pypi
+      url: https://pypi.org/p/amici
+
+    permissions:
+      id-token: write
+
     steps:
     - name: Set up Python ${{ matrix.python-version }}
       uses: actions/setup-python@v4
@@ -40,8 +47,6 @@ jobs:
     - name: Publish a Python distribution to PyPI
       uses: pypa/gh-action-pypi-publish@release/v1
       with:
-        user: __token__
-        password: ${{ secrets.pypi_password }}
         packages-dir: python/sdist/dist
 
   bioSimulatorsUpdateCliAndDockerImage:


### PR DESCRIPTION
Use PyPI [trusted publishing](https://docs.pypi.org/trusted-publishers/) instead of username/password.