### PR TITLE
Require pyarrow

### DIFF
--- a/python/sdist/setup.cfg
+++ b/python/sdist/setup.cfg
@@ -35,6 +35,7 @@ install_requires =
     numpy; python_version>='3.12'
     python-libsbml
     pandas>=2.0.2
+    pyarrow
     wurlitzer
     toposort
     setuptools>=48


### PR DESCRIPTION
Avoids
```
.tox\unit\lib\site-packages\pandas\__init__.py:249: in <module>
    warnings.warn(
E   DeprecationWarning:
E   Pyarrow will become a required dependency of pandas in the next major release of pandas (pandas 3.0),
E   (to allow more performant data types, such as the Arrow string type, and better interoperability with other libraries)
E   but was not found to be installed on your system.
E   If this would cause problems for you,
E   please provide us feedback at https://github.com/pandas-dev/pandas/issues/54466
```