### PR TITLE
Fix `ENABLE_AMICI_DEBUGGING=TRUE` not working with MSVC

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -84,7 +84,12 @@ endif()
 
 # Debug build?
 if("$ENV{ENABLE_AMICI_DEBUGGING}" OR "$ENV{ENABLE_GCOV_COVERAGE}")
-  add_compile_options(-UNDEBUG -O0 -g)
+  add_compile_options(-UNDEBUG)
+  if(MSVC)
+    add_compile_options(-DEBUG)
+  else()
+    add_compile_options(-O0 -g)
+  endif()
   set(CMAKE_BUILD_TYPE "Debug")
 endif()
 

--- a/src/CMakeLists.template.cmake
+++ b/src/CMakeLists.template.cmake
@@ -41,7 +41,12 @@ message(STATUS "Found AMICI ${Amici_DIR}")
 
 # Debug build?
 if("$ENV{ENABLE_AMICI_DEBUGGING}" OR "$ENV{ENABLE_GCOV_COVERAGE}")
-  add_compile_options(-UNDEBUG -O0 -g)
+  add_compile_options(-UNDEBUG)
+  if(MSVC)
+    add_compile_options(-DEBUG)
+  else()
+    add_compile_options(-O0 -g)
+  endif()
   set(CMAKE_BUILD_TYPE "Debug")
 endif()
 


### PR DESCRIPTION
Fixes
```
cl : Command line warning D9002 : ignoring unknown option '-O0'
cl : Command line warning D9002 : ignoring unknown option '-g'
```

see also https://learn.microsoft.com/en-us/cpp/build/reference/debug-generate-debug-info?view=msvc-170

Fixes #2228
