### PR TITLE
Skip unnecessary toposorting in `DEModel._collect_heaviside_roots`

### DIFF
--- a/python/sdist/amici/de_export.py
+++ b/python/sdist/amici/de_export.py
@@ -2724,6 +2724,9 @@ class DEModel:
             elif arg.has(sp.Heaviside):
                 root_funs.extend(self._collect_heaviside_roots(arg.args))
 
+        if not root_funs:
+            return []
+
         # substitute 'w' expressions into root expressions now, to avoid
         # rewriting 'root.cpp' and 'stau.cpp' headers
         # to include 'w.h'


### PR DESCRIPTION
Sorting is only required if roots have been found. Most often this will not be the case. Only sort when necessary.