### PR TITLE
Don't eliminate parameters that are initial assignment targets (pt1)

### DIFF
--- a/python/sdist/amici/sbml_import.py
+++ b/python/sdist/amici/sbml_import.py
@@ -1051,15 +1051,23 @@ class SbmlImporter:
                     "Parameter does not exist." % parameter
                 )
 
+        # parameter ID => initial assignment sympy expression
+        par_id_to_ia = {
+            par.getId(): ia
+            for par in self.sbml.getListOfParameters()
+            if (ia := self._get_element_initial_assignment(par.getId()))
+            is not None
+        }
+
         fixed_parameters = [
             parameter
             for parameter in self.sbml.getListOfParameters()
             if parameter.getId() in constant_parameters
         ]
         for parameter in fixed_parameters:
+            ia_math = par_id_to_ia.get(parameter.getId())
             if (
-                self._get_element_initial_assignment(parameter.getId())
-                is not None
+                (ia_math is not None and not ia_math.is_Number)
                 or self.is_assignment_rule_target(parameter)
                 or self.is_rate_rule_target(parameter)
             ):
@@ -1074,7 +1082,10 @@ class SbmlImporter:
             parameter
             for parameter in self.sbml.getListOfParameters()
             if parameter.getId() not in constant_parameters
-            and self._get_element_initial_assignment(parameter.getId()) is None
+            and (
+                (ia_math := par_id_to_ia.get(parameter.getId())) is None
+                or ia_math.is_Number
+            )
             and not self.is_assignment_rule_target(parameter)
             and parameter.getId() not in hardcode_symbols
         ]
@@ -1091,16 +1102,16 @@ class SbmlImporter:
             for par in settings["var"]:
                 self.symbols[partype][_get_identifier_symbol(par)] = {
                     "name": par.getName() if par.isSetName() else par.getId(),
-                    "value": sp.Float(par.getValue()),
+                    "value": par_id_to_ia.get(
+                        par.getId(), sp.Float(par.getValue())
+                    ),
                 }
 
         # Parameters that need to be turned into expressions
         #  so far, this concerns parameters with initial assignments containing rateOf(.)
         #  (those have been skipped above)
         for par in self.sbml.getListOfParameters():
-            if (
-                ia := self._get_element_initial_assignment(par.getId())
-            ) is not None and ia.find(
+            if (ia := par_id_to_ia.get(par.getId())) is not None and ia.find(
                 sp.core.function.UndefinedFunction("rateOf")
             ):
                 self.symbols[SymbolId.EXPRESSION][
@@ -1877,7 +1888,10 @@ class SbmlImporter:
         for ia in self.sbml.getListOfInitialAssignments():
             identifier = _get_identifier_symbol(ia)
             if identifier in itt.chain(
-                self.symbols[SymbolId.SPECIES], self.compartments
+                self.symbols[SymbolId.SPECIES],
+                self.compartments,
+                self.symbols[SymbolId.PARAMETER],
+                self.symbols[SymbolId.FIXED_PARAMETER],
             ):
                 continue
 


### PR DESCRIPTION
Currently, parameters that are targets of initial assignments don't show up as parameters or expressions in the amici model. This is rather not what most users would expect.

For example, previously:
SBML parameter with `value=2` -> will result in an amici parameter with that name
SBML parameter with initial assignment `2` -> will *not* result in an amici parameter with that name

As a first step: treat all SBML parameters that are initial assignment targets and whose initial assignment evaluates to a number as amici parameters.

Related to #2150.