### PR TITLE
GHA: only try to publish docker image if secrets are set

### DIFF
--- a/.github/workflows/deploy_protected.yml
+++ b/.github/workflows/deploy_protected.yml
@@ -13,9 +13,25 @@ on:
   workflow_dispatch:
 
 jobs:
+  check-secret:
+    runs-on: ubuntu-latest
+    outputs:
+      secrets-defined: ${{ steps.secret-check.outputs.defined }}
+    steps:
+      - name: Check for Secret availability
+        id: secret-check
+        shell: bash
+        run: |
+          if [ "${{ secrets.DOCKER_USERNAME }}" != '' ]; then
+            echo "defined=true" >> $GITHUB_OUTPUT;
+          else
+            echo "defined=false" >> $GITHUB_OUTPUT;
+          fi
+
   dockerhub:
     name: Deploy Dockerhub
-    if: github.event.pull_request.head.repo.fork == false
+    needs: [check-secret]
+    if: needs.check-secret.outputs.secrets-defined == 'true'
     runs-on: ubuntu-22.04
 
     strategy:


### PR DESCRIPTION
Another attempt to avoid failures on forks due to unavailable secrets. The previous check did not cover push-triggered runs.
