### PR TITLE
Refactor de_export.py, extract template functions

### DIFF
--- a/python/sdist/amici/_codegen/template.py
+++ b/python/sdist/amici/_codegen/template.py
@@ -1,0 +1,42 @@
+"""Functions to apply template substitution to files."""
+from pathlib import Path
+from string import Template
+from typing import Union
+
+
+class TemplateAmici(Template):
+    """
+    Template format used in AMICI (see :class:`string.Template` for more
+    details).
+
+    :cvar delimiter:
+        delimiter that identifies template variables
+    """
+
+    delimiter = "TPL_"
+
+
+def apply_template(
+    source_file: Union[str, Path],
+    target_file: Union[str, Path],
+    template_data: dict[str, str],
+) -> None:
+    """
+    Load source file, apply template substitution as provided in
+    templateData and save as targetFile.
+
+    :param source_file:
+        relative or absolute path to template file
+
+    :param target_file:
+        relative or absolute path to output file
+
+    :param template_data:
+        template keywords to substitute (key is template
+        variable without :attr:`TemplateAmici.delimiter`)
+    """
+    with open(source_file) as filein:
+        src = TemplateAmici(filein.read())
+    result = src.safe_substitute(template_data)
+    with open(target_file, "w") as fileout:
+        fileout.write(result)

--- a/python/sdist/amici/de_export.py
+++ b/python/sdist/amici/de_export.py
@@ -20,7 +20,6 @@ import sys
 from dataclasses import dataclass
 from itertools import chain, starmap
 from pathlib import Path
-from string import Template
 from typing import (
     TYPE_CHECKING,
     Any,
@@ -43,6 +42,7 @@ from . import (
     amiciSwigPath,
     splines,
 )
+from ._codegen.template import apply_template
 from .constants import SymbolId
 from .cxxcodeprinter import AmiciCxxCodePrinter, get_switch_statement
 from .de_model import *
@@ -4084,44 +4084,6 @@ class DEExporter:
             )
 
         self.model_name = model_name
-
-
-class TemplateAmici(Template):
-    """
-    Template format used in AMICI (see :class:`string.Template` for more
-    details).
-
-    :cvar delimiter:
-        delimiter that identifies template variables
-    """
-
-    delimiter = "TPL_"
-
-
-def apply_template(
-    source_file: Union[str, Path],
-    target_file: Union[str, Path],
-    template_data: dict[str, str],
-) -> None:
-    """
-    Load source file, apply template substitution as provided in
-    templateData and save as targetFile.
-
-    :param source_file:
-        relative or absolute path to template file
-
-    :param target_file:
-        relative or absolute path to output file
-
-    :param template_data:
-        template keywords to substitute (key is template
-        variable without :attr:`TemplateAmici.delimiter`)
-    """
-    with open(source_file) as filein:
-        src = TemplateAmici(filein.read())
-    result = src.safe_substitute(template_data)
-    with open(target_file, "w") as fileout:
-        fileout.write(result)
 
 
 def get_function_extern_declaration(fun: str, name: str, ode: bool) -> str:


### PR DESCRIPTION
Start moving functionality for amici model code generation to a private subpackage `amici._codegen`. More to follow.

Related to #2306