### PR TITLE
Refactor: Move amici.de_model to amici.de_model_components

### DIFF
--- a/.github/workflows/test_sbml_semantic_test_suite.yml
+++ b/.github/workflows/test_sbml_semantic_test_suite.yml
@@ -9,7 +9,7 @@ on:
     paths:
       - .github/workflows/test_sbml_semantic_test_suite.yml
       - python/sdist/amici/de_export.py
-      - python/sdist/amici/de_model.py
+      - python/sdist/amici/de_model_components.py
       - python/sdist/amici/sbml_import.py
       - python/sdist/amici/import_utils.py
       - scripts/run-SBMLTestsuite.sh

--- a/documentation/python_modules.rst
+++ b/documentation/python_modules.rst
@@ -25,7 +25,7 @@ AMICI Python API
    amici.petab_simulate
    amici.import_utils
    amici.de_export
-   amici.de_model
+   amici.de_model_components
    amici.plotting
    amici.pandas
    amici.logging

--- a/python/sdist/amici/de_export.py
+++ b/python/sdist/amici/de_export.py
@@ -45,7 +45,7 @@ from .cxxcodeprinter import (
     get_switch_statement,
     csc_matrix,
 )
-from .de_model import *
+from .de_model_components import *
 from .import_utils import (
     ObservableTransformation,
     SBMLException,

--- a/python/sdist/amici/de_model_components.py
+++ b/python/sdist/amici/de_model_components.py
@@ -199,7 +199,7 @@ class AlgebraicEquation(ModelQuantity):
         Create a new AlgebraicEquation instance.
 
         :param value:
-            formula of the algebraic equation, solution is given by
+            Formula of the algebraic equation, the solution is given by
             ``formula == 0``
         """
         super().__init__(sp.Symbol(identifier), identifier, value)

--- a/python/sdist/amici/sbml_import.py
+++ b/python/sdist/amici/sbml_import.py
@@ -32,7 +32,7 @@ from .de_export import (
     DEExporter,
     DEModel,
 )
-from .de_model import symbol_to_type, Expression
+from .de_model_components import symbol_to_type, Expression
 from .sympy_utils import smart_is_zero_matrix, smart_multiply
 from .import_utils import (
     RESERVED_SYMBOLS,

--- a/python/tests/test_de_model.py
+++ b/python/tests/test_de_model.py
@@ -1,5 +1,5 @@
 import sympy as sp
-from amici.de_model import Event
+from amici.de_model_components import Event
 from amici.import_utils import amici_time_symbol
 from amici.testing import skip_on_valgrind
 


### PR DESCRIPTION
... to make space to move `amici.de_export.DEModel` to `amici.de_model`

Related to #2306.