### PR TITLE
Fix size check in `Model::setStateIsNonNegative`

### DIFF
--- a/src/model.cpp
+++ b/src/model.cpp
@@ -883,11 +883,11 @@ void Model::setStateIsNonNegative(std::vector<bool> const& nonNegative) {
         // in case of conservation laws
         return;
     }
-    if (state_is_non_negative_.size() != gsl::narrow<unsigned long>(nx_rdata)) {
+    if (nonNegative.size() != gsl::narrow<unsigned long>(nx_rdata)) {
         throw AmiException(
             "Dimension of input stateIsNonNegative (%u) does "
             "not agree with number of state variables (%d)",
-            state_is_non_negative_.size(), nx_rdata
+            nonNegative.size(), nx_rdata
         );
     }
     state_is_non_negative_ = nonNegative;


### PR DESCRIPTION
Previously, the wrong array was checked :see_no_evil::

```python
amici_model.setAllStatesNonNegative() # works as expected
amici_model.setStateIsNonNegative([]) # should fail
amici_model.setAllStatesNonNegative() # should work, but fails

Traceback (most recent call last):
  File "<ipython-input-22-d7056e8e4e3f>", line 1, in <module>
    amici_model.setAllStatesNonNegative()
  File "python/sdist/amici/amici.py", line 2243, in setAllStatesNonNegative
    return _amici.ModelPtr_setAllStatesNonNegative(self)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
RuntimeError: Dimension of input stateIsNonNegative (0) does not agree with number of state variables (2)
```