### PR TITLE
Fix uncaught C++ exception in runAmiciSimulation

### DIFF
--- a/src/amici.cpp
+++ b/src/amici.cpp
@@ -220,10 +220,20 @@ std::unique_ptr<ReturnData> runAmiciSimulation(
         );
     }
 
-    rdata->processSimulationObjects(
-        preeq.get(), fwd.get(), bwd_success ? bwd.get() : nullptr, posteq.get(),
-        model, solver, edata
-    );
+    try {
+        rdata->processSimulationObjects(
+            preeq.get(), fwd.get(), bwd_success ? bwd.get() : nullptr, posteq.get(),
+            model, solver, edata
+        );
+    } catch (std::exception const& ex) {
+        rdata->status = AMICI_ERROR;
+        if (rethrow)
+            throw;
+        logger.log(
+            LogSeverity::error, "OTHER", "AMICI simulation failed: %s",
+            ex.what()
+        );
+    }
 
     rdata->cpu_time_total = cpu_timer.elapsed_milliseconds();
 


### PR DESCRIPTION
Previously, an exception during `ReturnData::processSimulationObjects` would result in program termination.

Fixes #1882.