### PR TITLE
Fix ReturnDataView AttributeError: messages

### DIFF
--- a/python/sdist/amici/numpy.py
+++ b/python/sdist/amici/numpy.py
@@ -9,7 +9,7 @@ import copy
 import itertools
 from typing import Literal, Union
 from collections.abc import Iterator
-
+from numbers import Number
 import amici
 import numpy as np
 import sympy as sp
@@ -238,6 +238,7 @@ class ReturnDataView(SwigPtrView):
         "numnonlinsolvconvfailsB",
         "cpu_timeB",
         "cpu_time_total",
+        "messages",
     ]
 
     def __init__(self, rdata: Union[ReturnDataPtr, ReturnData]):
@@ -440,7 +441,11 @@ def _field_as_numpy(
     attr = getattr(data, field)
     if field_dim := field_dimensions.get(field, None):
         return None if len(attr) == 0 else np.array(attr).reshape(field_dim)
-    return float(attr)
+
+    if isinstance(attr, Number):
+        return float(attr)
+
+    return attr
 
 
 def _entity_type_from_id(

--- a/python/tests/test_sbml_import.py
+++ b/python/tests/test_sbml_import.py
@@ -368,7 +368,7 @@ def test_solver_reuse(model_steadystate_module):
         assert rdata1.status == amici.AMICI_SUCCESS
 
         for attr in rdata1:
-            if "time" in attr:
+            if "time" in attr or attr == "messages":
                 continue
 
             val1 = getattr(rdata1, attr)

--- a/swig/amici.i
+++ b/swig/amici.i
@@ -235,6 +235,14 @@ def __repr__(self):
 %}
 };
 
+%extend amici::LogItem {
+%pythoncode %{
+def __repr__(self):
+    return (f"{self.__class__.__name__}(severity={self.severity}, "
+        f"identifier={self.identifier!r}, message={self.message!r})")
+%}
+};
+
 
 // Convert integer values to enum class
 // defeats the purpose of enum class, but didn't find a better way to allow for


### PR DESCRIPTION
* Make log messages from ReturnData available through ReturnDataView.
* Add `LogItem.__repr__`

Closes #2331.