### PR TITLE
Fix swig/std_unique_ptr.i

### DIFF
--- a/swig/std_unique_ptr.i
+++ b/swig/std_unique_ptr.i
@@ -17,7 +17,7 @@ namespace std {
 
      pointer operator-> () const;
      pointer release ();
-     void reset (pointer __p=pointer());
+     void reset (pointer __p=std::unique_ptr<Type>::pointer());
      void swap (unique_ptr &__u);
      pointer get () const;
      operator bool () const;


### PR DESCRIPTION
Fixes some `used without template arguments` compilation errors when running swig with `-builtin` or `-keyword`.