### PR TITLE
Add Solver::get_current_time

### DIFF
--- a/include/amici/solver.h
+++ b/include/amici/solver.h
@@ -965,6 +965,12 @@ class Solver {
     int getMaxConvFails() const;
 
     /**
+     * @brief Get the current time of the solver.
+     * @return internal time of the solver
+     */
+    virtual realtype get_current_time() const = 0;
+
+    /**
      * @brief Serialize Solver (see boost::serialization::serialize)
      * @param ar Archive to serialize to
      * @param s Data to serialize

--- a/include/amici/solver_cvodes.h
+++ b/include/amici/solver_cvodes.h
@@ -91,6 +91,8 @@ class CVodeSolver : public Solver {
 
     void setNonLinearSolverB(int which) const override;
 
+    realtype get_current_time() const override;
+
   protected:
     void calcIC(realtype tout1) const override;
 

--- a/include/amici/solver_idas.h
+++ b/include/amici/solver_idas.h
@@ -106,6 +106,8 @@ class IDASolver : public Solver {
 
     void setNonLinearSolverB(int which) const override;
 
+    realtype get_current_time() const override;
+
   protected:
     /**
      * @brief Postprocessing of the solver memory after a discontinuity

--- a/src/solver_cvodes.cpp
+++ b/src/solver_cvodes.cpp
@@ -386,6 +386,17 @@ void CVodeSolver::setNonLinearSolverB(int const which) const {
         throw CvodeException(status, "CVodeSetNonlinearSolverB");
 }
 
+realtype CVodeSolver::get_current_time() const {
+    if (!solver_memory_)
+        return std::numeric_limits<realtype>::quiet_NaN();
+
+    realtype time;
+    int status = CVodeGetCurrentTime(solver_memory_.get(), &time);
+    if (status != CV_SUCCESS)
+        throw CvodeException(status, "CVodeGetCurrentTime");
+    return time;
+}
+
 void CVodeSolver::setErrHandlerFn() const {
     int status = CVodeSetErrHandlerFn(
         solver_memory_.get(), wrapErrHandlerFn,

--- a/src/solver_idas.cpp
+++ b/src/solver_idas.cpp
@@ -17,7 +17,7 @@
 namespace amici {
 
 /*
- * The following static members are callback function to CVODES.
+ * The following static members are callback function to IDAS.
  * Their signatures must not be changes.
  */
 
@@ -419,7 +419,7 @@ void IDASolver::reInitPostProcess(
 
     auto status = IDASetStopTime(ida_mem, tout);
     if (status != IDA_SUCCESS)
-        throw IDAException(status, "CVodeSetStopTime");
+        throw IDAException(status, "IDASetStopTime");
 
     status = IDASolve(
         ami_mem, tout, t, yout->getNVector(), ypout->getNVector(), IDA_ONE_STEP
@@ -835,7 +835,7 @@ void IDASolver::setNonLinearSolver() const {
         solver_memory_.get(), non_linear_solver_->get()
     );
     if (status != IDA_SUCCESS)
-        throw CvodeException(status, "CVodeSetNonlinearSolver");
+        throw IDAException(status, "IDASetNonlinearSolver");
 }
 
 void IDASolver::setNonLinearSolverSens() const {
@@ -865,7 +865,7 @@ void IDASolver::setNonLinearSolverSens() const {
     }
 
     if (status != IDA_SUCCESS)
-        throw CvodeException(status, "CVodeSolver::setNonLinearSolverSens");
+        throw IDAException(status, "IDASolver::setNonLinearSolverSens");
 }
 
 void IDASolver::setNonLinearSolverB(int which) const {
@@ -873,7 +873,7 @@ void IDASolver::setNonLinearSolverB(int which) const {
         solver_memory_.get(), which, non_linear_solver_B_->get()
     );
     if (status != IDA_SUCCESS)
-        throw CvodeException(status, "CVodeSetNonlinearSolverB");
+        throw IDAException(status, "IDASetNonlinearSolverB");
 }
 
 realtype IDASolver::get_current_time() const {
@@ -883,7 +883,7 @@ realtype IDASolver::get_current_time() const {
     realtype time;
     int status = IDAGetCurrentTime(solver_memory_.get(), &time);
     if (status != IDA_SUCCESS)
-        throw CvodeException(status, "IDAGetCurrentTime");
+        throw IDAException(status, "IDAGetCurrentTime");
     return time;
 }
 

--- a/src/solver_idas.cpp
+++ b/src/solver_idas.cpp
@@ -876,6 +876,17 @@ void IDASolver::setNonLinearSolverB(int which) const {
         throw CvodeException(status, "CVodeSetNonlinearSolverB");
 }
 
+realtype IDASolver::get_current_time() const {
+    if (!solver_memory_)
+        return std::numeric_limits<realtype>::quiet_NaN();
+
+    realtype time;
+    int status = IDAGetCurrentTime(solver_memory_.get(), &time);
+    if (status != IDA_SUCCESS)
+        throw CvodeException(status, "IDAGetCurrentTime");
+    return time;
+}
+
 /**
  * @brief Jacobian of xdot with respect to states x
  * @param N number of state variables


### PR DESCRIPTION
... to get the current integration time from the solver.

(also fixes a couple of incorrect exception types and messages)

Prerequisite for #2246.