### PR TITLE
Make is-zero-checks compatible with the upcoming sympy>1.12

### DIFF
--- a/python/sdist/amici/cxxcodeprinter.py
+++ b/python/sdist/amici/cxxcodeprinter.py
@@ -339,7 +339,7 @@ def csc_matrix(
     for col in range(ncols):
         symbol_col_ptrs.append(idx)
         for row in range(nrows):
-            if matrix[row, col] == 0:
+            if matrix[row, col].is_zero:
                 continue
 
             symbol_row_vals.append(row)

--- a/python/sdist/amici/de_model.py
+++ b/python/sdist/amici/de_model.py
@@ -2115,7 +2115,7 @@ class DEModel:
         if isinstance(state, AlgebraicState):
             return False
 
-        return state.get_dt() == 0.0
+        return state.get_dt().is_zero
 
     def conservation_law_has_multispecies(self, tcl: ConservationLaw) -> bool:
         """
@@ -2179,7 +2179,7 @@ class DEModel:
             return None
 
         for root in roots:
-            if sp.simplify(root_found - root.get_val()) == 0:
+            if sp.simplify(root_found - root.get_val()).is_zero:
                 return root.get_id()
 
         # create an event for a new root function


### PR DESCRIPTION
Current sympy master (tested: 0ededfcfc033ddca2d1d54a0eda85bf53c63761c):

```python
IPython console for SymPy 1.13.dev (Python 3.12.2-64-bit) (ground types: python)
In [1]: Float(0) == 0
Out[1]: False
In [2]: Float(0).is_zero
Out[2]: True
```
vs 1.12:
```python
Python console for SymPy 1.12 (Python 3.12.2-64-bit) (ground types: python)
>>> Float(0) == 0
True
>>> Float(0).is_zero
True
```

Therefore, replace `== 0` by `.is_zero`.

Amongst other potential issues, this fixes zeros in sparse matrices. Closes #2320.