### PR TITLE
Fix in-place building of model wheels

### DIFF
--- a/python/sdist/amici/MANIFEST.template.in
+++ b/python/sdist/amici/MANIFEST.template.in
@@ -1,1 +1,3 @@
 include *.cpp *.h
+include CMakeLists.txt
+recursive-include swig/ *


### PR DESCRIPTION
Fix `python -m build -n` for generated model packages.

Fixes half of #2285