### PR TITLE
SBML import: Evaluate initial assignments

### DIFF
--- a/python/sdist/amici/sbml_import.py
+++ b/python/sdist/amici/sbml_import.py
@@ -1143,7 +1143,12 @@ class SbmlImporter:
 
         # parameter ID => initial assignment sympy expression
         par_id_to_ia = {
-            par.getId(): ia.evalf()
+            par.getId(): ia.subs(
+                {
+                    BooleanTrue(): sp.Float(1.0),
+                    BooleanFalse(): sp.Float(0.0),
+                }
+            ).evalf()
             for par in self.sbml.getListOfParameters()
             if (ia := self._get_element_initial_assignment(par.getId()))
             is not None

--- a/python/sdist/amici/sbml_import.py
+++ b/python/sdist/amici/sbml_import.py
@@ -1143,7 +1143,7 @@ class SbmlImporter:
 
         # parameter ID => initial assignment sympy expression
         par_id_to_ia = {
-            par.getId(): ia
+            par.getId(): ia.evalf()
             for par in self.sbml.getListOfParameters()
             if (ia := self._get_element_initial_assignment(par.getId()))
             is not None


### PR DESCRIPTION
Evaluate initial assignments to parameters to determine whether the targets are amici parameters or expressions. Related to https://github.com/AMICI-dev/AMICI/pull/2304.

For example, it the initial assignment is `log(10)`, this should still be a parameter instead of an expression, but `sympy.log(10).is_Number` will be `False`. 