### PR TITLE
Fix Solver::dky_ initialization

### DIFF
--- a/src/solver.cpp
+++ b/src/solver.cpp
@@ -1176,6 +1176,8 @@ void Solver::resetMutableMemory(int const nx, int const nplist, int const nquad)
     sx_ = AmiVectorArray(nx, nplist);
     sdx_ = AmiVectorArray(nx, nplist);
 
+    dky_ = AmiVector(nx);
+
     xB_ = AmiVector(nx);
     dxB_ = AmiVector(nx);
     xQB_ = AmiVector(nquad);


### PR DESCRIPTION
`Solver::dky_` is always empty. Any call to `CVodeGetDky` should fail. Seems like it's never used.