### PR TITLE
Skip recreating N_Vector in AmiVector::copy

### DIFF
--- a/src/vector.cpp
+++ b/src/vector.cpp
@@ -53,7 +53,6 @@ void AmiVector::copy(AmiVector const& other) {
             getLength(), other.getLength()
         );
     std::copy(other.vec_.begin(), other.vec_.end(), vec_.begin());
-    synchroniseNVector();
 }
 
 void AmiVector::synchroniseNVector() {


### PR DESCRIPTION
We only copy if the sizes match. Since the std::vector is not reallocated, there is no need to recreate the N_Vector.