### PR TITLE
Fix initial state issues with PEtab

### DIFF
--- a/python/sdist/amici/petab/parameter_mapping.py
+++ b/python/sdist/amici/petab/parameter_mapping.py
@@ -486,12 +486,11 @@ def create_parameter_mapping_for_condition(
                     condition_scale_map_preeq,
                     preeq_value,
                 )
-            else:
-                # need to set dummy value for preeq parameter anyways, as it
-                #  is expected below (set to 0, not nan, because will be
-                #  multiplied with indicator variable in initial assignment)
-                condition_map_sim[init_par_id] = 0.0
-                condition_scale_map_sim[init_par_id] = LIN
+            # need to set dummy value for preeq parameter anyways, as it
+            #  is expected below (set to 0, not nan, because will be
+            #  multiplied with indicator variable in initial assignment)
+            condition_map_sim[init_par_id] = 0.0
+            condition_scale_map_sim[init_par_id] = LIN
 
             # for simulation
             condition_id = condition[SIMULATION_CONDITION_ID]
@@ -505,6 +504,9 @@ def create_parameter_mapping_for_condition(
                 condition_scale_map_sim,
                 value,
             )
+            # set dummy value as above
+            condition_map_preeq[init_par_id] = 0.0
+            condition_scale_map_preeq[init_par_id] = LIN
 
     ##########################################################################
     # separate fixed and variable AMICI parameters, because we may have

--- a/python/sdist/amici/petab/parameter_mapping.py
+++ b/python/sdist/amici/petab/parameter_mapping.py
@@ -505,8 +505,9 @@ def create_parameter_mapping_for_condition(
                 value,
             )
             # set dummy value as above
-            condition_map_preeq[init_par_id] = 0.0
-            condition_scale_map_preeq[init_par_id] = LIN
+            if condition_map_preeq:
+                condition_map_preeq[init_par_id] = 0.0
+                condition_scale_map_preeq[init_par_id] = LIN
 
     ##########################################################################
     # separate fixed and variable AMICI parameters, because we may have

--- a/python/sdist/amici/petab/sbml_import.py
+++ b/python/sdist/amici/petab/sbml_import.py
@@ -300,6 +300,8 @@ def import_model_sbml(
             init_par = sbml_model.createParameter()
             init_par.setId(init_par_id)
             init_par.setName(init_par_id)
+            # must be a fixed parameter in any case to allow reinitialization
+            fixed_parameters.append(init_par_id)
         assignment = sbml_model.getInitialAssignment(assignee_id)
         if assignment is None:
             assignment = sbml_model.createInitialAssignment()
@@ -535,7 +537,7 @@ def _get_fixed_parameters_sbml(
                     ia.getMath(), parser_settings
                 )
             )
-            if not sym_math.is_Number:
+            if not sym_math.evalf().is_Number:
                 fixed_parameters.remove(fixed_parameter)
                 continue
 


### PR DESCRIPTION
* Ensure initial state parameters are always fixed parameters
* Ensure initial concentration for preequilibration and simulation are both set in both phases to avoid NaN issues
* Fix initialAssignment handling during PEtab import (missed in #2359)