### PR TITLE
Numpy 2.0 compatibility

### DIFF
--- a/python/sdist/pyproject.toml
+++ b/python/sdist/pyproject.toml
@@ -4,13 +4,7 @@
 requires = [
     "setuptools>=61",
     "wheel",
-    # oldest-supported-numpy helps us to pin numpy here to the lowest supported
-    # version to have ABI-compatibility with the numpy version in the runtime
-    # environment. The undesirable alternative would be pinning the setup.py
-    # numpy requirement to the same version as here, which we want to avoid.
-    # cf. discussion at https://github.com/numpy/numpy/issues/5888
-    # (https://github.com/scipy/oldest-supported-numpy/)
-    "oldest-supported-numpy",
+    "numpy>=2.0",
     "cmake-build-extension==0.6.0",
 ]
 build-backend = "setuptools.build_meta"

--- a/python/tests/test_preequilibration.py
+++ b/python/tests/test_preequilibration.py
@@ -32,7 +32,7 @@ def preeq_fixture(pysb_example_presimulation_module):
 
     edata_preeq = amici.ExpData(edata)
     edata_preeq.t_presim = 0
-    edata_preeq.setTimepoints([np.infty])
+    edata_preeq.setTimepoints([np.inf])
     edata_preeq.fixedParameters = edata.fixedParametersPreequilibration
     edata_preeq.fixedParametersPresimulation = ()
     edata_preeq.fixedParametersPreequilibration = ()


### PR DESCRIPTION
* Require numpy>=2.0 at *build* time (the run time requirement remains unaffected)
  `oldest-supported-numpy` is no longer necessary, see [numpy docs](https://numpy.org/devdocs/dev/depending_on_numpy.html#adding-a-dependency-on-numpy) for details
* Fix numpy2.0 np.infty -> np.inf 
  Fixes `AttributeError: `np.infty` was removed in the NumPy 2.0 release. Use `np.inf` instead.`
  Missed in #2422.

NOTE: There are some test failures (all of type `ValueError: could not convert string to float: 'np.float64(0.10132835605031565)'`) related to today's numpy 2.0 release which is incompatible with the current sympy 1.12. This will be fixed in sympy 1.13 for which there is already a release candidate and which I guess will be released shortly, so I would ignore those in amici for now.

Closes #2377 