### PR TITLE
Model::checkFinite: exclude timepoints

### DIFF
--- a/src/model.cpp
+++ b/src/model.cpp
@@ -1671,7 +1671,6 @@ int Model::checkFinite(
         && model_quantity != ModelQuantity::ts) {
         checkFinite(state_.fixedParameters, ModelQuantity::k, t);
         checkFinite(state_.unscaledParameters, ModelQuantity::p, t);
-        checkFinite(simulation_parameters_.ts_, ModelQuantity::ts, t);
         if (!always_check_finite_ && model_quantity != ModelQuantity::w) {
             // don't check twice if always_check_finite_ is true
             checkFinite(derived_state_.w_, ModelQuantity::w, t);
@@ -1789,7 +1788,6 @@ int Model::checkFinite(
     // check upstream
     checkFinite(state_.fixedParameters, ModelQuantity::k, t);
     checkFinite(state_.unscaledParameters, ModelQuantity::p, t);
-    checkFinite(simulation_parameters_.ts_, ModelQuantity::ts, t);
     checkFinite(derived_state_.w_, ModelQuantity::w, t);
 
     return AMICI_RECOVERABLE_ERROR;
@@ -1880,7 +1878,6 @@ int Model::checkFinite(SUNMatrix m, ModelQuantity model_quantity, realtype t)
     // check upstream
     checkFinite(state_.fixedParameters, ModelQuantity::k, t);
     checkFinite(state_.unscaledParameters, ModelQuantity::p, t);
-    checkFinite(simulation_parameters_.ts_, ModelQuantity::ts, t);
     checkFinite(derived_state_.w_, ModelQuantity::w, t);
 
     return AMICI_RECOVERABLE_ERROR;


### PR DESCRIPTION
Removes the check for non-finite timepoints. This rather confusing (#2370) than helpful. The current timepoint is already included in all other nan/inf messages, and the other timepoints don't matter in this context.

Closes #2370.