### PR TITLE
Get rid of amici.swig_wrappers.ExpData

### DIFF
--- a/documentation/conf.py
+++ b/documentation/conf.py
@@ -558,15 +558,15 @@ def fix_typehints(sig: str) -> str:
     sig = sig.replace("sunindextype", "int")
     sig = sig.replace("H5::H5File", "object")
 
-    # remove const
-    sig = sig.replace(" const ", r" ")
-    sig = re.sub(r" const$", r"", sig)
+    # remove const / const&
+    sig = sig.replace(" const&? ", r" ")
+    sig = re.sub(r" const&?$", r"", sig)
 
     # remove pass by reference
     sig = re.sub(r" &(,|\))", r"\1", sig)
     sig = re.sub(r" &$", r"", sig)
 
-    # turn gsl_spans and pointers int Iterables
+    # turn gsl_spans and pointers into Iterables
     sig = re.sub(r"([\w.]+) \*", r"Iterable[\1]", sig)
     sig = re.sub(r"gsl::span< ([\w.]+) >", r"Iterable[\1]", sig)
 

--- a/python/sdist/amici/__init__.py
+++ b/python/sdist/amici/__init__.py
@@ -134,8 +134,6 @@ if not _imported_from_setup():
             """Create a model instance."""
             ...
 
-    AmiciModel = Union[amici.Model, amici.ModelPtr]
-
 
 class add_path:
     """Context manager for temporarily changing PYTHONPATH"""

--- a/swig/amici.i
+++ b/swig/amici.i
@@ -341,6 +341,8 @@ def __repr__(self):
 
 // Handle AMICI_DLL_DIRS environment variable
 %pythonbegin %{
+from __future__ import annotations
+
 import sys
 import os
 
@@ -353,13 +355,45 @@ if sys.platform == 'win32' and (dll_dirs := os.environ.get('AMICI_DLL_DIRS')):
 // import additional types for typehints
 // also import np for use in __repr__ functions
 %pythonbegin %{
-from typing import TYPE_CHECKING, Iterable, Sequence
+from typing import TYPE_CHECKING, Iterable, Union
+from collections.abc import Sequence
 import numpy as np
 if TYPE_CHECKING:
     import numpy
 %}
 
 %pythoncode %{
+
+AmiciModel = Union[Model, ModelPtr]
+AmiciSolver = Union[Solver, SolverPtr]
+AmiciExpData = Union[ExpData, ExpDataPtr]
+AmiciReturnData = Union[ReturnData, ReturnDataPtr]
+AmiciExpDataVector = Union[ExpDataPtrVector, Sequence[AmiciExpData]]
+
+
+def _get_ptr(
+    obj: AmiciModel | AmiciExpData | AmiciSolver | AmiciReturnData,
+) -> Model | ExpData | Solver | ReturnData:
+    """
+    Convenience wrapper that returns the smart pointer pointee, if applicable
+
+    :param obj:
+        Potential smart pointer
+
+    :returns:
+        Non-smart pointer
+    """
+    if isinstance(
+        obj,
+        (
+            ModelPtr,
+            ExpDataPtr,
+            SolverPtr,
+            ReturnDataPtr,
+        ),
+    ):
+        return obj.get()
+    return obj
 
 
 __all__ = [
@@ -368,4 +402,5 @@ __all__ = [
     if not x.startswith('_')
     and x not in {"np", "sys", "os", "numpy", "IntEnum", "enum", "pi", "TYPE_CHECKING", "Iterable", "Sequence"}
 ]
+
 %}

--- a/swig/edata.i
+++ b/swig/edata.i
@@ -8,6 +8,24 @@ using namespace amici;
 
 %ignore ConditionContext;
 
+%feature("pythonprepend") amici::ExpData::ExpData %{
+    """
+    Convenience wrapper for :py:class:`amici.amici.ExpData` constructors
+
+    :param args: arguments
+
+    :returns: ExpData Instance
+    """
+    if args:
+        from amici.numpy import ReturnDataView
+
+        # Get the raw pointer if necessary
+        if isinstance(args[0], (ExpData, ExpDataPtr, Model, ModelPtr)):
+            args = (_get_ptr(args[0]), *args[1:])
+        elif isinstance(args[0], ReturnDataView):
+            args = (_get_ptr(args[0]["ptr"]), *args[1:])
+%}
+
 // ExpData.__repr__
 %pythoncode %{
 def _edata_repr(self: "ExpData"):


### PR DESCRIPTION
Move the `amici.swig_wrappers.ExpData` logic into the swig-generated `ExpData`.
This avoids shading the `ExpData` class by  `amici.swig_wrappers.ExpData`. 
The old implementation prevented using e.g. `isinstance(x, amici.ExpData)`.

This required also:
* Moving some annotation types and `_get_ptr` from `amici.swig_wrappers` to the swig-generated `amici.py` 
* Some smaller changes to allow for using `from __future__ import annotations` in `amici.py`

Closes #2380