### PR TITLE
Fix to conda installation.

### DIFF
--- a/python/sdist/setup.py
+++ b/python/sdist/setup.py
@@ -11,6 +11,7 @@ Non-python-package requirements:
 """
 import os
 import sys
+from shutil import which
 from pathlib import Path
 
 from cmake_build_extension import CMakeExtension
@@ -42,6 +43,7 @@ def get_extensions():
     global_cmake_configure_options = [
         "-DCMAKE_VERBOSE_MAKEFILE=ON",
         f"-DCMAKE_MODULE_PATH={prefix_path.as_posix()}",
+        f"-DCMAKE_AR={which('ar')}",
     ]
 
     # SuiteSparse Config


### PR DESCRIPTION
Adding cmake flag to specify path to ar executable fixed errors in installation in a conda env.

Specifically in a conda env made with:
```
conda create -c conda-forge -n amici blas cmake gcc make pip python==3.11 swig suitesparse binutils gxx hdf5
conda activate amici
export BLAS_LIBS=-lopenblas
pip install amici
```