### PR TITLE
CMake: Fix MKL detection when not using environment modules

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -135,7 +135,7 @@ endif()
 set(VENDORED_SUNDIALS_DIR ${CMAKE_CURRENT_SOURCE_DIR}/ThirdParty/sundials)
 set(SUNDIALS_PRIVATE_INCLUDE_DIRS "${VENDORED_SUNDIALS_DIR}/src")
 # Handle different sundials build/install dirs, depending on whether we are
-#  building the Python extension only or the full C++ interface
+# building the Python extension only or the full C++ interface
 if(AMICI_PYTHON_BUILD_EXT_ONLY)
   set(VENDORED_SUNDIALS_BUILD_DIR ${CMAKE_CURRENT_SOURCE_DIR})
   set(VENDORED_SUNDIALS_INSTALL_DIR ${VENDORED_SUNDIALS_BUILD_DIR})

--- a/cmake/AmiciFindBLAS.cmake
+++ b/cmake/AmiciFindBLAS.cmake
@@ -22,6 +22,7 @@ if(${BLAS} STREQUAL "MKL" OR DEFINED ENV{MKLROOT})
     if(NOT DEFINED BLA_VENDOR)
       set(BLA_VENDOR Intel10_64lp)
     endif()
+    message(STATUS "Trying FindBLAS with BLA_VENDOR=${BLA_VENDOR}")
     find_package(BLAS)
     if(BLAS_FOUND)
       message(STATUS "Found BLAS via FindBLAS and MKLROOT")
@@ -56,6 +57,7 @@ elseif(
 
   if(APPLE AND (NOT DEFINED BLA_VENDOR OR BLA_VENDOR STREQUAL "All"))
     set(BLA_VENDOR Apple)
+    message(STATUS "Trying FindBLAS with BLA_VENDOR=${BLA_VENDOR}")
     find_package(BLAS)
     if(BLAS_FOUND)
       message(STATUS "Found Apple Accelerate BLAS")
@@ -73,6 +75,7 @@ elseif(
 
   endif()
   if(NOT BLAS_FOUND)
+    message(STATUS "Trying FindBLAS with BLA_VENDOR=${BLA_VENDOR}")
     find_package(BLAS)
     if(BLAS_FOUND)
       message(STATUS "Found BLAS via FindBLAS")

--- a/cmake/cmakelang-tools.cmake
+++ b/cmake/cmakelang-tools.cmake
@@ -9,7 +9,9 @@ set(ALL_CMAKE_FILES
     tests/cpp/unittests/CMakeLists.txt
     ${CMAKE_MODULE_PATH}/cmakelang-tools.cmake
     ${CMAKE_MODULE_PATH}/clang-tools.cmake
+    ${CMAKE_MODULE_PATH}/AmiciFindBLAS.cmake
     ${CMAKE_MODULE_PATH}/version.cmake)
+
 list(JOIN ALL_CMAKE_FILES " " ALL_CMAKE_FILES)
 
 # --- cmake-format ---

--- a/swig/CMakeLists.txt
+++ b/swig/CMakeLists.txt
@@ -20,7 +20,10 @@ find_package(
   Python3
   COMPONENTS Interpreter Development NumPy
   REQUIRED)
-message(STATUS "Found numpy ${Python3_NumPy_VERSION} include dir ${Python3_NumPy_INCLUDE_DIRS}")
+message(
+  STATUS
+    "Found numpy ${Python3_NumPy_VERSION} include dir ${Python3_NumPy_INCLUDE_DIRS}"
+)
 set(AMICI_INTERFACE_LIST
     ${CMAKE_CURRENT_SOURCE_DIR}/amici.i
     ${CMAKE_CURRENT_SOURCE_DIR}/edata.i


### PR DESCRIPTION
If MKLROOT is set (e.g., `source /opt/intel/oneapi/setvars.sh` will do that), first try FindBLAS instead of just relying on MKL_INCDIR and MKL_LIB.

Fixes #2441.