### PR TITLE
Specify cmake build types and require cmake-build-extension==0.6.0

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -134,7 +134,7 @@ endif()
 set(VENDORED_SUNDIALS_DIR ${CMAKE_CURRENT_SOURCE_DIR}/ThirdParty/sundials)
 set(SUNDIALS_PRIVATE_INCLUDE_DIRS "${VENDORED_SUNDIALS_DIR}/src")
 # Handle different sundials build/install dirs, depending on whether we are
-#  building the Python extension only or the full C++ interface
+# building the Python extension only or the full C++ interface
 if(AMICI_PYTHON_BUILD_EXT_ONLY)
   set(VENDORED_SUNDIALS_BUILD_DIR ${CMAKE_CURRENT_SOURCE_DIR})
   set(VENDORED_SUNDIALS_INSTALL_DIR ${VENDORED_SUNDIALS_BUILD_DIR})

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -90,7 +90,6 @@ if("$ENV{ENABLE_AMICI_DEBUGGING}" OR "$ENV{ENABLE_GCOV_COVERAGE}")
   else()
     add_compile_options(-O0 -g)
   endif()
-  set(CMAKE_BUILD_TYPE "Debug")
 endif()
 
 # coverage options

--- a/python/sdist/amici/setup.template.py
+++ b/python/sdist/amici/setup.template.py
@@ -24,6 +24,8 @@ def get_extension() -> CMakeExtension:
     else:
         os.environ["CMAKE_BUILD_PARALLEL_LEVEL"] = "1"
 
+    debug_build = os.getenv("AMICI_DEBUG", "").lower() in ["1", "true"]
+
     return CMakeExtension(
         name="model_ext",
         source_dir=os.getcwd(),
@@ -37,6 +39,7 @@ def get_extension() -> CMakeExtension:
             "-DAMICI_PYTHON_BUILD_EXT_ONLY=ON",
             f"-DPython3_EXECUTABLE={Path(sys.executable).as_posix()}",
         ],
+        cmake_build_type="Debug" if debug_build else "Release",
     )
 
 

--- a/python/sdist/amici/setup.template.py
+++ b/python/sdist/amici/setup.template.py
@@ -24,7 +24,10 @@ def get_extension() -> CMakeExtension:
     else:
         os.environ["CMAKE_BUILD_PARALLEL_LEVEL"] = "1"
 
-    debug_build = os.getenv("AMICI_DEBUG", "").lower() in ["1", "true"]
+    debug_build = os.getenv("ENABLE_AMICI_DEBUGGING", "").lower() in [
+        "1",
+        "true",
+    ]
 
     return CMakeExtension(
         name="model_ext",

--- a/python/sdist/amici/setup.template.py
+++ b/python/sdist/amici/setup.template.py
@@ -27,7 +27,7 @@ def get_extension() -> CMakeExtension:
     debug_build = os.getenv("ENABLE_AMICI_DEBUGGING", "").lower() in [
         "1",
         "true",
-    ]
+    ] or os.getenv("ENABLE_GCOV_COVERAGE", "").lower() in ["1", "true"]
 
     return CMakeExtension(
         name="model_ext",

--- a/python/sdist/pyproject.toml
+++ b/python/sdist/pyproject.toml
@@ -11,7 +11,7 @@ requires = [
     # cf. discussion at https://github.com/numpy/numpy/issues/5888
     # (https://github.com/scipy/oldest-supported-numpy/)
     "oldest-supported-numpy",
-    "cmake-build-extension==0.5.1",
+    "cmake-build-extension==0.6.0",
 ]
 build-backend = "setuptools.build_meta"
 
@@ -21,7 +21,7 @@ dynamic = ["version"]
 description = "Advanced multi-language Interface to CVODES and IDAS"
 requires-python = ">=3.10"
 dependencies = [
-    "cmake-build-extension==0.5.1",
+    "cmake-build-extension==0.6.0",
     "sympy>=1.9",
     "numpy>=1.19.3; python_version=='3.9'",
     "numpy>=1.21.4; python_version>='3.10'",

--- a/python/sdist/setup.py
+++ b/python/sdist/setup.py
@@ -141,7 +141,10 @@ def get_extensions():
         ],
     )
     # AMICI
-    debug_build = os.getenv("AMICI_DEBUG", "").lower() in ["1", "true"]
+    debug_build = os.getenv("ENABLE_AMICI_DEBUGGING", "").lower() in [
+        "1",
+        "true",
+    ]
     amici_ext = CMakeExtension(
         name="amici",
         install_prefix="amici",

--- a/python/sdist/setup.py
+++ b/python/sdist/setup.py
@@ -141,6 +141,7 @@ def get_extensions():
         ],
     )
     # AMICI
+    debug_build = os.getenv("AMICI_DEBUG", "").lower() in ["1", "true"]
     amici_ext = CMakeExtension(
         name="amici",
         install_prefix="amici",
@@ -153,6 +154,7 @@ def get_extensions():
             "-DAMICI_PYTHON_BUILD_EXT_ONLY=ON",
             f"-DPython3_EXECUTABLE={Path(sys.executable).as_posix()}",
         ],
+        cmake_build_type="Debug" if debug_build else "Release",
     )
     # Order matters!
     return [suitesparse_config, amd, btf, colamd, klu, sundials, amici_ext]

--- a/python/sdist/setup.py
+++ b/python/sdist/setup.py
@@ -144,7 +144,7 @@ def get_extensions():
     debug_build = os.getenv("ENABLE_AMICI_DEBUGGING", "").lower() in [
         "1",
         "true",
-    ]
+    ] or os.getenv("ENABLE_GCOV_COVERAGE", "").lower() in ["1", "true"]
     amici_ext = CMakeExtension(
         name="amici",
         install_prefix="amici",

--- a/python/tests/test_misc.py
+++ b/python/tests/test_misc.py
@@ -65,8 +65,9 @@ def test_cmake_compilation(sbml_example_presimulation_module):
     amici_dir = (Path(__file__).parents[2] / "build").absolute()
     cmd = (
         f"set -e; "
-        f"cmake -S {source_dir} -B '{build_dir}' -DAmici_DIR={amici_dir}; "
-        f"cmake --build '{build_dir}'"
+        f"cmake -S {source_dir} -B '{build_dir}' "
+        f"-DCMAKE_BUILD_TYPE=Debug -DAmici_DIR={amici_dir}; "
+        f"cmake --build '{build_dir}' --config Debug"
     )
 
     try:

--- a/scripts/buildAmici.sh
+++ b/scripts/buildAmici.sh
@@ -14,7 +14,8 @@ mkdir -p "${amici_build_dir}"
 cd "${amici_build_dir}"
 
 if [ "${GITHUB_ACTIONS:-}" = true ] ||
-  [ "${ENABLE_AMICI_DEBUGGING:-}" = TRUE ]; then
+  [ "${ENABLE_AMICI_DEBUGGING:-}" = TRUE ] ||
+  [ "${ENABLE_GCOV_COVERAGE:-}" = TRUE ]; then
   # Running on CI server
   build_type="Debug"
   # exceptions instead of terminate()

--- a/scripts/installAmiciSource.sh
+++ b/scripts/installAmiciSource.sh
@@ -33,7 +33,7 @@ fi
 export PYTHON_EXECUTABLE="${AMICI_PATH}/venv/bin/python"
 
 python -m pip install --upgrade pip wheel
-python -m pip install --upgrade pip setuptools cmake_build_extension numpy
+python -m pip install --upgrade pip setuptools cmake_build_extension==0.6.0 numpy
 python -m pip install git+https://github.com/FFroehlich/pysb@fix_pattern_matching # pin to PR for SPM with compartments
 AMICI_BUILD_TEMP="${AMICI_PATH}/python/sdist/build/temp" \
   python -m pip install --verbose -e "${AMICI_PATH}/python/sdist[petab,test,vis]" --no-build-isolation

--- a/src/CMakeLists.template.cmake
+++ b/src/CMakeLists.template.cmake
@@ -38,6 +38,10 @@ endif()
 find_package(Amici TPL_AMICI_VERSION REQUIRED HINTS
              ${CMAKE_CURRENT_LIST_DIR}/../../build)
 message(STATUS "Found AMICI ${Amici_DIR}")
+set_target_properties(Upstream::amici PROPERTIES
+    MAP_IMPORTED_CONFIG_RELWITHDEBINFO RelWithDebInfo;Release;
+    MAP_IMPORTED_CONFIG_RELEASE Release
+    MAP_IMPORTED_CONFIG_DEBUG Debug;RelWithDebInfo;)
 
 # Debug build?
 if("$ENV{ENABLE_AMICI_DEBUGGING}" OR "$ENV{ENABLE_GCOV_COVERAGE}")

--- a/src/CMakeLists.template.cmake
+++ b/src/CMakeLists.template.cmake
@@ -47,7 +47,6 @@ if("$ENV{ENABLE_AMICI_DEBUGGING}" OR "$ENV{ENABLE_GCOV_COVERAGE}")
   else()
     add_compile_options(-O0 -g)
   endif()
-  set(CMAKE_BUILD_TYPE "Debug")
 endif()
 
 # coverage options

--- a/swig/CMakeLists.txt
+++ b/swig/CMakeLists.txt
@@ -20,7 +20,10 @@ find_package(
   Python3
   COMPONENTS Interpreter Development NumPy
   REQUIRED)
-message(STATUS "Found numpy ${Python3_NumPy_VERSION} include dir ${Python3_NumPy_INCLUDE_DIRS}")
+message(
+  STATUS
+    "Found numpy ${Python3_NumPy_VERSION} include dir ${Python3_NumPy_INCLUDE_DIRS}"
+)
 set(AMICI_INTERFACE_LIST
     ${CMAKE_CURRENT_SOURCE_DIR}/amici.i
     ${CMAKE_CURRENT_SOURCE_DIR}/edata.i


### PR DESCRIPTION
* Require https://github.com/diegoferigo/cmake-build-extension/releases/tag/v0.6.0
* Specify cmake build types properly 
  Closes #2447 
  Closes #2442