### PR TITLE
pytest: ignore log(0) warnings

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -19,5 +19,7 @@ filterwarnings =
     ignore:The --rsyncdir command line argument and rsyncdirs config variable are deprecated.:DeprecationWarning
     ignore:.*:ImportWarning:tellurium
     ignore:.*PyDevIPCompleter6.*:DeprecationWarning
+    # ignore numpy log(0) warnings (np.log(0) = -inf)
+    ignore:divide by zero encountered in log:RuntimeWarning
 
 norecursedirs = .git amici_models build doc documentation matlab models ThirdParty amici sdist examples


### PR DESCRIPTION
The warning/error in #2444 is caused by `petab.parameters.scale()`. Whether this warning should be suppressed there or not is to discussed in the PEtab context. For amici, I'd say we're fine with just accepting `np.log(0) == -inf` without a warnings.

Closes #2444.