### PR TITLE
PEtab: fix missing parameters in fill_in_parameters

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -19,5 +19,7 @@ filterwarnings =
     ignore:The --rsyncdir command line argument and rsyncdirs config variable are deprecated.:DeprecationWarning
     ignore:.*:ImportWarning:tellurium
     ignore:.*PyDevIPCompleter6.*:DeprecationWarning
+    # ignore numpy log(0) warnings (np.log(0) = -inf)
+    ignore:divide by zero encountered in log:RuntimeWarning
 
 norecursedirs = .git amici_models build doc documentation matlab models ThirdParty amici sdist examples

--- a/python/sdist/amici/petab/simulations.py
+++ b/python/sdist/amici/petab/simulations.py
@@ -166,30 +166,33 @@ def simulate_petab(
             amici_model=amici_model,
         )
 
-    if problem_parameters is None:
-        # scaled PEtab nominal values
-        problem_parameters = dict(
-            zip(
-                petab_problem.x_ids,
-                petab_problem.x_nominal_scaled,
-                strict=True,
-            )
-        )
-        # depending on `fill_fixed_parameters` for parameter mapping, the
-        #  parameter mapping may contain values instead of symbols for fixed
-        #  parameters. In this case, we need to filter them here to avoid
-        #  warnings in `fill_in_parameters`.
-        free_parameters = parameter_mapping.free_symbols
-        problem_parameters = {
-            par_id: par_value
-            for par_id, par_value in problem_parameters.items()
-            if par_id in free_parameters
-        }
-
-    elif not scaled_parameters:
+    if problem_parameters is not None and not scaled_parameters:
         problem_parameters = petab_problem.scale_parameters(problem_parameters)
-
     scaled_parameters = True
+
+    if problem_parameters is None:
+        problem_parameters = {}
+
+    # scaled PEtab nominal values
+    default_problem_parameters = dict(
+        zip(
+            petab_problem.x_ids,
+            petab_problem.get_x_nominal(scaled=scaled_parameters),
+            strict=True,
+        )
+    )
+    # depending on `fill_fixed_parameters` for parameter mapping, the
+    #  parameter mapping may contain values instead of symbols for fixed
+    #  parameters. In this case, we need to filter them here to avoid
+    #  warnings in `fill_in_parameters`.
+    free_parameters = parameter_mapping.free_symbols
+    default_problem_parameters = {
+        par_id: par_value
+        for par_id, par_value in default_problem_parameters.items()
+        if par_id in free_parameters
+    }
+
+    problem_parameters = default_problem_parameters | problem_parameters
 
     # Get edatas
     if edatas is None:

--- a/tests/benchmark-models/test_petab_benchmark.py
+++ b/tests/benchmark-models/test_petab_benchmark.py
@@ -36,6 +36,7 @@ models = [
         "Isensee_JCB2018",
         "Beer_MolBioSystems2014",
         "Alkan_SciSignal2018",
+        "Lang_PLOSComputBiol2024",
         # excluded due to excessive numerical failures
         "Crauste_CellSystems2017",
         "Fujita_SciSignal2010",


### PR DESCRIPTION
Allows providing only a subset of parameter to simulate_petab. The missing parameters are taken from nominalValues in the parameter table.

Fixes https://github.com/AMICI-dev/AMICI/issues/2444. Nevertheless, exclude `Lang_PLOSComputBiol2024` to save time.