### PR TITLE
PEtab: Fix estimated initial conditions specified via the conditions table

### DIFF
--- a/.github/workflows/test_petab_test_suite.yml
+++ b/.github/workflows/test_petab_test_suite.yml
@@ -63,7 +63,7 @@ jobs:
       # retrieve test models
       - name: Download and install PEtab test suite
         run: |
-          git clone --depth 1 --branch main \
+          git clone --depth 1 --branch add_test_ic_est \
             https://github.com/PEtab-dev/petab_test_suite \
             && source ./venv/bin/activate \
             && cd petab_test_suite && pip3 install -e .

--- a/python/sdist/amici/petab/cli/import_petab.py
+++ b/python/sdist/amici/petab/cli/import_petab.py
@@ -145,10 +145,7 @@ def _main():
 
     import_model_sbml(
         model_name=args.model_name,
-        sbml_model=pp.sbml_model,
-        condition_table=pp.condition_df,
-        observable_table=pp.observable_df,
-        measurement_table=pp.measurement_df,
+        petab_problem=pp,
         model_output_dir=args.model_output_dir,
         compile=args.compile,
         generate_sensitivity_code=args.generate_sensitivity_code,

--- a/python/sdist/amici/petab/import_helpers.py
+++ b/python/sdist/amici/petab/import_helpers.py
@@ -229,9 +229,10 @@ def get_fixed_parameters(
         # check global parameters
         if not petab_problem.model.has_entity_with_id(fixed_parameter):
             # TODO: could still exist as an output parameter?
+            # TODO: or in the parameters table
             logger.warning(
                 f"Column '{fixed_parameter}' used in condition "
-                "table but not entity with the corresponding ID "
+                "table but no entity with the corresponding ID "
                 "exists. Ignoring."
             )
             fixed_parameters.remove(fixed_parameter)

--- a/python/sdist/amici/petab/sbml_import.py
+++ b/python/sdist/amici/petab/sbml_import.py
@@ -266,7 +266,8 @@ def import_model_sbml(
 
     initial_states = get_states_in_condition_table(petab_problem)
     requires_preequilibration = (
-        petab.PREEQUILIBRATION_CONDITION_ID in petab_problem.measurement_df
+        petab_problem.measurement_df is not None
+        and petab.PREEQUILIBRATION_CONDITION_ID in petab_problem.measurement_df
         and petab_problem.measurement_df[petab.PREEQUILIBRATION_CONDITION_ID]
         .notnull()
         .any()
@@ -313,7 +314,9 @@ def import_model_sbml(
             "Adding preequilibration indicator "
             f"constant {PREEQ_INDICATOR_ID}"
         )
-    logger.debug(f"Adding initial assignments for {initial_states.keys()}")
+    logger.debug(
+        f"Adding initial assignments for {list(initial_states.keys())}"
+    )
     for assignee_id in initial_states:
         init_par_id_preeq = f"initial_{assignee_id}_preeq"
         init_par_id_sim = f"initial_{assignee_id}_sim"

--- a/python/sdist/amici/petab/sbml_import.py
+++ b/python/sdist/amici/petab/sbml_import.py
@@ -135,6 +135,7 @@ def import_model_sbml(
             else SbmlModel.from_file(sbml_model),
             condition_df=petab.get_condition_df(condition_table),
             observable_df=petab.get_observable_df(observable_table),
+            measurement_df=petab.get_measurement_df(measurement_table),
         )
 
     if petab_problem.observable_df is None:

--- a/tests/petab_test_suite/test_petab_suite.py
+++ b/tests/petab_test_suite/test_petab_suite.py
@@ -178,8 +178,9 @@ def check_derivatives(
         problem_parameters=problem_parameters,
     ):
         # check_derivatives does currently not support parameters in ExpData
-        model.setParameters(edata.parameters)
+        # set parameter scales before setting parameter values!
         model.setParameterScale(edata.pscale)
+        model.setParameters(edata.parameters)
         edata.parameters = []
         edata.pscale = amici.parameterScalingFromIntVector([])
         amici_check_derivatives(model, solver, edata)


### PR DESCRIPTION
* For reinitialization of state variables after preequilibration, we need to add *fixed* parameters for initial conditions (otherwise parameter values can't be different for pre-equilibration and the following period). This case was handled fine.
* If we want to estimate initial conditions and want to compute sensitivities w.r.t. those, we need *non-fixed* parameters for the initial conditions. This was not handled correctly, those were added as *fixed* parameters.
* As a consequence, we *can't* handle reinitialization *and* estimation of initial values for the same state variable.

Closes #2455.