### PR TITLE
Require sympy>=1.12.1 for numpy>=2.0 compatibility

### DIFF
--- a/python/sdist/pyproject.toml
+++ b/python/sdist/pyproject.toml
@@ -16,7 +16,7 @@ description = "Advanced multi-language Interface to CVODES and IDAS"
 requires-python = ">=3.10"
 dependencies = [
     "cmake-build-extension==0.6.0",
-    "sympy>=1.9",
+    "sympy>=1.12.1",
     "numpy>=1.19.3; python_version=='3.9'",
     "numpy>=1.21.4; python_version>='3.10'",
     "numpy>=1.23.2; python_version=='3.11'",


### PR DESCRIPTION
So far, sympy was restricted to <=1.11 via pysb, but sympy 1.11 is incompatible with numpy>=2.0