### PR TITLE
GHA: -Werror only for amici repo

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -8,6 +8,10 @@ cmake_policy(VERSION 3.15...3.27)
 if(POLICY CMP0144)
   cmake_policy(SET CMP0144 NEW)
 endif(POLICY CMP0144)
+# cmake >= 3.30
+if(POLICY CMP0167)
+  cmake_policy(SET CMP0167 NEW)
+endif(POLICY CMP0167)
 
 project(amici)
 

--- a/python/sdist/setup.py
+++ b/python/sdist/setup.py
@@ -152,7 +152,9 @@ def get_extensions():
         cmake_configure_options=[
             *global_cmake_configure_options,
             "-Werror=dev"
-            if "GITHUB_ACTIONS" in os.environ
+            # Turn warnings in to errors on GitHub Actions,
+            #  match original repo and forks with default name
+            if os.environ.get("GITHUB_REPOSITORY", "").endswith("/AMICI")
             else "-Wno-error=dev",
             "-DAMICI_PYTHON_BUILD_EXT_ONLY=ON",
             f"-DPython3_EXECUTABLE={Path(sys.executable).as_posix()}",

--- a/scripts/buildAmici.sh
+++ b/scripts/buildAmici.sh
@@ -13,7 +13,7 @@ amici_build_dir="${amici_path}/build"
 mkdir -p "${amici_build_dir}"
 cd "${amici_build_dir}"
 
-if [ "${GITHUB_ACTIONS:-}" = true ] ||
+if [[ "${GITHUB_REPOSITORY:-}" = *"/AMICI" ]] ||
   [ "${ENABLE_AMICI_DEBUGGING:-}" = TRUE ] ||
   [ "${ENABLE_GCOV_COVERAGE:-}" = TRUE ]; then
   # Running on CI server

--- a/swig/CMakeLists_model.cmake
+++ b/swig/CMakeLists_model.cmake
@@ -1,4 +1,15 @@
 cmake_minimum_required(VERSION 3.15)
+cmake_policy(VERSION 3.15...3.27)
+
+# cmake >=3.27
+if(POLICY CMP0144)
+  cmake_policy(SET CMP0144 NEW)
+endif(POLICY CMP0144)
+# cmake >= 3.30
+if(POLICY CMP0167)
+  cmake_policy(SET CMP0167 NEW)
+endif(POLICY CMP0167)
+
 
 if(DEFINED ENV{SWIG})
   set(SWIG_EXECUTABLE $ENV{SWIG})


### PR DESCRIPTION
We have a couple of -Werror options enabled when running on GHA. However, we should also check for the repo name.
If amici is used in tests of any downstream projects, we don't want errors.

Also use CMake's `-Wno-dev` for non-amici-ci installations.

Fixes #2477 