### PR TITLE
Tests: Fix petab benchmark models paths

### DIFF
--- a/.github/workflows/test_benchmark_collection_models.yml
+++ b/.github/workflows/test_benchmark_collection_models.yml
@@ -61,6 +61,7 @@ jobs:
       run: |
         git clone --depth 1 https://github.com/benchmarking-initiative/Benchmark-Models-PEtab.git \
           && export BENCHMARK_COLLECTION="$(pwd)/Benchmark-Models-PEtab/Benchmark-Models/" \
+          && pip3 install -e $BENCHMARK_COLLECTION/../src/python \
           && AMICI_PARALLEL_COMPILE="" tests/benchmark-models/test_benchmark_collection.sh
 
     # run gradient checks

--- a/tests/benchmark-models/test_benchmark_collection.sh
+++ b/tests/benchmark-models/test_benchmark_collection.sh
@@ -87,6 +87,12 @@ script_path=$(cd "$script_path" && pwd)
 
 for model in $models; do
   yaml="${model_dir}"/"${model}"/"${model}".yaml
+
+  # different naming scheme
+  if [[ "$model" == "Bertozzi_PNAS2020" ]]; then
+    yaml="${model_dir}"/"${model}"/problem.yaml
+  fi
+
   amici_model_dir=test_bmc/"${model}"
   mkdir -p "$amici_model_dir"
   cmd_import="amici_import_petab ${yaml} -o ${amici_model_dir} -n ${model} --flatten"


### PR DESCRIPTION
Naming scheme changed. Use provided library to constructs paths.