### PR TITLE
GHA: cache remote test files

### DIFF
--- a/.github/actions/setup-sonar-tools/action.yml
+++ b/.github/actions/setup-sonar-tools/action.yml
@@ -3,7 +3,7 @@ description: Download and install sonar-scanner and build-wrapper
 runs:
   using: "composite"
   steps:
-    - run: echo "SONAR_SCANNER_VERSION=5.0.1.3006" >> $GITHUB_ENV
+    - run: echo "SONAR_SCANNER_VERSION=6.1.0.4477" >> $GITHUB_ENV
       shell: bash
     - run: echo "SONAR_SCANNER_HOME=${HOME}/.sonar/sonar-scanner-$SONAR_SCANNER_VERSION-linux" >> $GITHUB_ENV
       shell: bash

--- a/.github/actions/setup-sonar-tools/action.yml
+++ b/.github/actions/setup-sonar-tools/action.yml
@@ -3,7 +3,7 @@ description: Download and install sonar-scanner and build-wrapper
 runs:
   using: "composite"
   steps:
-    - run: echo "SONAR_SCANNER_VERSION=6.1.0.4477" >> $GITHUB_ENV
+    - run: echo "SONAR_SCANNER_VERSION=5.0.1.3006" >> $GITHUB_ENV
       shell: bash
     - run: echo "SONAR_SCANNER_HOME=${HOME}/.sonar/sonar-scanner-$SONAR_SCANNER_VERSION-linux" >> $GITHUB_ENV
       shell: bash

--- a/.github/workflows/test_python_cplusplus.yml
+++ b/.github/workflows/test_python_cplusplus.yml
@@ -125,6 +125,13 @@ jobs:
       with:
         python-version: ${{ matrix.python-version }}
 
+    - name: Cache
+      uses: actions/cache@v4
+      with:
+        path: |
+          ~/.cache/pooch
+        key: ${{ runner.os }}-py${{ matrix.python-version }}-${{ github.job }}
+
     - uses: actions/checkout@v4
     - run: git fetch --prune --unshallow
 
@@ -201,6 +208,13 @@ jobs:
       with:
         python-version: ${{ matrix.python-version }}
 
+    - name: Cache
+      uses: actions/cache@v4
+      with:
+        path: |
+          ~/.cache/pooch
+        key: ${{ runner.os }}-py${{ matrix.python-version }}-${{ github.job }}
+
     - uses: actions/checkout@v4
     - run: git fetch --prune --unshallow
 
@@ -259,6 +273,17 @@ jobs:
     - name: C++ tests
       run: scripts/run-cpp-tests.sh
 
+    - name: Get Pooch Cache Directory
+      id: get-pooch-cache
+      run: |
+        echo "pooch-cache=$(source venv/bin/activate && python -c 'import pooch; print(pooch.os_cache("pooch"))')" >> $GITHUB_ENV
+
+    - name: Cache Pooch Directory
+      uses: actions/cache@v4
+      with:
+        path: ${{ env.pooch-cache }}
+        key: ${{ runner.os }}-py${{ matrix.python-version }}-${{ github.job }}
+
     - name: Python tests
       run: |
         scripts/run-python-tests.sh \
@@ -300,6 +325,18 @@ jobs:
 
     - name: Get BioNetGen
       run: scripts/buildBNGL.sh
+
+
+    - name: Get Pooch Cache Directory
+      id: get-pooch-cache
+      run: |
+        echo "pooch-cache=$(source venv/bin/activate && python -c 'import pooch; print(pooch.os_cache("pooch"))')" >> $GITHUB_ENV
+
+    - name: Cache Pooch Directory
+      uses: actions/cache@v4
+      with:
+        path: ${{ env.pooch-cache }}
+        key: ${{ runner.os }}-py${{ matrix.python-version }}-${{ github.job }}
 
     - name: Python tests
       run: |

--- a/.github/workflows/test_python_ver_matrix.yml
+++ b/.github/workflows/test_python_ver_matrix.yml
@@ -60,6 +60,17 @@ jobs:
     - run: source venv/bin/activate && pip3 install "sympy>=1.12.1"
       if: matrix.python-version != '3.12'
 
+    - name: Get Pooch Cache Directory
+      id: get-pooch-cache
+      run: |
+        echo "pooch-cache=$(source venv/bin/activate && python -c 'import pooch; print(pooch.os_cache("pooch"))')" >> $GITHUB_ENV
+
+    - name: Cache Pooch Directory
+      uses: actions/cache@v4
+      with:
+        path: ${{ env.pooch-cache }}
+        key: ${{ runner.os }}-py${{ matrix.python-version }}-${{ github.job }}
+
     - name: Python tests
       run: |
         source venv/bin/activate \

--- a/.github/workflows/test_windows.yml
+++ b/.github/workflows/test_windows.yml
@@ -81,6 +81,7 @@ jobs:
       id: get-pooch-cache
       run: |
         echo "pooch-cache=$(python -c 'import pooch; print(pooch.os_cache("pooch"))')" >> $GITHUB_ENV
+      shell: bash
 
     - name: Cache Pooch Directory
       uses: actions/cache@v4

--- a/.github/workflows/test_windows.yml
+++ b/.github/workflows/test_windows.yml
@@ -77,6 +77,17 @@ jobs:
 
     - run: python -m amici
 
+    - name: Get Pooch Cache Directory
+      id: get-pooch-cache
+      run: |
+        echo "pooch-cache=$(python -c 'import pooch; print(pooch.os_cache("pooch"))')" >> $GITHUB_ENV
+
+    - name: Cache Pooch Directory
+      uses: actions/cache@v4
+      with:
+        path: ${{ env.pooch-cache }}
+        key: ${{ runner.os }}-py${{ matrix.python-version }}-${{ github.job }}
+
     - name: Run Python tests
       shell: bash
       run: |


### PR DESCRIPTION
There are again many test failures due to timeouts when accessing remote test files. Cache those.

Closes #2378