### PR TITLE
Fix sympy float comparison issue in spline code

### DIFF
--- a/python/sdist/amici/splines.py
+++ b/python/sdist/amici/splines.py
@@ -31,7 +31,7 @@ import xml.etree.ElementTree as ET
 from abc import ABC, abstractmethod
 from itertools import count
 from numbers import Integral
-
+from numbers import Real
 import libsbml
 import numpy as np
 import sympy as sp
@@ -902,7 +902,11 @@ class AbstractSpline(ABC):
 
     def integrate(self, x0: Real | sp.Basic, x1: Real | sp.Basic) -> sp.Basic:
         """Integrate the spline between the points `x0` and `x1`."""
-        x = sp.Dummy("x")
+        # Use integer values to prevent sympy-comparison issues down the line
+        if isinstance(x0, Real) and x0 % 1 == 0:
+            x0 = int(x0)
+        if isinstance(x1, Real) and x1 % 1 == 0:
+            x1 = int(x1)
         x0, x1 = sp.sympify((x0, x1))
 
         if x0 > x1:
@@ -910,6 +914,8 @@ class AbstractSpline(ABC):
 
         if x0 == x1:
             return sp.sympify(0)
+
+        x = sp.Dummy("x")
 
         if self.extrapolate != ("periodic", "periodic"):
             return self._formula(x=x, cache=False).integrate((x, x0, x1))

--- a/python/tests/test_splines.py
+++ b/python/tests/test_splines.py
@@ -103,6 +103,7 @@ def test_multiple_splines(**kwargs):
         os.path.dirname(os.path.abspath(__file__)),
         "test_splines_precomputed.npz",
     )
-    kwargs["groundtruth"] = dict(np.load(precomputed_path))
+    with np.load(precomputed_path) as data:
+        kwargs["groundtruth"] = dict(data)
 
     return check_splines_full(splines, params, tols, **kwargs)


### PR DESCRIPTION
Fixes #2498

Fixes an assertion that broke due to sympy's recent change that made float and int compare unequal.

Also ensure an opened test file is closed properly and prevent ResourceWarnings.