### PR TITLE
Refactor Model::steadystate_mask_

### DIFF
--- a/include/amici/model.h
+++ b/include/amici/model.h
@@ -1489,17 +1489,7 @@ class Model : public AbstractModel, public ModelDimensions {
      *
      * @return Steady-state mask
      */
-    std::vector<double> get_steadystate_mask() const {
-        return steadystate_mask_.getVector();
-    };
-
-    /**
-     * @brief Get steady-state mask as AmiVector.
-     *
-     * See `set_steadystate_mask` for details.
-     * @return Steady-state mask
-     */
-    AmiVector const& get_steadystate_mask_av() const {
+    std::vector<realtype> get_steadystate_mask() const {
         return steadystate_mask_;
     };
 
@@ -1514,7 +1504,7 @@ class Model : public AbstractModel, public ModelDimensions {
      *
      * @param mask Mask of length `nx_solver`.
      */
-    void set_steadystate_mask(std::vector<double> const& mask);
+    void set_steadystate_mask(std::vector<realtype> const& mask);
 
     /**
      * Flag indicating whether for
@@ -2130,7 +2120,7 @@ class Model : public AbstractModel, public ModelDimensions {
      * Negative values indicate that the corresponding state variable should
      * be ignored.
      */
-    AmiVector steadystate_mask_;
+    std::vector<realtype> steadystate_mask_;
 };
 
 bool operator==(Model const& a, Model const& b);

--- a/include/amici/steadystateproblem.h
+++ b/include/amici/steadystateproblem.h
@@ -400,6 +400,8 @@ class SteadystateProblem {
     AmiVector xQB_;
     /** time-derivative of quadrature state vector */
     AmiVector xQBdot_;
+    /** NVector around Model::steadystate_mask_ */
+    AmiVector steadystate_mask_;
 
     /** maximum number of steps for Newton solver for allocating numlinsteps */
     int max_steps_{0};

--- a/src/model.cpp
+++ b/src/model.cpp
@@ -288,8 +288,7 @@ bool operator==(Model const& a, Model const& b) {
            && (a.state_is_non_negative_ == b.state_is_non_negative_)
            && (a.sigma_res_ == b.sigma_res_) && (a.min_sigma_ == b.min_sigma_)
            && (a.state_ == b.state_)
-           && (a.steadystate_mask_.getVector()
-               == b.steadystate_mask_.getVector());
+           && (a.steadystate_mask_ == b.steadystate_mask_);
 }
 
 bool operator==(ModelDimensions const& a, ModelDimensions const& b) {
@@ -3137,11 +3136,9 @@ std::vector<double> Model::get_trigger_timepoints() const {
     return trigger_timepoints;
 }
 
-void Model::set_steadystate_mask(std::vector<double> const& mask) {
+void Model::set_steadystate_mask(const std::vector<realtype> &mask) {
     if (mask.size() == 0) {
-        if (steadystate_mask_.getLength() != 0) {
-            steadystate_mask_ = AmiVector();
-        }
+        steadystate_mask_.clear();
         return;
     }
 
@@ -3151,7 +3148,7 @@ void Model::set_steadystate_mask(std::vector<double> const& mask) {
             gsl::narrow<int>(mask.size()), nx_solver
         );
 
-    steadystate_mask_ = AmiVector(mask);
+    steadystate_mask_ = mask;
 }
 
 const_N_Vector Model::computeX_pos(const_N_Vector x) {

--- a/src/steadystateproblem.cpp
+++ b/src/steadystateproblem.cpp
@@ -28,6 +28,7 @@ SteadystateProblem::SteadystateProblem(Solver const& solver, Model const& model)
     , xQ_(model.nJ * model.nx_solver)
     , xQB_(model.nplist())
     , xQBdot_(model.nplist())
+    , steadystate_mask_(AmiVector(model.get_steadystate_mask()))
     , max_steps_(solver.getNewtonMaxSteps())
     , dJydx_(model.nJ * model.nx_solver * model.nt(), 0.0)
     , state_(
@@ -551,7 +552,7 @@ SteadystateProblem::getWrms(Model& model, SensitivityMethod sensi_method) {
                 "steady state computations. Stopping."
             );
         wrms = getWrmsNorm(
-            xQB_, xQBdot_, model.get_steadystate_mask_av(), atol_quad_,
+            xQB_, xQBdot_, steadystate_mask_, atol_quad_,
             rtol_quad_, ewtQB_
         );
     } else {
@@ -563,7 +564,7 @@ SteadystateProblem::getWrms(Model& model, SensitivityMethod sensi_method) {
             updateRightHandSide(model);
         wrms = getWrmsNorm(
             state_.x, newton_step_conv_ ? delta_ : xdot_,
-            model.get_steadystate_mask_av(), atol_, rtol_, ewt_
+            steadystate_mask_, atol_, rtol_, ewt_
         );
     }
     return wrms;
@@ -585,7 +586,7 @@ realtype SteadystateProblem::getWrmsFSA(Model& model) {
         if (newton_step_conv_)
             newton_solver_->solveLinearSystem(xdot_);
         wrms = getWrmsNorm(
-            state_.sx[ip], xdot_, model.get_steadystate_mask_av(), atol_sensi_,
+            state_.sx[ip], xdot_, steadystate_mask_, atol_sensi_,
             rtol_sensi_, ewt_
         );
         /* ideally this function would report the maximum of all wrms over


### PR DESCRIPTION
* AmiVector -> std::vector
* Wrap it with an NVector only when need in SteadystateProblem

Avoids SUNContext issues when copying Model