### PR TITLE
GHA: Install benchmark collection only where necessary

### DIFF
--- a/.github/workflows/deploy_release.yml
+++ b/.github/workflows/deploy_release.yml
@@ -36,11 +36,6 @@ jobs:
 
     - run: echo "AMICI_DIR=$(pwd)" >> $GITHUB_ENV
 
-    - name: Remove direct dependencies from setup.cfg
-      # Remove any "git+https"-based dependencies that are not supported
-      #  by PyPI and are only required for testing.
-      run: sed -i '/git+https/d' python/sdist/pyproject.toml
-
     - name: sdist
       run: scripts/buildSdist.sh
 

--- a/.github/workflows/test_petab_test_suite.yml
+++ b/.github/workflows/test_petab_test_suite.yml
@@ -15,7 +15,7 @@ jobs:
   build:
     name: PEtab Testsuite
 
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
 
     env:
       ENABLE_GCOV_COVERAGE: TRUE
@@ -67,6 +67,12 @@ jobs:
             https://github.com/PEtab-dev/petab_test_suite \
             && source ./venv/bin/activate \
             && cd petab_test_suite && pip3 install -e .
+
+      - name: Install PEtab benchmark collection
+        run: |
+          git clone --depth 1 https://github.com/benchmarking-initiative/Benchmark-Models-PEtab.git \
+            && export BENCHMARK_COLLECTION="$(pwd)/Benchmark-Models-PEtab/Benchmark-Models/" \
+            && source venv/bin/activate && python -m pip install -e $BENCHMARK_COLLECTION/../src/python
 
       - name: Install petab
         run: |

--- a/.github/workflows/test_python_cplusplus.yml
+++ b/.github/workflows/test_python_cplusplus.yml
@@ -338,6 +338,12 @@ jobs:
         path: ${{ env.pooch-cache }}
         key: ${{ runner.os }}-py${{ matrix.python-version }}-${{ github.job }}
 
+    - name: Install PEtab benchmark collection
+      run: |
+        git clone --depth 1 https://github.com/benchmarking-initiative/Benchmark-Models-PEtab.git \
+          && export BENCHMARK_COLLECTION="$(pwd)/Benchmark-Models-PEtab/Benchmark-Models/" \
+          && source venv/bin/activate && python -m pip install -e $BENCHMARK_COLLECTION/../src/python
+
     - name: Python tests
       run: |
         scripts/run-python-tests.sh \

--- a/python/sdist/pyproject.toml
+++ b/python/sdist/pyproject.toml
@@ -61,7 +61,6 @@ classifiers = [
 petab = ["petab>=0.4.0"]
 pysb = ["pysb>=1.13.1"]
 test = [
-    "benchmark_models_petab @ git+https://github.com/Benchmarking-Initiative/Benchmark-Models-PEtab.git@master#subdirectory=src/python",
     "h5py",
     "pytest",
     "pytest-cov",


### PR DESCRIPTION
... and get rid of the URLs in pyproject.toml that aren't allowed on PyPI