### PR TITLE
Fix initialization of Model::simulation_parameters_::pscale

### DIFF
--- a/src/model.cpp
+++ b/src/model.cpp
@@ -196,7 +196,7 @@ Model::Model(
         == gsl::narrow<int>(simulation_parameters_.fixedParameters.size())
     );
 
-    simulation_parameters.pscale = std::vector<ParameterScaling>(
+    simulation_parameters_.pscale = std::vector<ParameterScaling>(
         model_dimensions.np, ParameterScaling::none
     );
 


### PR DESCRIPTION
pscale was set on moved-from object simulation_parameters instead of simulation_parameters_