### PR TITLE
Pin sphinx<8 / update sphinx config for sphinx8

### DIFF
--- a/documentation/conf.py
+++ b/documentation/conf.py
@@ -215,7 +215,7 @@ ref = ret.stdout.rstrip().decode()
 nbsphinx_prolog = (
     f"{{% set {ref=} %}}"
     r"""
-    {% set docname = "documentation/" + env.doc2path(env.docname, base=False) %}
+    {% set docname = "documentation/" + env.doc2path(env.docname, base=False)|string %}
     .. raw:: html
 
         <div class="note">

--- a/documentation/rtd_requirements.txt
+++ b/documentation/rtd_requirements.txt
@@ -1,5 +1,5 @@
 # NOTE: relative paths are expected to be relative to the repository root
-sphinx
+sphinx<8
 mock>=5.0.2
 setuptools>=67.7.2
 pysb>=1.11.0


### PR DESCRIPTION
Some dependency lifted there sphinx<8 requirement, but this leads to a number of issues with other dependencies. Therefore, require sphinx<8 for now.

Anyways fix some upcoming issue with sphinx 8 when doc2path will return something path-like (see https://github.com/ICB-DCM/pyPESTO/issues/1482).