### PR TITLE
Fix AmiVector::nvec_ for size 0

### DIFF
--- a/include/amici/vector.h
+++ b/include/amici/vector.h
@@ -88,8 +88,7 @@ class AmiVector {
             return;
         }
         nvec_ = N_VMake_Serial(
-            gsl::narrow<long int>(vold.vec_.size()), vec_.data(),
-            vold.nvec_->sunctx
+            gsl::narrow<long int>(vec_.size()), vec_.data(), vold.nvec_->sunctx
         );
     }
 

--- a/src/solver.cpp
+++ b/src/solver.cpp
@@ -769,7 +769,7 @@ void Solver::setConstraints(std::vector<realtype> const& constraints) {
 
     if (!any_constraint) {
         // all-0 must be converted to empty, otherwise sundials will fail
-        constraints_ = AmiVector();
+        constraints_ = AmiVector(0, sunctx_);
         return;
     }
 

--- a/src/vector.cpp
+++ b/src/vector.cpp
@@ -58,11 +58,11 @@ void AmiVector::copy(AmiVector const& other) {
 void AmiVector::synchroniseNVector(SUNContext sunctx) {
     if (nvec_)
         N_VDestroy_Serial(nvec_);
-    nvec_ = vec_.empty()
-                ? nullptr
-                : N_VMake_Serial(
-                      gsl::narrow<long int>(vec_.size()), vec_.data(), sunctx
-                  );
+    if (sunctx) {
+        nvec_ = N_VMake_Serial(
+            gsl::narrow<long int>(vec_.size()), vec_.data(), sunctx
+        );
+    }
 }
 
 AmiVector::~AmiVector() {


### PR DESCRIPTION
* We still need to create an NVector, even if it's empty.
* Don't pass nullptr as sunctx

Issue introduced in #2513. 

Closes #2534.