### PR TITLE
Fix SBML test IDs

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -76,7 +76,7 @@ def pytest_generate_tests(metafunc):
         else:
             # Run all tests
             test_numbers = get_all_semantic_case_ids()
-
+        test_numbers = map(format_test_id, test_numbers)
         metafunc.parametrize("test_number", test_numbers)
 
 
@@ -89,8 +89,6 @@ def pytest_sessionfinish(session, exitstatus):
     terminalreporter.ensure_newline()
     # parse test names to get passed case IDs (don't know any better way to
     # access fixture values)
-    from testSBMLSuite import format_test_id
-
     passed_ids = [format_test_id(_) for _ in passed_ids]
     if passed_ids:
         write_passed_tags(passed_ids, terminalreporter)
@@ -157,3 +155,8 @@ def get_tags_for_test(test_id: str) -> tuple[set[str], set[str]]:
                 return component_tags, test_tags
     print(f"No componentTags or testTags found for test case {test_id}.")
     return component_tags, test_tags
+
+
+def format_test_id(test_id) -> str:
+    """Format numeric to 0-padded string"""
+    return f"{test_id:0>5}"

--- a/tests/testSBMLSuite.py
+++ b/tests/testSBMLSuite.py
@@ -24,6 +24,7 @@ import pytest
 from amici.constants import SymbolId
 from amici.gradient_check import check_derivatives
 from numpy.testing import assert_allclose
+from conftest import format_test_id
 
 
 @pytest.fixture(scope="session")
@@ -351,8 +352,3 @@ def read_settings_file(current_test_path: Path, test_id: str):
                 (key, val) = line.split(":")
                 settings[key] = val.strip()
     return settings
-
-
-def format_test_id(test_id) -> str:
-    """Format numeric to 0-padded string"""
-    return f"{test_id:0>5}"


### PR DESCRIPTION
Make sure the printed test IDs correspond to actual test IDs, so they can be copy/pasted to rerun. Previously this was not the case when running with pytest-xdist.