### PR TITLE
Update CMake export config

### DIFF
--- a/.github/workflows/test_python_cplusplus.yml
+++ b/.github/workflows/test_python_cplusplus.yml
@@ -38,6 +38,11 @@ jobs:
     - name: Set up AMICI C++ libraries
       uses: ./.github/actions/setup-amici-cpp
 
+    - name: Install libsuitesparse-dev
+      # We don't need libsuitesparse-dev, but let's have it installed,
+      # to ensure that its presence does not break the build
+      run: sudo apt-get install -y libsuitesparse-dev
+
     - name: C++ tests
       run: scripts/run-cpp-tests.sh
 

--- a/cmake/AmiciConfig.cmake.in
+++ b/cmake/AmiciConfig.cmake.in
@@ -9,24 +9,8 @@ find_package(OpenMP)
 # tmpdirs.
 list(APPEND CMAKE_PREFIX_PATH
      @CMAKE_SOURCE_DIR@/ThirdParty/SuiteSparse/install/)
-find_dependency(SuiteSparse_config REQUIRED)
-find_dependency(AMD REQUIRED)
-find_dependency(BTF REQUIRED)
-find_dependency(COLAMD REQUIRED)
-find_dependency(KLU REQUIRED)
 
 include("${CMAKE_CURRENT_LIST_DIR}/AmiciFindBLAS.cmake")
-
-add_library(SUNDIALS::KLU INTERFACE IMPORTED)
-target_link_libraries(
-  SUNDIALS::KLU
-  INTERFACE "${KLU_STATIC}"
-  INTERFACE "${COLAMD_STATIC}"
-  INTERFACE "${BTF_STATIC}"
-  INTERFACE "${AMD_STATIC}"
-  INTERFACE "${SUITESPARSE_CONFIG_STATIC}")
-set_target_properties(SUNDIALS::KLU PROPERTIES INTERFACE_INCLUDE_DIRECTORIES
-                                               "${KLU_INCLUDE_DIR}")
 
 find_dependency(SUNDIALS REQUIRED PATHS
              "@CMAKE_SOURCE_DIR@/ThirdParty/sundials/build/@CMAKE_INSTALL_LIBDIR@/cmake/sundials/")

--- a/python/sdist/amici/setup.template.py
+++ b/python/sdist/amici/setup.template.py
@@ -35,10 +35,7 @@ def get_extension() -> CMakeExtension:
         install_prefix="TPL_MODELNAME",
         cmake_configure_options=[
             "-DCMAKE_VERBOSE_MAKEFILE=ON",
-            "-DCMAKE_MODULE_PATH="
-            f"{prefix_path.as_posix()}/lib/cmake/SuiteSparse;"
-            f"{prefix_path.as_posix()}/lib64/cmake/SuiteSparse",
-            f"-DKLU_ROOT={prefix_path.as_posix()}",
+            f"-DCMAKE_PREFIX_PATH={prefix_path.as_posix()}",
             "-DAMICI_PYTHON_BUILD_EXT_ONLY=ON",
             f"-DPython3_EXECUTABLE={Path(sys.executable).as_posix()}",
         ],


### PR DESCRIPTION
* We don't need to find SuiteSparse - sundials takes care of that
* Fixes some issues when consuming the amici-exported CMake config 
* Set CMAKE_PREFIX_PATH when configuring models
* Install system-wide libsuitesparse-dev to make sure it doesn't interfere with our vendored version