### PR TITLE
CMake: Don't attempt to create alias target if target of the same name already exists

### DIFF
--- a/src/CMakeLists.template.cmake
+++ b/src/CMakeLists.template.cmake
@@ -59,7 +59,11 @@ set(MODEL_DIR ${CMAKE_CURRENT_LIST_DIR})
 set(SRC_LIST_LIB TPL_SOURCES ${MODEL_DIR}/wrapfunctions.cpp)
 
 add_library(${PROJECT_NAME} ${SRC_LIST_LIB})
-add_library(model ALIAS ${PROJECT_NAME})
+
+# ${PROJECT_NAME} might already be "model"
+if(NOT TARGET model)
+    add_library(model ALIAS ${PROJECT_NAME})
+endif()
 
 # Some special functions require boost
 #


### PR DESCRIPTION

Fixes #2546.