### PR TITLE
Fix `_collect_heaviside_roots` for `sympy.Heaviside` arguments

### DIFF
--- a/python/sdist/amici/de_model.py
+++ b/python/sdist/amici/de_model.py
@@ -2226,7 +2226,7 @@ class DEModel:
 
     def _collect_heaviside_roots(
         self,
-        args: Sequence[sp.Expr],
+        args: Sequence[sp.Basic],
     ) -> list[sp.Expr]:
         """
         Recursively checks an expression for the occurrence of Heaviside
@@ -2288,7 +2288,7 @@ class DEModel:
         # replace them later by the new expressions
         heavisides = []
         # run through the expression tree and get the roots
-        tmp_roots_old = self._collect_heaviside_roots(dxdt.args)
+        tmp_roots_old = self._collect_heaviside_roots((dxdt,))
         for tmp_old in unique_preserve_order(tmp_roots_old):
             # we want unique identifiers for the roots
             tmp_new = self._get_unique_root(tmp_old, roots)


### PR DESCRIPTION
Since https://github.com/AMICI-dev/AMICI/commit/b7a3e9133fd53c36daa6df6a71c580f5ff1eead2, if dxdt was a sympy.Heaviside, it wasn't correctly processed, because only its arguments were checked. That means, root-finding would not be enabled for this discontinuity.

This would happen if a Rule or KineticLaw is a plain Piecewise function (not embedded inside a more complex expression).

Fixes #2545.

The bug was exposed only after the previous release, this did not affect any former amici releases.