### PR TITLE
Fix capturing SUNDIALS warnings after 7.1.1 upgrade

### DIFF
--- a/ThirdParty/sundials/src/cvodes/cvodes.c
+++ b/ThirdParty/sundials/src/cvodes/cvodes.c
@@ -9930,6 +9930,8 @@ void cvProcessError(CVodeMem cv_mem, int error_code, int line, const char* func,
       break;
     }
 
+/* AMICI: https://github.com/AMICI-dev/AMICI/issues/2550 */
+#ifdef AMICI_SUNLOGGER_WARNINGS
     if (error_code == CV_WARNING)
     {
 #if SUNDIALS_LOGGING_LEVEL >= SUNDIALS_LOGGING_WARNING
@@ -9940,6 +9942,7 @@ void cvProcessError(CVodeMem cv_mem, int error_code, int line, const char* func,
 #endif
       break;
     }
+#endif
 
     /* Call the SUNDIALS main error handler */
     SUNHandleErrWithMsg(line, func, file, msg, error_code, cv_mem->cv_sunctx);

--- a/ThirdParty/sundials/src/idas/idas.c
+++ b/ThirdParty/sundials/src/idas/idas.c
@@ -8779,6 +8779,8 @@ void IDAProcessError(IDAMem IDA_mem, int error_code, int line, const char* func,
       break;
     }
 
+/* AMICI: https://github.com/AMICI-dev/AMICI/issues/2550 */
+#ifdef AMICI_SUNLOGGER_WARNINGS
     if (error_code == IDA_WARNING)
     {
 #if SUNDIALS_LOGGING_LEVEL >= SUNDIALS_LOGGING_WARNING
@@ -8789,6 +8791,7 @@ void IDAProcessError(IDAMem IDA_mem, int error_code, int line, const char* func,
 #endif
       break;
     }
+#endif
 
     /* Call the SUNDIALS main error handler */
     SUNHandleErrWithMsg(line, func, file, msg, error_code, IDA_mem->ida_sunctx);

--- a/include/amici/defines.h
+++ b/include/amici/defines.h
@@ -60,6 +60,7 @@ constexpr double pi = M_PI;
 //
 // NOTE: When adding / removing / renaming return codes,
 //       please update simulation_status_to_str_map in amici.h
+constexpr int AMICI_WARNING=                  99;
 constexpr int AMICI_RECOVERABLE_ERROR=         1;
 constexpr int AMICI_UNRECOVERABLE_ERROR=     -10;
 constexpr int AMICI_TOO_MUCH_WORK=            -1;

--- a/src/amici.cpp
+++ b/src/amici.cpp
@@ -50,6 +50,7 @@ std::map<int, std::string> simulation_status_to_str_map = {
     {AMICI_NOT_RUN, "AMICI_NOT_RUN"},
     {AMICI_LSETUP_FAIL, "AMICI_LSETUP_FAIL"},
     {AMICI_FIRST_QRHSFUNC_ERR, "AMICI_FIRST_QRHSFUNC_ERR"},
+    {AMICI_WARNING, "AMICI_WARNING"},
 };
 
 std::unique_ptr<ReturnData> runAmiciSimulation(

--- a/src/solver.cpp
+++ b/src/solver.cpp
@@ -27,7 +27,7 @@ void wrapErrHandlerFn(
         std::is_same<SUNErrCode, int>::value, "Must update format string"
     );
     // for debug builds, include full file path and line numbers
-#ifdef NDEBUG
+#ifndef NDEBUG
     snprintf(msg_buffer, BUF_SIZE, "%s:%d: %s (%d)", file, line, msg, err_code);
 #else
     snprintf(msg_buffer, BUF_SIZE, "%s", msg);

--- a/src/solver_cvodes.cpp
+++ b/src/solver_cvodes.cpp
@@ -90,6 +90,10 @@ static_assert(
     amici::AMICI_FIRST_QRHSFUNC_ERR == CV_FIRST_QRHSFUNC_ERR,
     "AMICI_FIRST_QRHSFUNC_ERR != CV_FIRST_QRHSFUNC_ERR"
 );
+static_assert(
+    amici::AMICI_WARNING == CV_WARNING,
+    "AMICI_WARNING != CV_WARNING"
+);
 
 /*
  * The following static members are callback function to CVODES.

--- a/src/solver_idas.cpp
+++ b/src/solver_idas.cpp
@@ -70,6 +70,10 @@ static_assert(
     amici::AMICI_IDAS_CONSTR_FAIL == IDA_CONSTR_FAIL,
     "AMICI_IDAS_CONSTR_FAIL != IDA_CONSTR_FAIL"
 );
+static_assert(
+    amici::AMICI_WARNING == IDA_WARNING,
+    "AMICI_WARNING != IDA_WARNING"
+);
 
 /*
  * The following static members are callback function to IDAS.


### PR DESCRIPTION
Disable SUNDIALS's warning-handling through `SUNLogger`. Instead pipe everything both errors and warnings through the provided`SUNErrHandlerFn`.

For details, see #2550.

Fixes #2550.

This also corrects the error message formatting - file path and line numbers for debug builds, but omitted in release builds - which was inverted before. 

---

Previously (see red box): https://amici.readthedocs.io/en/develop/example_errors.html#Internal-t-=-[...]-and-h-=-[...]-are-such-that-t-+-h-=-t-on-the-next-step
Now: https://amici--2551.org.readthedocs.build/en/2551/example_errors.html#Internal-t-=-[...]-and-h-=-[...]-are-such-that-t-+-h-=-t-on-the-next-step