### PR TITLE
add 3.13 to test matrix

### DIFF
--- a/.github/workflows/test_python_ver_matrix.yml
+++ b/.github/workflows/test_python_ver_matrix.yml
@@ -25,7 +25,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ['3.10', '3.11', '3.12']
+        python-version: ['3.10', '3.11', '3.12', '3.13']
         experimental: [false]
 
     steps:
@@ -53,12 +53,7 @@ jobs:
     # install pysb before sympy to allow for sympy>=1.12 (https://github.com/pysb/pysb/commit/e83937cb8c74afc9b2fa96595b68464946745f33)
     - run: source venv/bin/activate && pip3 install git+https://github.com/pysb/pysb
 
-    # until sympy>1.12 is released
-    - run: source venv/bin/activate && pip3 install git+https://github.com/sympy/sympy.git@master
-      if: matrix.python-version == '3.12'
-
-    - run: source venv/bin/activate && pip3 install "sympy>=1.12.1"
-      if: matrix.python-version != '3.12'
+    - run: source venv/bin/activate && pip3 install "sympy>1.12"
 
     - name: Get Pooch Cache Directory
       id: get-pooch-cache

--- a/python/sdist/pyproject.toml
+++ b/python/sdist/pyproject.toml
@@ -17,7 +17,6 @@ requires-python = ">=3.10"
 dependencies = [
     "cmake-build-extension==0.6.0",
     "sympy>=1.12.1",
-    "numpy>=1.19.3; python_version=='3.9'",
     "numpy>=1.21.4; python_version>='3.10'",
     "numpy>=1.23.2; python_version=='3.11'",
     "numpy>=1.26.2; python_version=='3.12'",


### PR DESCRIPTION
python 3.13 was released on Oct 7, 2024: https://docs.python.org/3.13/whatsnew/3.13.html