### PR TITLE
Fix dangling pointer in SolverTest.SettersGettersWithSetup

### DIFF
--- a/.github/workflows/test_valgrind.yml
+++ b/.github/workflows/test_valgrind.yml
@@ -4,6 +4,7 @@ on:
     branches:
       - master
       - update_valgrind_supp
+      - fix_valgrind_tests
   pull_request:
     branches:
       - master

--- a/scripts/run-valgrind-cpp.sh
+++ b/scripts/run-valgrind-cpp.sh
@@ -10,4 +10,4 @@ set -eou pipefail
 # run tests
 cd "${AMICI_PATH}/build/"
 VALGRIND_OPTS="--leak-check=full --error-exitcode=1 --trace-children=yes --show-leak-kinds=definite"
-valgrind ${VALGRIND_OPTS} ctest
+CTEST_OUTPUT_ON_FAILURE=1 valgrind ${VALGRIND_OPTS} ctest

--- a/tests/cpp/unittests/testMisc.cpp
+++ b/tests/cpp/unittests/testMisc.cpp
@@ -360,10 +360,9 @@ TEST_F(SolverTest, SettersGettersWithSetup)
     ASSERT_EQ(static_cast<int>(solver.getSensitivityMethod()),
               static_cast<int>(sensi_meth));
 
-    sundials::Context sunctx;
     auto rdata = std::make_unique<ReturnData>(solver, testModel);
-    AmiVector x(nx, sunctx), dx(nx, sunctx);
-    AmiVectorArray sx(nx, 1, sunctx), sdx(nx, 1, sunctx);
+    AmiVector x(nx, solver.getSunContext()), dx(nx, solver.getSunContext());
+    AmiVectorArray sx(nx, 1, solver.getSunContext()), sdx(nx, 1, solver.getSunContext());
 
     testModel.setInitialStates(std::vector<realtype>{ 0 });
 


### PR DESCRIPTION
Fixes a dangling pointer issue in SolverTest.SettersGettersWithSetup.
The SUNContext was destroyed before the associated AmiVectors which resulted in invalid reads.