### PR TITLE
GHA: Ignore python3.13 failures for now

### DIFF
--- a/.github/workflows/test_python_ver_matrix.yml
+++ b/.github/workflows/test_python_ver_matrix.yml
@@ -25,8 +25,15 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ['3.10', '3.11', '3.12', '3.13']
-        experimental: [false]
+        include:
+          - python-version: '3.10'
+            experimental: false
+          - python-version: '3.11'
+            experimental: false
+          - python-version: '3.12'
+            experimental: false
+          - python-version: '3.13'
+            experimental: true
 
     steps:
     - run: echo "AMICI_DIR=$(pwd)" >> $GITHUB_ENV


### PR DESCRIPTION
Until all dependencies work with Python3.13. pyarrow wheels are still missing.