### PR TITLE
GHA: PYTHONFAULTHANDLER=1

### DIFF
--- a/.github/workflows/test_python_cplusplus.yml
+++ b/.github/workflows/test_python_cplusplus.yml
@@ -247,6 +247,8 @@ jobs:
   macos_cpp_py:
     name: Tests MacOS C++/Python
     runs-on: macos-latest
+    env:
+      PYTHONFAULTHANDLER: "1"
 
     steps:
     - name: Set up Python
@@ -300,6 +302,8 @@ jobs:
   macos_python:
     name: Tests MacOS Python
     runs-on: macos-latest
+    env:
+      PYTHONFAULTHANDLER: "1"
 
     steps:
     - name: Cache

--- a/scripts/run-python-tests.sh
+++ b/scripts/run-python-tests.sh
@@ -15,7 +15,7 @@ cd "${amici_path}"/python/tests
 source "${amici_path}"/venv/bin/activate
 
 # PEtab tests are run separately
-pytest \
+pytest -s \
   --ignore-glob=*petab* \
   --ignore-glob=*test_splines.py \
   --durations=10 \

--- a/scripts/run-python-tests.sh
+++ b/scripts/run-python-tests.sh
@@ -15,7 +15,7 @@ cd "${amici_path}"/python/tests
 source "${amici_path}"/venv/bin/activate
 
 # PEtab tests are run separately
-pytest -s \
+pytest \
   --ignore-glob=*petab* \
   --ignore-glob=*test_splines.py \
   --durations=10 \


### PR DESCRIPTION
Set PYTHONFAULTHANDLER=1 for more output on crashes (#2565). So far, this was only set for Ubuntu tests.