### PR TITLE
GHA: Workaround for macos segfaults

### DIFF
--- a/.github/workflows/test_python_cplusplus.yml
+++ b/.github/workflows/test_python_cplusplus.yml
@@ -293,7 +293,7 @@ jobs:
 
     - name: Python tests
       run: |
-        scripts/run-python-tests.sh \
+        scripts/run-python-tests.sh -W ignore:: \
           test_pregenerated_models.py \
           test_splines_short.py \
           test_misc.py
@@ -355,7 +355,7 @@ jobs:
 
     - name: Python tests
       run: |
-        scripts/run-python-tests.sh \
+        scripts/run-python-tests.sh -W ignore:: \
           --ignore=test_pregenerated_models.py \
           --ignore=test_splines_short.py \
           --ignore=test_misc.py

--- a/.github/workflows/test_python_cplusplus.yml
+++ b/.github/workflows/test_python_cplusplus.yml
@@ -293,6 +293,7 @@ jobs:
 
     - name: Python tests
       run: |
+        # ignore warnings until https://github.com/swig/swig/issues/3061 is resolved
         scripts/run-python-tests.sh -W ignore:: \
           test_pregenerated_models.py \
           test_splines_short.py \
@@ -355,6 +356,7 @@ jobs:
 
     - name: Python tests
       run: |
+        # ignore warnings until https://github.com/swig/swig/issues/3061 is resolved
         scripts/run-python-tests.sh -W ignore:: \
           --ignore=test_pregenerated_models.py \
           --ignore=test_splines_short.py \


### PR DESCRIPTION
Homebrew serves swig 4.3.0 which is incompatible with `filterwarnings = error` in pytest resulting in segfaults (#2565,  https://github.com/swig/swig/issues/3061). 
For now, the easiest workaround seems to be just ignoring any warnings during macos runs.