### PR TITLE
Fix potentially incorrect disabling of Newton's method

### DIFF
--- a/src/steadystateproblem.cpp
+++ b/src/steadystateproblem.cpp
@@ -133,7 +133,8 @@ void SteadystateProblem::findSteadyState(
         = model.getSteadyStateComputationMode()
               == SteadyStateComputationMode::integrationOnly
           || solver.getNewtonMaxSteps() == 0
-          || (model.getSteadyStateSensitivityMode()
+          || (solver.getSensitivityOrder() >= SensitivityOrder::first
+              && model.getSteadyStateSensitivityMode()
                   == SteadyStateSensitivityMode::integrationOnly
               && ((it == -1
                    && solver.getSensitivityMethodPreequilibration()


### PR DESCRIPTION
Fixes a bug that would result in disabling Newton's method for steady-state computation when steady-state sensitivity mode is set to `integrationOnly`, even if no senitivities are computed.

This was because only the sensitivity method was checked, but not the sensitivity order.
The problem exists since `Model::setSteadyStateSensitivityMode` was introduced (https://github.com/AMICI-dev/AMICI/pull/2074, v0.19.0 (2023-08-26)).

Fixes #2575.