### PR TITLE
GHA: require Python3.13 tests to pass

### DIFF
--- a/.github/workflows/test_python_ver_matrix.yml
+++ b/.github/workflows/test_python_ver_matrix.yml
@@ -33,7 +33,7 @@ jobs:
           - python-version: '3.12'
             experimental: false
           - python-version: '3.13'
-            experimental: true
+            experimental: false
 
     steps:
     - run: echo "AMICI_DIR=$(pwd)" >> $GITHUB_ENV


### PR DESCRIPTION
It looks like all our dependencies are now Python3.13-ready (https://github.com/AMICI-dev/AMICI/actions/runs/11753436377/job/32746292107), so we should require Python3.13 tests to pass.