### PR TITLE
Add function for writing ExpData to HDF5

### DIFF
--- a/include/amici/hdf5.h
+++ b/include/amici/hdf5.h
@@ -164,14 +164,26 @@ std::unique_ptr<ExpData> readSimulationExpData(
 /**
  * @brief Write AMICI experimental data to HDF5 file.
  * @param edata The experimental data which is to be written
- * @param file Name of HDF5 file
- * @param hdf5Location Path inside the HDF5 file to object having ExpData
+ * @param file HDF5 file
+ * @param hdf5Location Path inside the HDF5 file
  */
 
 void writeSimulationExpData(
     ExpData const& edata, H5::H5File const& file,
     std::string const& hdf5Location
 );
+
+/**
+ * @brief Write AMICI experimental data to HDF5 file.
+ * @param edata The experimental data which is to be written
+ * @param file Name of HDF5 file
+ * @param hdf5Location Path inside the HDF5 file
+ */
+void writeSimulationExpData(
+    ExpData const& edata, std::string const& hdf5Filename,
+    std::string const& hdf5Location
+    );
+
 
 /**
  * @brief Check whether an attribute with the given name exists

--- a/src/hdf5.cpp
+++ b/src/hdf5.cpp
@@ -1388,5 +1388,14 @@ std::vector<double> getDoubleDataset3D(
     return result;
 }
 
+void writeSimulationExpData(
+    ExpData const& edata, std::string const& hdf5Filename,
+    std::string const& hdf5Location
+) {
+    auto file = createOrOpenForWriting(hdf5Filename);
+
+    writeSimulationExpData(edata, file, hdf5Location);
+}
+
 } // namespace hdf5
 } // namespace amici


### PR DESCRIPTION
So far, there was only a H5File-based version, which is inconvenient to use from Python.

This allows passing a file name instead.