### PR TITLE
CI: Fix installation of homebrew packages

### DIFF
--- a/.github/actions/install-macos-dependencies/action.yml
+++ b/.github/actions/install-macos-dependencies/action.yml
@@ -27,5 +27,8 @@ runs:
 
     # install amici dependencies
     - name: homebrew
-      run: brew install hdf5 swig gcc libomp boost
+      # install hdf5 without dependencies, because pkgconf installation fails,
+      # because it's already installed on the runners. install the other
+      # hdf5 dependencies (libaec) manually
+      run: brew install libaec && brew install --ignore-dependencies hdf5 && brew install swig libomp boost
       shell: bash

--- a/.github/workflows/test_install.yml
+++ b/.github/workflows/test_install.yml
@@ -96,14 +96,8 @@ jobs:
 
     - run: echo "AMICI_DIR=$(pwd)" >> $GITHUB_ENV
 
-    # install amici dependencies
-    - name: homebrew
-      run: |
-        brew install hdf5 swig gcc cppcheck libomp boost \
-          && brew ls -v boost \
-          && brew ls -v libomp \
-          && echo LDFLAGS="-L/usr/local/lib/ -L/usr/local/Cellar/boost/1.81.0_1/lib/" >> $GITHUB_ENV \
-          && echo CPPFLAGS="-I /usr/local/Cellar/boost/1.81.0_1/include/" >> $GITHUB_ENV
+    - name: Install dependencies
+      uses: ./.github/actions/install-macos-dependencies
 
     - name: Create AMICI sdist
       run: scripts/buildSdist.sh

--- a/python/sdist/amici/__main__.py
+++ b/python/sdist/amici/__main__.py
@@ -2,7 +2,13 @@
 
 import sys
 
-from . import __version__, compiledWithOpenMP, has_clibs, hdf5_enabled
+from . import (
+    __version__,
+    compiledWithOpenMP,
+    has_clibs,
+    hdf5_enabled,
+    CpuTimer,
+)
 
 
 def print_info():
@@ -19,6 +25,9 @@ def print_info():
 
     if hdf5_enabled:
         features.append("HDF5")
+
+    if CpuTimer.uses_thread_clock:
+        features.append("thread_clock")
 
     print(
         f"AMICI ({sys.platform}) version {__version__} ({','.join(features)})"


### PR DESCRIPTION
Things started failing yesterday(?), seemingly because of a pre-installed pkgconf interfering with the one to be installed as hdf5 dependency.