### PR TITLE
Improve model extension import

### DIFF
--- a/python/examples/example_splines/ExampleSplines.ipynb
+++ b/python/examples/example_splines/ExampleSplines.ipynb
@@ -25,8 +25,6 @@
    "outputs": [],
    "source": [
     "import os\n",
-    "import sys\n",
-    "from importlib import import_module\n",
     "from shutil import rmtree\n",
     "from tempfile import TemporaryDirectory\n",
     "from uuid import uuid1\n",
@@ -57,7 +55,7 @@
     "                parameters,\n",
     "                build_dir=build_dir,\n",
     "                model_name=model_name,\n",
-    "                **kwargs\n",
+    "                **kwargs,\n",
     "            )\n",
     "    else:\n",
     "        build_dir = os.path.join(BUILD_PATH, model_name)\n",
@@ -67,7 +65,7 @@
     "            parameters,\n",
     "            build_dir=build_dir,\n",
     "            model_name=model_name,\n",
-    "            **kwargs\n",
+    "            **kwargs,\n",
     "        )\n",
     "\n",
     "\n",
@@ -79,7 +77,7 @@
     "    model_name,\n",
     "    T=1,\n",
     "    discard_annotations=False,\n",
-    "    plot=True\n",
+    "    plot=True,\n",
     "):\n",
     "    if parameters is None:\n",
     "        parameters = {}\n",
@@ -89,13 +87,12 @@
     "    )\n",
     "    sbml_importer.sbml2amici(model_name, build_dir)\n",
     "    # Import the model module\n",
-    "    sys.path.insert(0, os.path.abspath(build_dir))\n",
-    "    model_module = import_module(model_name)\n",
+    "    model_module = amici.import_model_module(model_name, build_dir)\n",
     "    # Setup simulation timepoints and parameters\n",
     "    model = model_module.getModel()\n",
     "    for name, value in parameters.items():\n",
     "        model.setParameterByName(name, value)\n",
-    "    if isinstance(T, (int, float)):\n",
+    "    if isinstance(T, int | float):\n",
     "        T = np.linspace(0, T, 100)\n",
     "    model.setTimepoints([float(t) for t in T])\n",
     "    solver = model.getSolver()\n",
@@ -320,7 +317,7 @@
    ],
    "source": [
     "# Finally, we can simulate it in AMICI\n",
-    "model, rdata = simulate(sbml_model);"
+    "model, rdata = simulate(sbml_model)"
    ]
   },
   {

--- a/python/sdist/amici/__init__.template.py
+++ b/python/sdist/amici/__init__.template.py
@@ -1,8 +1,12 @@
 """AMICI-generated module for model TPL_MODELNAME"""
 
+import datetime
+import os
+import sys
 from pathlib import Path
 from typing import TYPE_CHECKING
 import amici
+
 
 if TYPE_CHECKING:
     from amici.jax import JAXModel
@@ -18,14 +22,44 @@ if "TPL_AMICI_VERSION" != amici.__version__:
         "version currently installed."
     )
 
-from .TPL_MODELNAME import *  # noqa: F403, F401
-from .TPL_MODELNAME import getModel as get_model  # noqa: F401
+TPL_MODELNAME = amici._module_from_path(
+    "TPL_MODELNAME.TPL_MODELNAME", Path(__file__).parent / "TPL_MODELNAME.py"
+)
+for var in dir(TPL_MODELNAME):
+    if not var.startswith("_"):
+        globals()[var] = getattr(TPL_MODELNAME, var)
+get_model = TPL_MODELNAME.getModel
+
+try:
+    # _self: this module; will be set during import
+    #  via amici.import_model_module
+    TPL_MODELNAME._model_module = _self  # noqa: F821
+except NameError:
+    # when the model package is imported via `import`
+    TPL_MODELNAME._model_module = sys.modules[__name__]
 
 
 def get_jax_model() -> "JAXModel":
-    from .jax import JAXModel_TPL_MODELNAME
-
-    return JAXModel_TPL_MODELNAME()
+    # If the model directory was meanwhile overwritten, this would load the
+    #  new version, which would not match the previously imported extension.
+    #  This is not allowed, as it would lead to inconsistencies.
+    jax_py_file = Path(__file__).parent / "jax.py"
+    jax_py_file = jax_py_file.resolve()
+    t_imported = TPL_MODELNAME._get_import_time()  # noqa: protected-access
+    t_modified = os.path.getmtime(jax_py_file)
+    if t_imported < t_modified:
+        t_imp_str = datetime.datetime.fromtimestamp(t_imported).isoformat()
+        t_mod_str = datetime.datetime.fromtimestamp(t_modified).isoformat()
+        raise RuntimeError(
+            f"Refusing to import {jax_py_file} which was changed since "
+            f"TPL_MODELNAME was imported. This is to avoid inconsistencies "
+            "between the different model implementations.\n"
+            f"Imported at {t_imp_str}\nModified at {t_mod_str}.\n"
+            "Import the module with a different name or restart the "
+            "Python kernel."
+        )
+    jax = amici._module_from_path("jax", jax_py_file)
+    return jax.JAXModel_TPL_MODELNAME()
 
 
 __version__ = "TPL_PACKAGE_VERSION"

--- a/python/tests/test_events.py
+++ b/python/tests/test_events.py
@@ -724,7 +724,7 @@ def test_handling_of_fixed_time_point_event_triggers():
     end
     """
     module_name = "test_events_time_based"
-    with TemporaryDirectory(prefix=module_name, delete=False) as outdir:
+    with TemporaryDirectory(prefix=module_name) as outdir:
         antimony2amici(
             ant_model,
             model_name=module_name,
@@ -765,7 +765,7 @@ def test_multiple_event_assignment_with_compartment():
     """
     # watch out for too long path names on windows ...
     module_name = "tst_mltple_ea_w_cmprtmnt"
-    with TemporaryDirectory(prefix=module_name, delete=False) as outdir:
+    with TemporaryDirectory(prefix=module_name) as outdir:
         antimony2amici(
             ant_model,
             model_name=module_name,

--- a/swig/modelname.template.i
+++ b/swig/modelname.template.i
@@ -1,4 +1,48 @@
-%module TPL_MODELNAME
+%define MODULEIMPORT
+"
+import amici
+import datetime
+import importlib.util
+import os
+import sysconfig
+from pathlib import Path
+
+ext_suffix = sysconfig.get_config_var('EXT_SUFFIX')
+_TPL_MODELNAME = amici._module_from_path(
+    'TPL_MODELNAME._TPL_MODELNAME' if __package__ or '.' in __name__
+    else '_TPL_MODELNAME',
+    Path(__file__).parent / f'_TPL_MODELNAME{ext_suffix}',
+)
+
+def _get_import_time():
+    return _TPL_MODELNAME._get_import_time()
+
+t_imported = _get_import_time()
+t_modified = os.path.getmtime(__file__)
+if t_imported < t_modified:
+    t_imp_str = datetime.datetime.fromtimestamp(t_imported).isoformat()
+    t_mod_str = datetime.datetime.fromtimestamp(t_modified).isoformat()
+    module_path = Path(__file__).resolve()
+    raise RuntimeError(
+        f'Cannot import extension for TPL_MODELNAME from '
+        f'{module_path}, because an extension in the same location '
+        f'has already been imported, but the file was modified on '
+        f'disk. \\nImported at {t_imp_str}\\nModified at {t_mod_str}.\\n'
+        'Import the module with a different name or restart the '
+        'Python kernel.'
+    )
+"
+%enddef
+
+%module(package="TPL_MODELNAME",moduleimport=MODULEIMPORT) TPL_MODELNAME
+
+%pythoncode %{
+# the model-package __init__.py module (will be set during import)
+_model_module = None
+
+
+%}
+
 %import amici.i
 // Add necessary symbols to generated header
 
@@ -30,8 +74,7 @@ static double _get_import_time();
 // Make model module accessible from the model
 %feature("pythonappend") amici::generic_model::getModel %{
     if '.' in __name__:
-        import sys
-        val.module = sys.modules['.'.join(__name__.split('.')[:-1])]
+        val.module = _model_module
 %}
 
 


### PR DESCRIPTION
Previously, it wasn't possible to import two model modules with the same name. Now this is at least possible if they are in different locations. Overwriting and importing a previously imported extension is still not supported.

In essence, we avoid using `import` and `sys.modules`, and directly import the specific files. For a single file, this works pretty neatly, but for an actual package less so. 

Closes #1936 