### PR TITLE
don't throw on jax equilibration failures

### DIFF
--- a/python/sdist/amici/jax/model.py
+++ b/python/sdist/amici/jax/model.py
@@ -262,6 +262,7 @@ class JAXModel(eqx.Module):
             max_steps=max_steps,
             adjoint=diffrax.DirectAdjoint(),
             event=diffrax.Event(cond_fn=diffrax.steady_state_event()),
+            throw=False,
         )
         return sol.ys[-1, :], sol.stats
 


### PR DESCRIPTION
we weren't throwing during simulation, no reason to throw during equilibration.