### PR TITLE
Doc: Include hdf5 functions in Python API doc

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -21,6 +21,7 @@ build:
   os: "ubuntu-22.04"
   apt_packages:
     - libatlas-base-dev
+    - libhdf5-serial-dev
     - swig
   tools:
     python: "3.11"

--- a/documentation/cpp_installation.rst
+++ b/documentation/cpp_installation.rst
@@ -18,6 +18,7 @@ Prerequisites:
 * a C++17 compatible compiler
 * a C compiler
 * Optional:
+
   * HDF5 libraries
   * boost for serialization
 

--- a/include/amici/solver.h
+++ b/include/amici/solver.h
@@ -39,7 +39,8 @@ namespace amici {
  * variables and status flags) are specified as mutable and not included in
  * serialization or equality checks. No solver setting parameter should be
  * marked mutable.
- *
+ */
+/*
  * NOTE: Any changes in data members here must be propagated to copy ctor,
  * equality operator, serialization functions in serialization.h, and
  * amici::hdf5::(read/write)SolverSettings(From/To)HDF5 in hdf5.cpp.

--- a/python/examples/example_steadystate/ExampleSteadystate.ipynb
+++ b/python/examples/example_steadystate/ExampleSteadystate.ipynb
@@ -6,7 +6,7 @@
    "source": [
     "# SBML import, observation model, sensitivity analysis, data export and visualization\n",
     "\n",
-    "This is an example using the [model_steadystate_scaled.sbml] model to demonstrate:\n",
+    "This is an example using the [model_steadystate_scaled.xml] model to demonstrate:\n",
     "\n",
     "* SBML import\n",
     "* specifying the observation model\n",
@@ -988,7 +988,7 @@
   {
    "cell_type": "markdown",
    "metadata": {},
-   "source": "The provided measurements can be visualized together with the simulation results by passing the `Expdata` to `amici.plotting.plot_observable_trajectories`:"
+   "source": "The provided measurements can be visualized together with the simulation results by passing the `ExpData` to `amici.plotting.plot_observable_trajectories`:"
   },
   {
    "cell_type": "code",


### PR DESCRIPTION
* requires libhdf5 on RTD
* exclude developer info from API doc
* minor doc fixes