### PR TITLE
Fix ModelStateDerived copy ctor

### DIFF
--- a/include/amici/model_state.h
+++ b/include/amici/model_state.h
@@ -175,6 +175,7 @@ struct ModelStateDerived {
             dwdx.set_ctx(sunctx_);
         }
         sspl_.set_ctx(sunctx_);
+        x_pos_tmp_.set_ctx(sunctx_);
         dwdw_.set_ctx(sunctx_);
         dJydy_dense_.set_ctx(sunctx_);
     }


### PR DESCRIPTION
`SUNContext` for `x_pos_tmp_` wasn't updated after copying.

Hopefully fixes #2607.