### PR TITLE
PEtab: fill in fixed parameter values for initial values

### DIFF
--- a/tests/petab_test_suite/test_petab_suite.py
+++ b/tests/petab_test_suite/test_petab_suite.py
@@ -66,11 +66,15 @@ def _test_case(case, model_type, version):
     )
     solver = model.getSolver()
     solver.setSteadyStateToleranceFactor(1.0)
+    problem_parameters = dict(
+        zip(problem.x_free_ids, problem.x_nominal_free, strict=True)
+    )
 
     # simulate
     ret = simulate_petab(
         problem,
         model,
+        problem_parameters=problem_parameters,
         solver=solver,
         log_level=logging.DEBUG,
     )
@@ -138,7 +142,7 @@ def _test_case(case, model_type, version):
         f"LLH: simulated: {llh}, expected: {gt_llh}, " f"match = {llhs_match}",
     )
 
-    check_derivatives(problem, model, solver)
+    check_derivatives(problem, model, solver, problem_parameters)
 
     if not all([llhs_match, simulations_match]) or not chi2s_match:
         logger.error(f"Case {case} failed.")
@@ -150,7 +154,10 @@ def _test_case(case, model_type, version):
 
 
 def check_derivatives(
-    problem: petab.Problem, model: amici.Model, solver: amici.Solver
+    problem: petab.Problem,
+    model: amici.Model,
+    solver: amici.Solver,
+    problem_parameters: dict[str, float],
 ) -> None:
     """Check derivatives using finite differences for all experimental
     conditions
@@ -159,11 +166,8 @@ def check_derivatives(
         problem: PEtab problem
         model: AMICI model matching ``problem``
         solver: AMICI solver
+        problem_parameters: Dictionary of problem parameters
     """
-    problem_parameters = {
-        t.Index: getattr(t, petab.NOMINAL_VALUE)
-        for t in problem.parameter_df.itertuples()
-    }
     solver.setSensitivityMethod(amici.SensitivityMethod.forward)
     solver.setSensitivityOrder(amici.SensitivityOrder.first)
     # Required for case 9 to not fail in


### PR DESCRIPTION
During PEtab parameter mapping, fill in fixed parameter values for initial values if requested. So far, this was only done for other parameters.

Update documentation for amici/petab/parameter_mapping.py

Fixes #2610.