### PR TITLE
Tests: Skip llh test for Isensee_JCB2018

### DIFF
--- a/.github/workflows/test_benchmark_collection_models.yml
+++ b/.github/workflows/test_benchmark_collection_models.yml
@@ -67,7 +67,7 @@ jobs:
         AMICI_PARALLEL_COMPILE: ""
       run: |
           cd tests/benchmark-models && pytest \
-              --durations=10
+              --durations=10 \
               --cov=amici \
               --cov-report=xml:"coverage_py.xml" \
               --cov-append \

--- a/tests/benchmark-models/test_petab_benchmark.py
+++ b/tests/benchmark-models/test_petab_benchmark.py
@@ -123,7 +123,9 @@ problems_for_llh_check = [
     "Elowitz_Nature2000",
     "Fiedler_BMCSystBiol2016",
     "Fujita_SciSignal2010",
-    "Isensee_JCB2018",
+    # Excluded until https://github.com/Benchmarking-Initiative/Benchmark-Models-PEtab/pull/253
+    #  is sorted out
+    # "Isensee_JCB2018",
     "Lucarelli_CellSystems2018",
     "Schwen_PONE2014",
     "Smith_BMCSystBiol2013",


### PR DESCRIPTION
Until it has been decided which model/dataset is the correct one, and the expected llh is updated accordingly.

See https://github.com/Benchmarking-Initiative/Benchmark-Models-PEtab/pull/253