### PR TITLE
Fix RDataReporting::observables_likelihood

### DIFF
--- a/python/tests/test_swig_interface.py
+++ b/python/tests/test_swig_interface.py
@@ -623,7 +623,9 @@ def test_reporting_mode_obs_llh(sbml_example_presimulation_module):
                 assert rdata.sy.size > 0
                 assert rdata.ssigmay.size > 0
                 assert rdata.sllh.size > 0
+                assert not np.isnan(rdata.sllh).any()
             case amici.SensitivityMethod.adjoint:
                 assert rdata.sy is None
                 assert rdata.ssigmay is None
                 assert rdata.sllh.size > 0
+                assert not np.isnan(rdata.sllh).any()

--- a/src/rdata.cpp
+++ b/src/rdata.cpp
@@ -811,6 +811,7 @@ void ReturnData::applyChainRuleFactorToSimulationResults(Model const& model) {
 
 void ReturnData::initializeObjectiveFunction(bool enable_chi2) {
     if (rdata_reporting == RDataReporting::likelihood
+        || rdata_reporting == RDataReporting::observables_likelihood
         || rdata_reporting == RDataReporting::full) {
         llh = 0.0;
         std::fill(sllh.begin(), sllh.end(), 0.0);


### PR DESCRIPTION
Fixes #2627. ReturnData.sllh was always NaN because it wasn't 0-initialized.