### PR TITLE
GHA: Use recent Ubuntu in test_matlab.yml

### DIFF
--- a/.github/workflows/test_matlab.yml
+++ b/.github/workflows/test_matlab.yml
@@ -12,7 +12,7 @@ jobs:
   matlab:
     name: Matlab
 
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
 
     steps:
     - uses: actions/checkout@v4

--- a/.github/workflows/test_matlab.yml
+++ b/.github/workflows/test_matlab.yml
@@ -12,7 +12,7 @@ jobs:
   matlab:
     name: Matlab
 
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-22.04
 
     steps:
     - uses: actions/checkout@v4


### PR DESCRIPTION
Ubuntu 20.04 is no longer supported.