### PR TITLE
Fix incorrect sympification of '=='

### DIFF
--- a/python/sdist/amici/sbml_import.py
+++ b/python/sdist/amici/sbml_import.py
@@ -3045,7 +3045,9 @@ def _parse_event_trigger(trigger: sp.Expr) -> sp.Expr:
         # convert relational expressions into trigger functions
         if isinstance(
             trigger,
-            sp.core.relational.LessThan | sp.core.relational.StrictLessThan,
+            sp.core.relational.LessThan
+            | sp.core.relational.StrictLessThan
+            | sp.core.relational.Equality,
         ):
             # y < x or y <= x
             return -root

--- a/python/sdist/amici/sbml_import.py
+++ b/python/sdist/amici/sbml_import.py
@@ -2812,12 +2812,18 @@ class SbmlImporter:
             try:
                 formula = sp.sympify(
                     _parse_logical_operators(math_string),
+                    # for correctly parsing '=='
+                    #  -> https://github.com/sympy/sympy/issues/26227
+                    evaluate=False,
                     locals=self._local_symbols,
                 )
             except TypeError as err:
                 if str(err) == "BooleanAtom not allowed in this context.":
                     formula = sp.sympify(
                         _parse_logical_operators(math_string),
+                        # for correctly parsing '=='
+                        #  -> https://github.com/sympy/sympy/issues/26227
+                        evaluate=False,
                         locals={
                             "true": sp.Float(1.0),
                             "false": sp.Float(0.0),


### PR DESCRIPTION
Don't evaluate during `sympy.sympify` to prevent incorrect handling of `==`.

Workaround for https://github.com/sympy/sympy/issues/26227.

```python
In [1]: sympify('a == 1')
Out[1]: False
In [2]: sympify('a == 1', evaluate=False)
Out[2]: a = 1
```