### PR TITLE
Temporarily require interpax<=0.3.6

### DIFF
--- a/python/sdist/pyproject.toml
+++ b/python/sdist/pyproject.toml
@@ -87,7 +87,7 @@ jax = [
     "jaxlib>=0.4.36",
     "diffrax>=0.6.1",
     "jaxtyping>=0.2.34",
-    "equinox>=0.11.10",
+    "equinox>=0.11.10,<=0.11.11",
     "optimistix>=0.0.9",
     "interpax>=0.3.3,<=0.3.6",
 ]

--- a/python/sdist/pyproject.toml
+++ b/python/sdist/pyproject.toml
@@ -89,7 +89,7 @@ jax = [
     "jaxtyping>=0.2.34",
     "equinox>=0.11.10",
     "optimistix>=0.0.9",
-    "interpax>=0.3.3",
+    "interpax>=0.3.3,<=0.3.6",
 ]
 
 [project.scripts]

--- a/python/sdist/pyproject.toml
+++ b/python/sdist/pyproject.toml
@@ -87,7 +87,7 @@ jax = [
     "jaxlib>=0.4.36",
     "diffrax>=0.6.1",
     "jaxtyping>=0.2.34",
-    "equinox>=0.11.10,<=0.11.11",
+    "equinox>=0.11.10",
     "optimistix>=0.0.9",
     "interpax>=0.3.3,<=0.3.6",
 ]


### PR DESCRIPTION
To prevent CI failures. See #2672.