### PR TITLE
SBML import: Handle unsolvable event triggers

### DIFF
--- a/python/sdist/amici/sbml_import.py
+++ b/python/sdist/amici/sbml_import.py
@@ -1875,9 +1875,16 @@ class SbmlImporter:
             return
 
         # check if events are guaranteed to not trigger at the same time
+        def try_solve_t(expr: sp.Expr) -> list:
+            """Try to solve the expression for time."""
+            try:
+                return sp.solve(expr, sbml_time_symbol)
+            except NotImplementedError:
+                return []
+
         trigger_times = [
-            sp.solve(event["value"], sbml_time_symbol)
-            for event_sym, event in self.symbols[SymbolId.EVENT].items()
+            try_solve_t(event["value"])
+            for event in self.symbols[SymbolId.EVENT].values()
         ]
         # for now, we only check for single/fixed/unique time points, but there
         # are probably other cases we could cover


### PR DESCRIPTION
Not all event trigger functions can be solved for `time` when trying to compute the trigger time. Handle sympy errors in that case.