### PR TITLE
Prevent segfaults under pytest after swig4.3 wrapping 

### DIFF
--- a/.github/workflows/test_python_cplusplus.yml
+++ b/.github/workflows/test_python_cplusplus.yml
@@ -288,8 +288,7 @@ jobs:
 
     - name: Python tests
       run: |
-        # ignore warnings until https://github.com/swig/swig/issues/3061 is resolved
-        scripts/run-python-tests.sh -W ignore:: \
+        scripts/run-python-tests.sh \
           test_pregenerated_models.py \
           test_splines_short.py \
           test_misc.py
@@ -351,8 +350,7 @@ jobs:
 
     - name: Python tests
       run: |
-        # ignore warnings until https://github.com/swig/swig/issues/3061 is resolved
-        scripts/run-python-tests.sh -W ignore:: \
+        scripts/run-python-tests.sh \
           --ignore=test_pregenerated_models.py \
           --ignore=test_splines_short.py \
           --ignore=test_misc.py

--- a/python/sdist/amici/__init__.py
+++ b/python/sdist/amici/__init__.py
@@ -16,6 +16,7 @@ from pathlib import Path
 from types import ModuleType
 from typing import Any
 from collections.abc import Callable
+import warnings
 
 
 def _get_amici_path():
@@ -102,7 +103,18 @@ __commit__ = _get_commit_hash()
 # Import SWIG module and swig-dependent submodules if required and available
 if not _imported_from_setup():
     if has_clibs:
-        from . import amici
+        # prevent segfaults under pytest
+        #  see also:
+        #  https://github.com/swig/swig/issues/2881
+        #  https://github.com/AMICI-dev/AMICI/issues/2565
+        with warnings.catch_warnings():
+            warnings.filterwarnings(
+                "ignore",
+                category=DeprecationWarning,
+                message="builtin type .* has no __module__ attribute",
+            )
+            from . import amici
+
         from .amici import *
 
         # has to be done before importing readSolverSettingsFromHDF5

--- a/python/sdist/amici/__init__.py
+++ b/python/sdist/amici/__init__.py
@@ -247,7 +247,17 @@ def import_model_module(
     module_path_matlab = Path(model_root, f"{module_name}.py")
     if not module_path.is_file() and module_path_matlab.is_file():
         with set_path(model_root):
-            return _module_from_path(module_name, module_path_matlab)
+            # prevent segfaults under pytest
+            #  see also:
+            #  https://github.com/swig/swig/issues/2881
+            #  https://github.com/AMICI-dev/AMICI/issues/2565
+            with warnings.catch_warnings():
+                warnings.filterwarnings(
+                    "ignore",
+                    category=DeprecationWarning,
+                    message="builtin type .* has no __module__ attribute",
+                )
+                return _module_from_path(module_name, module_path_matlab)
 
     module = _module_from_path(module_name, module_path)
     module._self = module

--- a/python/sdist/amici/__init__.template.py
+++ b/python/sdist/amici/__init__.template.py
@@ -3,7 +3,7 @@
 import sys
 from pathlib import Path
 import amici
-
+import warnings
 
 # Ensure we are binary-compatible, see #556
 if "TPL_AMICI_VERSION" != amici.__version__:
@@ -16,9 +16,22 @@ if "TPL_AMICI_VERSION" != amici.__version__:
         "version currently installed."
     )
 
-TPL_MODELNAME = amici._module_from_path(
-    "TPL_MODELNAME.TPL_MODELNAME", Path(__file__).parent / "TPL_MODELNAME.py"
-)
+# prevent segfaults under pytest
+#  see also:
+#  https://github.com/swig/swig/issues/2881
+#  https://github.com/AMICI-dev/AMICI/issues/2565
+with warnings.catch_warnings():
+    warnings.filterwarnings(
+        "ignore",
+        category=DeprecationWarning,
+        message="builtin type .* has no __module__ attribute",
+    )
+
+    TPL_MODELNAME = amici._module_from_path(
+        "TPL_MODELNAME.TPL_MODELNAME",
+        Path(__file__).parent / "TPL_MODELNAME.py",
+    )
+
 for var in dir(TPL_MODELNAME):
     if not var.startswith("_"):
         globals()[var] = getattr(TPL_MODELNAME, var)


### PR DESCRIPTION
#2565 now also triggers under Ubuntu 25.04 that comes with swig4.3.0.

It seems like it will take another while until the underlying issue will be fixed in swig itself.

Ignoring the problematic warnings when importing swig-extensions prevents the segfaults.

Reverts https://github.com/AMICI-dev/AMICI/pull/2572.

Fixes #2565.