### PR TITLE
Fix `SetuptoolsDeprecationWarning: \`project.license\` as a TOML table is deprecated`

### DIFF
--- a/python/sdist/pyproject.toml
+++ b/python/sdist/pyproject.toml
@@ -2,7 +2,7 @@
 # https://setuptools.pypa.io/en/latest/userguide/index.html
 [build-system]
 requires = [
-    "setuptools>=61",
+    "setuptools>=77",
     "wheel",
     "numpy>=2.0",
     "cmake-build-extension==0.6.0",
@@ -29,7 +29,7 @@ dependencies = [
     "setuptools>=48",
     "mpmath",
 ]
-license = {text = "BSD 3-Clause License"}
+license = "BSD-3-Clause"
 authors = [
     {name = "Fabian Froehlich", email = "froehlichfab@gmail.com"},
     {name = "Daniel Weindl", email = "sci@danielweindl.de"},
@@ -46,7 +46,6 @@ keywords =["differential equations", "simulation", "ode", "cvodes",
 classifiers = [
     "Development Status :: 5 - Production/Stable",
     "Intended Audience :: Science/Research",
-    "License :: OSI Approved :: BSD License",
     "Operating System :: POSIX :: Linux",
     "Operating System :: MacOS :: MacOS X",
     "Programming Language :: Python",


### PR DESCRIPTION
Fixes #2695:

```
          ********************************************************************************
          Please use a simple string containing a SPDX expression for `project.license`. You can also use `project.license-files`. (Both options available on setuptools>=77.0.0).

          By 2026-Feb-18, you need to update your project and remove deprecated calls
          or your builds will no longer be supported.

          See https://packaging.python.org/en/latest/guides/writing-pyproject-toml/#license for details.
          ********************************************************************************
```
and 
```
          ********************************************************************************
          Please consider removing the following classifiers in favor of a SPDX license expression:

          License :: OSI Approved :: BSD License

          See https://packaging.python.org/en/latest/guides/writing-pyproject-toml/#license for details.
          ********************************************************************************
``` 