### PR TITLE
doc: Enable building docs with Python 3.13

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -24,4 +24,4 @@ build:
     - libhdf5-serial-dev
     - swig
   tools:
-    python: "3.11"
+    python: "3.13"

--- a/doc/rtd_requirements.txt
+++ b/doc/rtd_requirements.txt
@@ -2,11 +2,15 @@
 sphinx<8
 mock>=5.0.2
 setuptools>=67.7.2
-pysb>=1.11.0
+# pysb>=1.11.0
+# WIP PR for compatibility with recent sympy
+#  https://github.com/pysb/pysb/pull/599
+#  for building the documentation, we don't care whether this fully works
+git+https://github.com/pysb/pysb@0afeaab385e9a1d813ecf6fdaf0153f4b91358af
 jax>=0.4.26
 diffrax>=0.5.0
 interpax>=0.3.4
-matplotlib==3.7.1
+matplotlib>=3.7.1
 nbsphinx==0.9.1
 nbformat==5.8.0
 recommonmark>=0.7.1
@@ -21,9 +25,8 @@ exhale>=0.3.7
 sphinxcontrib-matlabdomain>=0.20.0
 sphinxcontrib-napoleon>=0.7
 pygments>=2.15.1
-Jinja2==3.1.4
+Jinja2>=3.1.6
 git+https://github.com/readthedocs/readthedocs-sphinx-ext
 ipykernel
 -e git+https://github.com/Benchmarking-Initiative/Benchmark-Models-PEtab.git@master#subdirectory=src/python&egg=benchmark_models_petab
 -e python/sdist/
-numpy<2.0


### PR DESCRIPTION
Work around some pysb/sympy/petab/numpy/Python compatibilty issues.