### PR TITLE
SBML import: Handle unsolvable event triggers

### DIFF
--- a/python/sdist/amici/de_model_components.py
+++ b/python/sdist/amici/de_model_components.py
@@ -737,7 +737,11 @@ class Event(ModelQuantity):
         self._initial_value = initial_value
 
         # expression(s) for the timepoint(s) at which the event triggers
-        self._t_root = sp.solve(self.get_val(), amici_time_symbol)
+        try:
+            self._t_root = sp.solve(self.get_val(), amici_time_symbol)
+        except NotImplementedError:
+            # the trigger can't be solved for `t`
+            self._t_root = []
 
     def get_initial_value(self) -> bool:
         """


### PR DESCRIPTION
Not all event trigger functions can be solved for `time` when trying to compute the trigger time. Handle sympy errors in that case.

This location was missed in https://github.com/AMICI-dev/AMICI/pull/2686.