### PR TITLE
SBML import: avoid repeated xdot==0 checks

### DIFF
--- a/.github/workflows/test_sbml_semantic_test_suite.yml
+++ b/.github/workflows/test_sbml_semantic_test_suite.yml
@@ -10,6 +10,7 @@ on:
       - .github/workflows/test_sbml_semantic_test_suite.yml
       - python/sdist/amici/de_export.py
       - python/sdist/amici/de_model_components.py
+      - python/sdist/amici/de_model.py
       - python/sdist/amici/sbml_import.py
       - python/sdist/amici/import_utils.py
       - scripts/run-SBMLTestsuite.sh

--- a/python/sdist/amici/de_model.py
+++ b/python/sdist/amici/de_model.py
@@ -1693,9 +1693,14 @@ class DEModel:
             ]
 
         elif name == "deltasx":
-            if self.num_states_solver() * self.num_par() == 0:
+            if (
+                self.num_states_solver() * self.num_par() * self.num_events()
+                == 0
+            ):
                 self._eqs[name] = []
                 return
+
+            xdot_is_zero = smart_is_zero_matrix(self.eq("xdot"))
 
             event_eqs = []
             for ie, event in enumerate(self._events):
@@ -1703,9 +1708,11 @@ class DEModel:
 
                 # need to check if equations are zero since we are using
                 # symbols
-                if not smart_is_zero_matrix(
-                    self.eq("stau")[ie]
-                ) and not smart_is_zero_matrix(self.eq("xdot")):
+
+                if (
+                    not smart_is_zero_matrix(self.eq("stau")[ie])
+                    and not xdot_is_zero
+                ):
                     tmp_eq += smart_multiply(
                         self.sym("xdot") - self.sym("xdot_old"),
                         self.sym("stau").T,
@@ -1739,7 +1746,7 @@ class DEModel:
                         self.eq("ddeltaxdx")[ie], tmp_dxdp
                     )
 
-                else:
+                elif not xdot_is_zero:
                     tmp_eq = smart_multiply(
                         self.sym("xdot") - self.sym("xdot_old"),
                         self.eq("stau")[ie],


### PR DESCRIPTION
Avoid checking for `xdot==0` for every single event when computing `deltasx`.

Avoid avoid some extra matrix multiplication, which may result in undefined symbols for some funny models where xdot==0.

Update SBML test suite triggers.
