### PR TITLE
GHA: Use more recent Python

### DIFF
--- a/.github/workflows/deploy_branch.yml
+++ b/.github/workflows/deploy_branch.yml
@@ -9,7 +9,7 @@ jobs:
 
     strategy:
       matrix:
-        python-version: ["3.11"]
+        python-version: ["3.12"]
 
     steps:
     - name: Set up Python ${{ matrix.python-version }}

--- a/.github/workflows/deploy_protected.yml
+++ b/.github/workflows/deploy_protected.yml
@@ -36,7 +36,7 @@ jobs:
 
     strategy:
       matrix:
-        python-version: ["3.11"]
+        python-version: ["3.12"]
 
     steps:
     - name: Set up Python ${{ matrix.python-version }}

--- a/.github/workflows/deploy_release.yml
+++ b/.github/workflows/deploy_release.yml
@@ -12,7 +12,7 @@ jobs:
 
     strategy:
       matrix:
-        python-version: ["3.11"]
+        python-version: ["3.13"]
 
     environment:
       name: pypi

--- a/.github/workflows/test_benchmark_collection_models.yml
+++ b/.github/workflows/test_benchmark_collection_models.yml
@@ -22,7 +22,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: [ "3.11" ]
+        python-version: [ "3.12" ]
         extract_subexpressions: ["true", "false"]
     env:
       AMICI_EXTRACT_CSE: ${{ matrix.extract_subexpressions }}

--- a/.github/workflows/test_petab_test_suite.yml
+++ b/.github/workflows/test_petab_test_suite.yml
@@ -22,7 +22,7 @@ jobs:
 
     strategy:
       matrix:
-        python-version: ["3.11"]
+        python-version: ["3.12"]
 
     steps:
       - name: Set up Python ${{ matrix.python-version }}

--- a/.github/workflows/test_python_cplusplus.yml
+++ b/.github/workflows/test_python_cplusplus.yml
@@ -15,7 +15,7 @@ jobs:
 
     strategy:
       matrix:
-        python-version: [ "3.11" ]
+        python-version: [ "3.12" ]
 
     steps:
     - name: Cache
@@ -122,7 +122,7 @@ jobs:
 
     strategy:
       matrix:
-        python-version: [ "3.10" ]
+        python-version: [ "3.12" ]
 
     steps:
     - name: Set up Python ${{ matrix.python-version }}

--- a/.github/workflows/test_sbml_semantic_test_suite.yml
+++ b/.github/workflows/test_sbml_semantic_test_suite.yml
@@ -30,7 +30,7 @@ jobs:
       matrix:
         cases: ["1-250", "251-500", "501-750", "751-1000",
                 "1000-1250", "1251-"]
-        python-version: [ "3.11" ]
+        python-version: [ "3.13" ]
 
     steps:
     - name: Set up Python ${{ matrix.python-version }}

--- a/.github/workflows/test_valgrind.yml
+++ b/.github/workflows/test_valgrind.yml
@@ -21,7 +21,7 @@ jobs:
 
     strategy:
       matrix:
-        python-version: [ "3.11" ]
+        python-version: [ "3.13" ]
 
     env:
       ENABLE_AMICI_DEBUGGING: "TRUE"
@@ -71,7 +71,7 @@ jobs:
 
     strategy:
       matrix:
-        python-version: [ "3.11" ]
+        python-version: [ "3.13" ]
 
     env:
       ENABLE_AMICI_DEBUGGING: "TRUE"


### PR DESCRIPTION
Reduces the number of test failures due to libsbml/swig/Python issues (https://github.com/sbmlteam/python-libsbml/issues/40).