### PR TITLE
doc: Update installation on Fedora

### DIFF
--- a/doc/python_installation.rst
+++ b/doc/python_installation.rst
@@ -64,7 +64,7 @@ Install AMICI:
 
    pip3 install amici
 
-Fedora 32
+Fedora 42
 ---------
 
 Install the AMICI dependencies via ``apt``
@@ -72,7 +72,7 @@ Install the AMICI dependencies via ``apt``
 
 .. code-block:: bash
 
-   sudo dnf install blas-devel swig
+   sudo dnf install openblas-devel swig
 
 Install AMICI:
 


### PR DESCRIPTION
Update amici installation instructions for fedora.

`blas-devel` should work in principle as it contains both Fortran BLAS and CBLAS, but CMake's FindBLAS will only link the Fortran BLAS (apparently [intended](https://gitlab.kitware.com/cmake/cmake/-/issues/19381), although not well [documented](https://cmake.org/cmake/help/latest/module/FindBLAS.html)). This could be addressed by custom linker flags, but just using openblas seems easier.