### PR TITLE
Support `!=` in trigger functions

### DIFF
--- a/doc/python_interface.rst
+++ b/doc/python_interface.rst
@@ -26,7 +26,7 @@ AMICI can import :term:`SBML` models via the
 Status of SBML support in Python-AMICI
 ++++++++++++++++++++++++++++++++++++++
 
-Python-AMICI currently **passes 1268 out of the 1821 (~70%) test cases** from
+Python-AMICI currently **passes 1271 out of the 1821 (~70%) test cases** from
 the semantic
 `SBML Test Suite <https://github.com/sbmlteam/sbml-test-suite/>`_
 (`current status <https://github.com/AMICI-dev/AMICI/actions>`_).

--- a/python/sdist/amici/sbml_import.py
+++ b/python/sdist/amici/sbml_import.py
@@ -54,6 +54,7 @@ from .import_utils import (
     _parse_piecewise_to_heaviside,
     _xor_to_or,
     _eq_to_and,
+    _ne_to_or,
 )
 from .logging import get_logger, log_execution_time, set_log_level
 from .sbml_utils import SBMLException
@@ -3217,8 +3218,9 @@ def _parse_event_trigger(trigger: sp.Expr) -> sp.Expr:
 
     # rewrite n-ary XOR to OR to be handled below:
     trigger = trigger.replace(sp.Xor, _xor_to_or)
-    # rewrite equality
+    # rewrite ==, !=
     trigger = trigger.replace(sp.Eq, _eq_to_and)
+    trigger = trigger.replace(sp.Ne, _ne_to_or)
 
     # or(x,y): any of {x,y} is > 0: sp.Max(x, y)
     if isinstance(trigger, sp.Or):


### PR DESCRIPTION
Support `!=` in trigger functions.

Closes #2715.

Tested through SBML semantic cases 00957, 00958, 01486.