### PR TITLE
Fix bool to float conversion issues during SBML import

### DIFF
--- a/python/sdist/amici/de_export.py
+++ b/python/sdist/amici/de_export.py
@@ -210,6 +210,15 @@ class DEExporter:
         self.model_path: str = ""
         self.model_swig_path: str = ""
 
+        if (
+            de_model.num_states_solver() == 0
+            and de_model.num_events_solver() > 0
+        ):
+            raise NotImplementedError(
+                "Root-finding for models without differential states is "
+                "currently not supported."
+            )
+
         self.set_name(model_name)
         self.set_paths(outdir)
 


### PR DESCRIPTION
* Only floatify Boolean atoms where relevant
* Ensure that piecewise functions introduced through bool->float conversion get the proper piecewise treatment
* Raise in case of models with root functions but without differential states. Currently, root-finding wouldn't happen in such a case.

Closes #2717.