### PR TITLE
doc: Add history section

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,11 +14,11 @@ differential equation models specified as [SBML](http://sbml.org/)
 or [PySB](http://pysb.org/)
 and automatically compiles such models into Python modules, C++ libraries or
 Matlab `.mex` simulation files.
+The generated model expressions along with the corresponding sensitivity
+equations are transformed into native C++ code which allows for a significantly
+faster simulation.
 
-In contrast to the (no longer maintained)
-[sundialsTB](https://computing.llnl.gov/projects/sundials/sundials-software)
-Matlab interface, all necessary functions are transformed into native
-C++ code, which allows for a significantly faster simulation.
+**NOTE: The MATLAB interface is no longer supported and will be removed soon.**
 
 Beyond forward integration, the compiled simulation file also allows for
 forward sensitivity analysis, steady state sensitivity analysis and

--- a/doc/background.rst
+++ b/doc/background.rst
@@ -1,7 +1,44 @@
 Background
 ==========
 
-*This section is to be extended.*
+History
+-------
+
+The development of AMICI started out in 2015 by Fabian Fröhlich in the
+Jan Hasenauer lab as an *Advanced MATLAB Interface to CVODES and IDAS*.
+The goal was to provide a fast and flexible interface to the SUNDIALS
+:term:`CVODES` and :term:`IDAS` solvers for the efficient simulation and
+sensitivity analysis of large-scale biochemical reaction networks while
+supporting high-level model descriptions in :term:`SBML` as the de facto
+standard for systems biology models.
+In contrast to the (no longer maintained)
+`sundialsTB <https://computing.llnl.gov/projects/sundials/sundials-software>`__
+MATLAB interface, all necessary functions were transformed into native
+C++ code, which allowed for significantly faster simulations.
+
+Over time, various other researchers contributed to AMICI's development.
+AMICI's C core was reshaped into a reusable stand-alone C++ library,
+that was the basis for its Python interface. These additional interfaces lead
+to the reinterpretation of "AMICI" as "Advanced *Multi-language* Interface to
+CVODES and IDAS".
+
+Due to changes in MATLAB's symbolic math library and to foster open and
+reusable research, the development of AMICI's MATLAB interface
+was meanwhile discontinued, and the focus shifted to the Python interface.
+
+Over the years, AMICI has evolved into a powerful and flexible
+tool for the simulation and sensitivity analysis of large-scale
+biochemical reaction networks, supporting different input formats,
+different types of sensitivity analysis, discrete events,
+and many other features.
+Meanwhile, the use of AMICI has been documented in around 100 research papers
+from different labs and companies.
+
+AMICI is currently maintained by Fabian Fröhlich
+(`@FFroehlich <https://github.com/FFroehlich>`__,
+`Fröhlich lab <https://www.frohlichlab.com/>`__) and Daniel Weindl
+(`@dweindl <https://github.com/dweindl>`__,
+`Hasenauer lab <https://www.mathematics-and-life-sciences.uni-bonn.de/en/research/hasenauer-group>`__).
 
 Publications on various features of AMICI
 -----------------------------------------


### PR DESCRIPTION
Add a small section on the history of AMICI. Announce the removal of the MATLAB interface.