### PR TITLE
Support for event priorities

### DIFF
--- a/doc/python_interface.rst
+++ b/doc/python_interface.rst
@@ -26,7 +26,7 @@ AMICI can import :term:`SBML` models via the
 Status of SBML support in Python-AMICI
 ++++++++++++++++++++++++++++++++++++++
 
-Python-AMICI currently **passes 1271 out of the 1821 (~70%) test cases** from
+Python-AMICI currently **passes 1273 out of the 1821 (~70%) test cases** from
 the semantic
 `SBML Test Suite <https://github.com/sbmlteam/sbml-test-suite/>`_
 (`current status <https://github.com/AMICI-dev/AMICI/actions>`_).

--- a/python/sdist/amici/de_export.py
+++ b/python/sdist/amici/de_export.py
@@ -995,7 +995,13 @@ class DEExporter:
         def event_initializer(event: Event) -> str:
             """Return amici::Event initializer for the given event."""
             init = AmiciCxxCodePrinter.print_bool(event.get_initial_value())
-            return f'Event("{event.get_id()}", {init})'
+            priority = event.get_priority()
+            priority = (
+                "NAN"
+                if priority is None
+                else self._code_printer.doprint(priority)
+            )
+            return f'Event("{event.get_id()}", {init}, {priority})'
 
         def event_initializer_list() -> str:
             if events := self.model.events():

--- a/python/sdist/amici/de_model_components.py
+++ b/python/sdist/amici/de_model_components.py
@@ -739,7 +739,7 @@ class Event(ModelQuantity):
 
         if priority is not None and not priority.is_Number:
             raise NotImplementedError(
-                "Only fixed numbers are currently supported as event priority."
+                "Currently, only numeric values are supported as event priority."
             )
         # the priority of the event assignment
         self._priority = priority

--- a/python/sdist/amici/de_model_components.py
+++ b/python/sdist/amici/de_model_components.py
@@ -710,6 +710,7 @@ class Event(ModelQuantity):
         value: sp.Expr,
         state_update: sp.Expr | None,
         initial_value: bool | None = True,
+        priority: sp.Basic | None = None,
     ):
         """
         Create a new Event instance.
@@ -736,6 +737,13 @@ class Event(ModelQuantity):
         self._state_update = state_update
         self._initial_value = initial_value
 
+        if priority is not None and not priority.is_Number:
+            raise NotImplementedError(
+                "Only fixed numbers are currently supported as event priority."
+            )
+        # the priority of the event assignment
+        self._priority = priority
+
         # expression(s) for the timepoint(s) at which the event triggers
         try:
             self._t_root = sp.solve(self.get_val(), amici_time_symbol)
@@ -751,6 +759,10 @@ class Event(ModelQuantity):
             initial value formula
         """
         return self._initial_value
+
+    def get_priority(self) -> sp.Basic | None:
+        """Return the priority of the event assignment."""
+        return self._priority
 
     def __eq__(self, other):
         """

--- a/python/sdist/amici/gradient_check.py
+++ b/python/sdist/amici/gradient_check.py
@@ -226,7 +226,14 @@ def check_derivatives(
     if edata is not None:
         fields.append("llh")
 
+    # only check the sensitivities w.r.t. the selected parameters
+    plist = model.getParameterList()
+    if edata and edata.plist:
+        plist = edata.plist
+
     for ip, pval in enumerate(p):
+        if plist and ip not in plist:
+            continue
         if pval == 0.0 and skip_zero_pars:
             continue
         check_finite_difference(

--- a/python/sdist/amici/sbml_import.py
+++ b/python/sdist/amici/sbml_import.py
@@ -761,7 +761,7 @@ class SbmlImporter:
                 args += ["value"]
 
             if symbol_name == SymbolId.EVENT:
-                args += ["state_update", "initial_value"]
+                args += ["state_update", "initial_value", "priority"]
             elif symbol_name == SymbolId.OBSERVABLE:
                 args += ["transformation"]
             elif symbol_name == SymbolId.EVENT_OBSERVABLE:
@@ -931,12 +931,13 @@ class SbmlImporter:
                         "currently not supported in AMICI."
                     )
             # Check for priorities
-            if event.getPriority() is not None:
-                raise SBMLException(
-                    f"Event {event_id} has a priority "
-                    "specified. This is currently not "
-                    "supported in AMICI."
-                )
+            if (prio := event.getPriority()) is not None:
+                if (prio := self._sympify(prio)) and not prio.is_Number:
+                    raise SBMLException(
+                        f"Event {event_id} has a non-numeric priority "
+                        "specified. This is currently not "
+                        "supported in AMICI."
+                    )
 
             # check trigger
             trigger_sbml = event.getTrigger()
@@ -1915,6 +1916,7 @@ class SbmlImporter:
                 "state_update": sp.MutableDenseMatrix(bolus),
                 "initial_value": initial_value,
                 "use_values_from_trigger_time": use_trig_val,
+                "priority": self._sympify(event.getPriority()),
             }
 
         # Check `useValuesFromTriggerTime` attribute
@@ -1956,18 +1958,6 @@ class SbmlImporter:
             if len(trigger_times) == len(set(trigger_times)):
                 # all trigger times are unique
                 return
-
-        # If all events assign to different species, we are fine. This is the
-        # case if the list of assigned-to variables across all events contains
-        # only unique values.
-        assigned_to_species = [
-            variable
-            for event in self.symbols[SymbolId.EVENT].values()
-            for variable, update in zip(state_vector, event["state_update"])
-            if not update.is_zero
-        ]
-        if len(assigned_to_species) == len(set(assigned_to_species)):
-            return
 
         # if all assignments are absolute (not referring to other non-constant
         # model entities), we are fine.

--- a/python/sdist/amici/sbml_import.py
+++ b/python/sdist/amici/sbml_import.py
@@ -933,6 +933,10 @@ class SbmlImporter:
             # Check for priorities
             if (prio := event.getPriority()) is not None:
                 if (prio := self._sympify(prio)) and not prio.is_Number:
+                    # Computing sensitivities with respect to event priorities
+                    #  is not implemented, so let's import such models at all.
+                    #  We could support expressions that only depend on
+                    #  constant parameters, though. But who needs that anyway?
                     raise SBMLException(
                         f"Event {event_id} has a non-numeric priority "
                         "specified. This is currently not "

--- a/python/sdist/amici/swig_wrappers.py
+++ b/python/sdist/amici/swig_wrappers.py
@@ -58,7 +58,7 @@ def runAmiciSimulation(
         and solver.getSensitivityOrder() == amici_swig.SensitivityOrder.first
     ):
         warnings.warn(
-            "Adjoint sensitivity analysis for models with discontinuous right hand sides (events/piecewise functions) has not been thoroughly tested."
+            "Adjoint sensitivity analysis for models with discontinuous right hand sides (events/piecewise functions) has not been thoroughly tested. "
             "Sensitivities might be wrong. Tracked at https://github.com/AMICI-dev/AMICI/issues/18. "
             "Adjoint sensitivity analysis may work if the location of the discontinuity is not parameter-dependent, but we still recommend testing accuracy of gradients.",
             stacklevel=1,

--- a/python/tests/test_events.py
+++ b/python/tests/test_events.py
@@ -983,5 +983,5 @@ def test_random_event_ordering():
         assert np.allclose(
             [outcomes.count(1), outcomes.count(2), outcomes.count(3)],
             [N / 3, N / 3, N / 3],
-            rtol=0.1,
+            rtol=0.25,
         )

--- a/src/model.cpp
+++ b/src/model.cpp
@@ -207,7 +207,7 @@ Model::Model(
         // for matlab generated models, create event objects here
         for (int ie = 0; ie < ne; ie++) {
             events_.emplace_back(
-                std::string("event_") + std::to_string(ie), true
+                std::string("event_") + std::to_string(ie), true, 0
             );
         }
     }


### PR DESCRIPTION
Support plain numeric priorities of SBML events (not the arbitrary expressions that SBML would allow).

If there are multiple event assignments to be executed at the same model time, the ones with higher priority values come first.

Closes #2718.

Also:
* remove an incorrect check for whether we support `useValueFromTriggerTime=True`
 