### PR TITLE
Fix stale `ForwardProblem::xdot_old_`

### DIFF
--- a/include/amici/forwardproblem.h
+++ b/include/amici/forwardproblem.h
@@ -325,16 +325,25 @@ class ForwardProblem {
      * (dimension: dynamic) */
     std::vector<realtype> discs_;
 
-    /** array of state vectors (dimension nx) for all so far encountered
-     * discontinuities, extended as needed (dimension dynamic) */
+    /**
+     * array of post-event state vectors (dimension nx) for all so far
+     * encountered discontinuities, (extended as needed;
+     * after event processing, same dimension as discs_)
+     */
     std::vector<AmiVector> x_disc_;
 
-    /** array of differential state vectors (dimension nx) for all so far
-     * encountered discontinuities, extended as needed (dimension dynamic) */
+    /**
+     * array of post-event differential state vectors (dimension nx) for all so
+     * far encountered discontinuities, (extended as needed; after event
+     * processing, same dimension as discs_)
+     */
     std::vector<AmiVector> xdot_disc_;
 
-    /** array of old differential state vectors (dimension nx) for all so far
-     * encountered discontinuities, extended as needed (dimension dynamic) */
+    /**
+     * array of old (pre-event) differential state vectors (dimension nx) for
+     * all so far encountered discontinuities, (extended as needed; after event
+     * processing, same dimension as discs_)
+     */
     std::vector<AmiVector> xdot_old_disc_;
 
     /** Events that are waiting to be handled at the current timepoint. */

--- a/src/forwardproblem.cpp
+++ b/src/forwardproblem.cpp
@@ -286,6 +286,10 @@ void ForwardProblem::handleEvent(
             model->addStateSensitivityEventUpdate(
                 sx_, ie, t_, x_old_, xdot_, xdot_old_, stau_
             );
+        } else if (solver->computingASA()) {
+            // store x to compute jump in discontinuity
+            x_disc_.push_back(x_);
+            xdot_disc_.push_back(xdot_);
         }
 
         // check if the event assignment triggered another event
@@ -376,9 +380,6 @@ void ForwardProblem::store_pre_event_state(bool seflag, bool initial_event) {
             std::ranges::fill(stau_, 0.0);
         }
     } else if (solver->computingASA()) {
-        // store x to compute jump in discontinuity
-        x_disc_.push_back(x_);
-        xdot_disc_.push_back(xdot_);
         xdot_old_disc_.push_back(xdot_old_);
     }
 }

--- a/src/forwardproblem.cpp
+++ b/src/forwardproblem.cpp
@@ -355,10 +355,10 @@ void ForwardProblem::store_pre_event_state(bool seflag, bool initial_event) {
     if (solver->getSensitivityOrder() >= SensitivityOrder::first) {
         // store x and xdot to compute jump in sensitivities
         x_old_.copy(x_);
-    }
-    if (solver->computingFSA()) {
         model->fxdot(t_, x_, dx_, xdot_);
         xdot_old_.copy(xdot_);
+    }
+    if (solver->computingFSA()) {
         // compute event-time derivative only for primary events, we get
         // into trouble with multiple simultaneously firing events here (but
         // is this really well defined then?), in that case just use the


### PR DESCRIPTION
`ForwardProblem::xdot_old_` is required for adjoint sensitivity analysis, but it was only ever updated if we do forward sensitivity analysis.

Also fix `ForwardProblem::x_disc_` and `ForwardProblem::xdot_disc_` that should contain POST-event values, but had pre-event values.