### PR TITLE
Fix AlgebraicRule processing

### DIFF
--- a/python/sdist/amici/sbml_import.py
+++ b/python/sdist/amici/sbml_import.py
@@ -1533,11 +1533,17 @@ class SbmlImporter:
                 and sbml_var.isSetBoundaryCondition()
                 and sbml_var.getBoundaryCondition()
             )
-            is_involved_in_reaction = is_species and not smart_is_zero_matrix(
-                self.stoichiometric_matrix[
-                    list(self.symbols[SymbolId.SPECIES].keys()).index(symbol),
-                    :,
-                ]
+            is_involved_in_reaction = (
+                is_species
+                and symbol in self.symbols[SymbolId.SPECIES]
+                and not smart_is_zero_matrix(
+                    self.stoichiometric_matrix[
+                        list(self.symbols[SymbolId.SPECIES].keys()).index(
+                            symbol
+                        ),
+                        :,
+                    ]
+                )
             )
             if (
                 is_species


### PR DESCRIPTION
Fix the check for whether a species that occurs in an AlgebraicRule participates in any reaction. If that species occurs in multiple AlgebraicRule, it will have been removed from `self.symbols[SymbolId.SPECIES]` by the time the second rule is processed.