### PR TITLE
Fix dimension bug in ExpDataView

### DIFF
--- a/python/sdist/amici/__init__.py
+++ b/python/sdist/amici/__init__.py
@@ -186,11 +186,11 @@ class set_path:
         self.path: str = str(path)
 
     def __enter__(self):
-        self.orginal_path = sys.path.copy()
+        self.original_path = sys.path.copy()
         sys.path = [self.path]
 
     def __exit__(self, exc_type, exc_value, traceback):
-        sys.path = self.orginal_path
+        sys.path = self.original_path
 
 
 def _module_from_path(module_name: str, module_path: Path | str) -> ModuleType:

--- a/python/sdist/amici/numpy.py
+++ b/python/sdist/amici/numpy.py
@@ -311,7 +311,7 @@ class ReturnDataView(SwigPtrView):
         self, item: str
     ) -> np.ndarray | ReturnDataPtr | ReturnData | float:
         """
-        Access fields by name.s
+        Access fields by name.
 
         Custom ``__getitem__`` implementation shim to map ``t`` to ``ts``.
 
@@ -416,7 +416,7 @@ class ExpDataView(SwigPtrView):
                 len(edata.fixedParametersPreequilibration)
             ],
             "fixedParametersPresimulation": [
-                len(edata.fixedParametersPreequilibration)
+                len(edata.fixedParametersPresimulation)
             ],
         }
         edata.ts = edata.ts_


### PR DESCRIPTION
## Summary
- fix dimension for `fixedParametersPresimulation`
- fix typo in ReturnDataView docstring
- rename variable to `original_path` in context manager

## Testing
- `pytest --version` *(fails: command not found)*