### PR TITLE
Don't attempt FSA when nx==0

### DIFF
--- a/include/amici/solver.h
+++ b/include/amici/solver.h
@@ -812,7 +812,7 @@ class Solver {
     bool computingFSA() const {
         return getSensitivityOrder() >= SensitivityOrder::first
                && getSensitivityMethod() == SensitivityMethod::forward
-               && nplist() > 0;
+               && nplist() > 0 && nx() > 0;
     }
 
     /**


### PR DESCRIPTION
## Summary
- avoid segfault when computing forward sensitivities on models without state variables

## Testing
- `This environment doesn't have network access after setup, so Codex couldn't run certain commands. Consider configuring a setup script in your Codex environment to install dependencies.`