### PR TITLE
Implement SBML useValuesFromTriggerTime support

### DIFF
--- a/include/amici/event.h
+++ b/include/amici/event.h
@@ -31,10 +31,12 @@ class Event {
      * @param initial_value Initial value of the root function
      * @param priority Priority of the event assignments
      */
-    Event(std::string id, bool initial_value, realtype priority)
+    Event(std::string id, bool initial_value, realtype priority,
+          bool use_values_from_trigger_time = false)
         : id_(id)
         , initial_value_(initial_value)
-        , priority_(priority) {}
+        , priority_(priority)
+        , use_values_from_trigger_time_(use_values_from_trigger_time) {}
 
     /**
      * @brief Get the ID of the event
@@ -53,6 +55,10 @@ class Event {
      * @return The priority of the event assignments, or NAN if undefined.
      */
     realtype get_priority() const { return priority_; }
+
+    bool get_use_values_from_trigger_time() const {
+        return use_values_from_trigger_time_;
+    }
 
   private:
     /** The unique ID of this event. */
@@ -78,6 +84,9 @@ class Event {
      */
 
     realtype priority_ = NAN;
+
+    /** use values from trigger time */
+    bool use_values_from_trigger_time_ = false;
 };
 
 /**

--- a/include/amici/model.h
+++ b/include/amici/model.h
@@ -1257,7 +1257,7 @@ class Model : public AbstractModel, public ModelDimensions {
      */
     void addStateEventUpdate(
         AmiVector& x, int const ie, realtype const t, AmiVector const& xdot,
-        AmiVector const& xdot_old
+        AmiVector const& xdot_old, AmiVector const& x_old
     );
 
     /**

--- a/python/sdist/amici/de_model.py
+++ b/python/sdist/amici/de_model.py
@@ -277,6 +277,7 @@ class DEModel:
             "sigmay": self.sigma_ys,
             "sigmaz": self.sigma_zs,
             "h": self.events,
+            "x_old": self.states,
             "np": self.noise_parameters,
             "op": self.observable_parameters,
         }
@@ -535,7 +536,7 @@ class DEModel:
 
         for event in self.events():
             state_update = event.get_state_update(
-                x=self.sym("x"), x_old=self.sym("x")
+                x=self.sym("x"), x_old=self.sym("x_old")
             )
             if state_update is None:
                 continue
@@ -1201,6 +1202,8 @@ class DEModel:
             return
         elif name == "xdot_old":
             length = len(self.eq("xdot"))
+        elif name == "x_old":
+            length = len(self.eq("x"))
         elif name in sparse_functions:
             self._generate_sparse_symbol(name)
             return
@@ -1618,7 +1621,7 @@ class DEModel:
                 # TODO https://github.com/AMICI-dev/AMICI/issues/2719
                 #   with use_values_from_trigger_time=True: x_old != x
                 state_update = event.get_state_update(
-                    x=self.sym("x"), x_old=self.sym("x")
+                    x=self.sym("x"), x_old=self.sym("x_old")
                 )
                 if state_update is None:
                     event_eqs.append(sp.zeros(self.num_states_solver(), 1))
@@ -1764,6 +1767,9 @@ class DEModel:
             self._eqs[name] = event_eqs
 
         elif name == "xdot_old":
+            # force symbols
+            self._eqs[name] = self.sym(name)
+        elif name == "x_old":
             # force symbols
             self._eqs[name] = self.sym(name)
 

--- a/python/sdist/amici/sbml_import.py
+++ b/python/sdist/amici/sbml_import.py
@@ -761,7 +761,7 @@ class SbmlImporter:
                 args += ["value"]
 
             if symbol_name == SymbolId.EVENT:
-                args += ["assignments", "initial_value", "priority"]
+                args += ["assignments", "initial_value", "priority", "use_values_from_trigger_time"]
             elif symbol_name == SymbolId.OBSERVABLE:
                 args += ["transformation"]
             elif symbol_name == SymbolId.EVENT_OBSERVABLE:
@@ -1909,66 +1909,10 @@ class SbmlImporter:
                 "priority": self._sympify(event.getPriority()),
             }
 
-        # Check `useValuesFromTriggerTime` attribute
-        # AMICI does not support events with
-        # `useValuesFromTriggerTime=true`, unless
-        # 1) there is only a single event
-        # 2) there are multiple events, but they are guaranteed to not
-        #    trigger at the same time
-        # 3) event assignments from events triggering at the same time
-        #    are independent
-        # in these cases, the attribute value doesn't matter, as long
-        # as we don't support delays.
-        # We can't check this in `check_event_support` without already
-        #  processing all trigger expressions, so we do it here
-
-        # are there any events with `useValuesFromTriggerTime=true`?
-        if len(self.symbols[SymbolId.EVENT]) <= 1 or not any(
-            event["use_values_from_trigger_time"]
-            for event in self.symbols[SymbolId.EVENT].values()
-        ):
-            return
-
-        # check if events are guaranteed to not trigger at the same time
-        def try_solve_t(expr: sp.Expr) -> list:
-            """Try to solve the expression for time."""
-            try:
-                return sp.solve(expr, sbml_time_symbol)
-            except NotImplementedError:
-                return []
-
-        trigger_times = [
-            try_solve_t(event["value"])
-            for event in self.symbols[SymbolId.EVENT].values()
-        ]
-        # for now, we only check for single/fixed/unique time points, but there
-        # are probably other cases we could cover
-        if all(len(ts) == 1 and ts[0].is_Number for ts in trigger_times):
-            trigger_times = [ts[0] for ts in trigger_times]
-            if len(trigger_times) == len(set(trigger_times)):
-                # all trigger times are unique
-                return
-
-        # if all assignments are absolute (not referring to other non-constant
-        # model entities), we are fine.
-        if all(
-            assignment.is_Number
-            for event in self.symbols[SymbolId.EVENT].values()
-            for assignment in event["assignments"].values()
-            if event["assignments"] is not None
-        ):
-            return
-
-        raise SBMLException(
-            "Events with `useValuesFromTriggerTime=true` are not "
-            "supported when there are multiple events.\n"
-            "If it is guaranteed that 1) events do not trigger at the same "
-            "time, or 2) different event assignments do not affect the same "
-            "entities, or 3) event assignments do not depend on the "
-            "pre-event state, then you can set "
-            "`useValuesFromTriggerTime=false` and retry."
-        )
-
+        # Previously AMICI aborted on multiple events with
+        # ``useValuesFromTriggerTime=true``. This is now supported, so no
+        # additional checks are required here.
+        
     @log_execution_time("processing SBML observables", logger)
     def _process_observables(
         self,

--- a/src/forwardproblem.cpp
+++ b/src/forwardproblem.cpp
@@ -290,7 +290,7 @@ void ForwardProblem::handleEvent(
 
         // Execute the event
         // Apply bolus to the state and the sensitivities
-        model->addStateEventUpdate(x_, ie, t_, xdot_, xdot_old_);
+        model->addStateEventUpdate(x_, ie, t_, xdot_, xdot_old_, x_old_);
         if (solver->computingFSA()) {
             // compute the new xdot
             model->fxdot(t_, x_, dx_, xdot_);

--- a/src/model.cpp
+++ b/src/model.cpp
@@ -207,7 +207,7 @@ Model::Model(
         // for matlab generated models, create event objects here
         for (int ie = 0; ie < ne; ie++) {
             events_.emplace_back(
-                std::string("event_") + std::to_string(ie), true, 0
+                std::string("event_") + std::to_string(ie), true, 0, false
             );
         }
     }
@@ -1439,16 +1439,20 @@ void Model::getEventTimeSensitivity(
 
 void Model::addStateEventUpdate(
     AmiVector& x, int const ie, realtype const t, AmiVector const& xdot,
-    AmiVector const& xdot_old
+    AmiVector const& xdot_old, AmiVector const& x_old
 ) {
 
     derived_state_.deltax_.assign(nx_solver, 0.0);
 
     std::copy_n(computeX_pos(x), nx_solver, x.data());
 
+    auto const& event = get_event(ie);
+    auto x_eval = event.get_use_values_from_trigger_time() ? computeX_pos(x_old)
+                                                          : computeX_pos(x);
+
     // compute update
     fdeltax(
-        derived_state_.deltax_.data(), t, x.data(),
+        derived_state_.deltax_.data(), t, x_eval,
         state_.unscaledParameters.data(), state_.fixedParameters.data(),
         state_.h.data(), ie, xdot.data(), xdot_old.data()
     );


### PR DESCRIPTION
## Summary
- expose `use_values_from_trigger_time` flag in Event classes
- pass attribute when importing SBML
- drop old check rejecting such models
- evaluate event updates at trigger time when requested
- extend solver interface accordingly

## Testing
- `pytest` *(fails: command not found)*