### PR TITLE
Add/use `tempdir` fixture

### DIFF
--- a/python/sdist/amici/testing/fixtures.py
+++ b/python/sdist/amici/testing/fixtures.py
@@ -1,0 +1,24 @@
+"""AMICI-specific pytest fixtures.
+
+This module is not intended to be imported directly, but to be used
+in `pytest_plugins` in `conftest.py`.
+"""
+
+import pytest
+from .testing import TemporaryDirectoryWinSafe
+
+
+@pytest.fixture
+def tempdir(*args, **kwargs):
+    """Fixture that provides a temporary directory.
+
+    The temporary directory will be removed after the test function
+    completes. The fixture is scoped to the function, so each test function
+    will get a new temporary directory. Therefore, this is only compatible with
+    test cases and other function-scoped fixtures.
+
+    Different from pytest's ``tmpdir`` fixture, this one will ignore certain
+    cleanup errors on Windows, see :class:`TemporaryDirectoryWinSafe`.
+    """
+    with TemporaryDirectoryWinSafe(*args, **kwargs) as tmpdir:
+        yield tmpdir

--- a/python/tests/conftest.py
+++ b/python/tests/conftest.py
@@ -6,8 +6,11 @@ import sys
 
 import amici
 import pytest
-from amici.testing import TemporaryDirectoryWinSafe as TemporaryDirectory
 from pathlib import Path
+from amici.testing import TemporaryDirectoryWinSafe as TemporaryDirectory
+
+
+pytest_plugins = ["amici.testing.fixtures"]
 
 EXAMPLES_DIR = Path(__file__).parents[2] / "doc" / "examples"
 TEST_DIR = Path(__file__).parent

--- a/python/tests/petab_/test_petab_problem.py
+++ b/python/tests/petab_/test_petab_problem.py
@@ -1,6 +1,7 @@
 from amici.petab.petab_problem import PetabProblem
 from benchmark_models_petab import get_problem
 from amici.testing import skip_on_valgrind
+from amici.petab.petab_import import import_petab_problem
 
 
 @skip_on_valgrind
@@ -68,13 +69,19 @@ def test_amici_petab_problem_on_demand():
 
 
 @skip_on_valgrind
-def test_amici_petab_problem_pregenerate_equals_on_demand():
+def test_amici_petab_problem_pregenerate_equals_on_demand(tempdir):
     """Check that PetabProblem produces the same ExpDatas
     independent of the `store_edatas` parameter."""
     # any example is fine
     petab_problem = get_problem("Boehm_JProteomeRes2014")
-    app_store_true = PetabProblem(petab_problem, store_edatas=True)
-    app_store_false = PetabProblem(petab_problem, store_edatas=False)
+    amici_model = import_petab_problem(petab_problem, model_output_dir=tempdir)
+
+    app_store_true = PetabProblem(
+        petab_problem, store_edatas=True, amici_model=amici_model
+    )
+    app_store_false = PetabProblem(
+        petab_problem, store_edatas=False, amici_model=amici_model
+    )
 
     parameter_update = {app_store_true.model.getParameterIds()[0]: 0.12345}
     app_store_true.set_parameters(parameter_update, scaled_parameters=True)

--- a/python/tests/test_antimony_import.py
+++ b/python/tests/test_antimony_import.py
@@ -1,12 +1,11 @@
 import amici
 import numpy as np
 from amici.antimony_import import antimony2amici
-from amici.testing import TemporaryDirectoryWinSafe as TemporaryDirectory
 from amici.testing import skip_on_valgrind
 
 
 @skip_on_valgrind
-def test_antimony_example():
+def test_antimony_example(tempdir):
     """If this example requires changes, please also update documentation/python_interface.rst."""
     ant_model = """
     model lotka_volterra
@@ -28,17 +27,16 @@ def test_antimony_example():
     end
     """
     module_name = "test_antimony_example_lv"
-    with TemporaryDirectory(prefix=module_name) as outdir:
-        antimony2amici(
-            ant_model,
-            model_name=module_name,
-            output_dir=outdir,
-        )
-        model_module = amici.import_model_module(
-            module_name=module_name, module_path=outdir
-        )
-        amici_model = model_module.getModel()
-        amici_model.setTimepoints(np.linspace(0, 100, 200))
-        amici_solver = amici_model.getSolver()
-        rdata = amici.runAmiciSimulation(amici_model, amici_solver)
-        assert rdata.status == amici.AMICI_SUCCESS
+    antimony2amici(
+        ant_model,
+        model_name=module_name,
+        output_dir=tempdir,
+    )
+    model_module = amici.import_model_module(
+        module_name=module_name, module_path=tempdir
+    )
+    amici_model = model_module.getModel()
+    amici_model.setTimepoints(np.linspace(0, 100, 200))
+    amici_solver = amici_model.getSolver()
+    rdata = amici.runAmiciSimulation(amici_model, amici_solver)
+    assert rdata.status == amici.AMICI_SUCCESS

--- a/python/tests/test_events.py
+++ b/python/tests/test_events.py
@@ -8,7 +8,6 @@ import pytest
 from amici import import_model_module, SensitivityMethod, SensitivityOrder
 from amici.antimony_import import antimony2amici
 from amici.gradient_check import check_derivatives
-from amici.testing import TemporaryDirectoryWinSafe as TemporaryDirectory
 from amici.testing import skip_on_valgrind
 from util import (
     check_trajectories_with_forward_sensitivities,
@@ -713,7 +712,7 @@ def expm(x):
     return np.array(expm(x).tolist()).astype(float)
 
 
-def test_handling_of_fixed_time_point_event_triggers():
+def test_handling_of_fixed_time_point_event_triggers(tempdir):
     """Test handling of events without solver-tracked root functions."""
     ant_model = """
     model test_events_time_based
@@ -725,33 +724,32 @@ def test_handling_of_fixed_time_point_event_triggers():
     end
     """
     module_name = "test_events_time_based"
-    with TemporaryDirectory(prefix=module_name) as outdir:
-        antimony2amici(
-            ant_model,
-            model_name=module_name,
-            output_dir=outdir,
-            verbose=True,
-        )
-        model_module = import_model_module(
-            module_name=module_name, module_path=outdir
-        )
-        amici_model = model_module.getModel()
-        assert amici_model.ne == 3
-        assert amici_model.ne_solver == 0
-        amici_model.setTimepoints(np.linspace(0, 4, 200))
-        amici_solver = amici_model.getSolver()
-        rdata = amici.runAmiciSimulation(amici_model, amici_solver)
-        assert rdata.status == amici.AMICI_SUCCESS
-        assert (rdata.x[rdata.ts < 1] == 0).all()
-        assert (rdata.x[(rdata.ts >= 1) & (rdata.ts < 2)] == 1).all()
-        assert (rdata.x[(rdata.ts >= 2) & (rdata.ts < 3)] == 2).all()
-        assert (rdata.x[(rdata.ts >= 3)] == 3).all()
+    antimony2amici(
+        ant_model,
+        model_name=module_name,
+        output_dir=tempdir,
+        verbose=True,
+    )
+    model_module = import_model_module(
+        module_name=module_name, module_path=tempdir
+    )
+    amici_model = model_module.getModel()
+    assert amici_model.ne == 3
+    assert amici_model.ne_solver == 0
+    amici_model.setTimepoints(np.linspace(0, 4, 200))
+    amici_solver = amici_model.getSolver()
+    rdata = amici.runAmiciSimulation(amici_model, amici_solver)
+    assert rdata.status == amici.AMICI_SUCCESS
+    assert (rdata.x[rdata.ts < 1] == 0).all()
+    assert (rdata.x[(rdata.ts >= 1) & (rdata.ts < 2)] == 1).all()
+    assert (rdata.x[(rdata.ts >= 2) & (rdata.ts < 3)] == 2).all()
+    assert (rdata.x[(rdata.ts >= 3)] == 3).all()
 
-        check_derivatives(amici_model, amici_solver, edata=None)
+    check_derivatives(amici_model, amici_solver, edata=None)
 
 
 @skip_on_valgrind
-def test_multiple_event_assignment_with_compartment():
+def test_multiple_event_assignment_with_compartment(tempdir):
     """see https://github.com/AMICI-dev/AMICI/issues/2426"""
     ant_model = """
     model test_events_multiple_assignments
@@ -767,291 +765,279 @@ def test_multiple_event_assignment_with_compartment():
     """
     # watch out for too long path names on windows ...
     module_name = "tst_mltple_ea_w_cmprtmnt"
-    with TemporaryDirectory(prefix=module_name) as outdir:
-        antimony2amici(
-            ant_model,
-            model_name=module_name,
-            output_dir=outdir,
-            verbose=True,
-        )
-        model_module = import_model_module(
-            module_name=module_name, module_path=outdir
-        )
-        amici_model = model_module.getModel()
-        assert amici_model.ne == 2
-        assert amici_model.ne_solver == 0
-        assert amici_model.nx_rdata == 3
-        amici_model.setTimepoints(np.linspace(0, 15, 16))
-        amici_solver = amici_model.getSolver()
-        rdata = amici.runAmiciSimulation(amici_model, amici_solver)
-        assert rdata.status == amici.AMICI_SUCCESS
-        idx_event_target = amici_model.getStateIds().index("event_target")
-        idx_unrelated = amici_model.getStateIds().index("unrelated")
-        idx_species_in_event_target = amici_model.getStateIds().index(
-            "species_in_event_target"
-        )
+    antimony2amici(
+        ant_model,
+        model_name=module_name,
+        output_dir=tempdir,
+        verbose=True,
+    )
+    model_module = import_model_module(
+        module_name=module_name, module_path=tempdir
+    )
+    amici_model = model_module.getModel()
+    assert amici_model.ne == 2
+    assert amici_model.ne_solver == 0
+    assert amici_model.nx_rdata == 3
+    amici_model.setTimepoints(np.linspace(0, 15, 16))
+    amici_solver = amici_model.getSolver()
+    rdata = amici.runAmiciSimulation(amici_model, amici_solver)
+    assert rdata.status == amici.AMICI_SUCCESS
+    idx_event_target = amici_model.getStateIds().index("event_target")
+    idx_unrelated = amici_model.getStateIds().index("unrelated")
+    idx_species_in_event_target = amici_model.getStateIds().index(
+        "species_in_event_target"
+    )
 
-        assert_allclose(
-            rdata.x[(rdata.ts < 5) & (rdata.ts > 10), idx_event_target],
-            1,
-            rtol=0,
-            atol=1e-15,
-        )
-        assert_allclose(
-            rdata.x[(5 < rdata.ts) & (rdata.ts < 10), idx_event_target],
-            10,
-            rtol=0,
-            atol=1e-15,
-        )
-        assert_allclose(
-            rdata.x[(rdata.ts < 5) & (rdata.ts > 10), idx_unrelated],
-            2,
-            rtol=0,
-            atol=1e-15,
-        )
-        assert_allclose(
-            rdata.x[(5 < rdata.ts) & (rdata.ts < 10), idx_unrelated],
-            4,
-            rtol=0,
-            atol=1e-15,
-        )
-        assert_allclose(
-            rdata.x[
-                (rdata.ts < 5) & (rdata.ts > 10), idx_species_in_event_target
-            ],
-            1,
-            rtol=0,
-            atol=1e-15,
-        )
-        assert_allclose(
-            rdata.x[
-                (5 < rdata.ts) & (rdata.ts < 10), idx_species_in_event_target
-            ],
-            0.1,
-            rtol=0,
-            atol=1e-15,
-        )
+    assert_allclose(
+        rdata.x[(rdata.ts < 5) & (rdata.ts > 10), idx_event_target],
+        1,
+        rtol=0,
+        atol=1e-15,
+    )
+    assert_allclose(
+        rdata.x[(5 < rdata.ts) & (rdata.ts < 10), idx_event_target],
+        10,
+        rtol=0,
+        atol=1e-15,
+    )
+    assert_allclose(
+        rdata.x[(rdata.ts < 5) & (rdata.ts > 10), idx_unrelated],
+        2,
+        rtol=0,
+        atol=1e-15,
+    )
+    assert_allclose(
+        rdata.x[(5 < rdata.ts) & (rdata.ts < 10), idx_unrelated],
+        4,
+        rtol=0,
+        atol=1e-15,
+    )
+    assert_allclose(
+        rdata.x[(rdata.ts < 5) & (rdata.ts > 10), idx_species_in_event_target],
+        1,
+        rtol=0,
+        atol=1e-15,
+    )
+    assert_allclose(
+        rdata.x[(5 < rdata.ts) & (rdata.ts < 10), idx_species_in_event_target],
+        0.1,
+        rtol=0,
+        atol=1e-15,
+    )
 
 
 @pytest.mark.filterwarnings(
     "ignore:Adjoint sensitivity analysis for models with discontinuous "
 )
 @skip_on_valgrind
-def test_event_priorities():
+def test_event_priorities(tempdir):
     """Test SBML event priorities."""
     from amici.antimony_import import antimony2amici
 
     model_name = "test_event_priorities"
-    with TemporaryDirectory(prefix=model_name) as outdir:
-        antimony2amici(
-            r"""
-            target1 = 1
-            target2 = 2
-            target3 = 3
-            target3_rate = 0
-            target3' = target3_rate
-            trigger_time = 1
+    antimony2amici(
+        r"""
+        target1 = 1
+        target2 = 2
+        target3 = 3
+        target3_rate = 0
+        target3' = target3_rate
+        trigger_time = 1
 
-            # test time- and state-dependent triggers
-            some_time = time
-            some_time' = 1
+        # test time- and state-dependent triggers
+        some_time = time
+        some_time' = 1
 
-            two = 2
+        two = 2
 
-            # three events with different priorities, where priorities
-            #  don't match alphabetical order of IDs or anything the like
-            E_two: \
-                at some_time >= trigger_time, priority=22, fromTrigger=false:
-                target2 = two * target1 + target2 - two;
-            E_one: \
-                at some_time >= trigger_time, priority=111, fromTrigger=false:
-                target1 = 10 + time;
-            E_three: \
-                at some_time >= trigger_time, priority=3, fromTrigger=false:
-                target3 = target1 + target2, target3_rate = 1;
-            """,
-            model_name=model_name,
-            output_dir=outdir,
-        )
+        # three events with different priorities, where priorities
+        #  don't match alphabetical order of IDs or anything the like
+        E_two: \
+            at some_time >= trigger_time, priority=22, fromTrigger=false:
+            target2 = two * target1 + target2 - two;
+        E_one: \
+            at some_time >= trigger_time, priority=111, fromTrigger=false:
+            target1 = 10 + time;
+        E_three: \
+            at some_time >= trigger_time, priority=3, fromTrigger=false:
+            target3 = target1 + target2, target3_rate = 1;
+        """,
+        model_name=model_name,
+        output_dir=tempdir,
+    )
 
-        model_module = import_model_module(model_name, outdir)
+    model_module = import_model_module(model_name, tempdir)
 
-        model = model_module.get_model()
+    model = model_module.get_model()
 
-        # check just after the trigger time,
-        # the event does not fire at *exactly* 1
-        model.setTimepoints([0, 1 + 1e-6, 2])
+    # check just after the trigger time,
+    # the event does not fire at *exactly* 1
+    model.setTimepoints([0, 1 + 1e-6, 2])
 
-        solver = model.getSolver()
-        solver.setAbsoluteTolerance(1e-16)
-        solver.setRelativeTolerance(1e-14)
-        solver.setSensitivityOrder(SensitivityOrder.first)
-        solver.setSensitivityMethod(SensitivityMethod.forward)
+    solver = model.getSolver()
+    solver.setAbsoluteTolerance(1e-16)
+    solver.setRelativeTolerance(1e-14)
+    solver.setSensitivityOrder(SensitivityOrder.first)
+    solver.setSensitivityMethod(SensitivityMethod.forward)
 
-        rdata = amici.runAmiciSimulation(model, solver)
+    rdata = amici.runAmiciSimulation(model, solver)
 
-        assert np.all(rdata.by_id("target1") == [1, 11, 11])
-        assert np.all(rdata.by_id("target2") == [2, 22, 22])
-        assert_allclose(rdata.by_id("target3"), [3, 33 + 1e-6, 33 + 1])
+    assert np.all(rdata.by_id("target1") == [1, 11, 11])
+    assert np.all(rdata.by_id("target2") == [2, 22, 22])
+    assert_allclose(rdata.by_id("target3"), [3, 33 + 1e-6, 33 + 1])
 
-        # generate synthetic measurements
-        edata = amici.ExpData(rdata, 1, 0)
+    # generate synthetic measurements
+    edata = amici.ExpData(rdata, 1, 0)
 
-        # check forward sensitivities against finite differences
-        # FIXME: sensitivities w.r.t. the bolus parameter are not correct
-        model.setParameterList(
-            [
-                ip
-                for ip, par in enumerate(model.getParameterIds())
-                if par != "two"
-            ]
-        )
+    # check forward sensitivities against finite differences
+    # FIXME: sensitivities w.r.t. the bolus parameter are not correct
+    model.setParameterList(
+        [ip for ip, par in enumerate(model.getParameterIds()) if par != "two"]
+    )
 
-        check_derivatives(
-            model,
-            solver,
-            edata=edata,
-            atol=1e-6,
-            rtol=1e-6,
-            # smaller than the offset from the trigger time
-            epsilon=1e-8,
-        )
+    check_derivatives(
+        model,
+        solver,
+        edata=edata,
+        atol=1e-6,
+        rtol=1e-6,
+        # smaller than the offset from the trigger time
+        epsilon=1e-8,
+    )
 
-        # TODO: test ASA after https://github.com/AMICI-dev/AMICI/pull/1539
+    # TODO: test ASA after https://github.com/AMICI-dev/AMICI/pull/1539
 
 
 @skip_on_valgrind
-def test_random_event_ordering():
+def test_random_event_ordering(tempdir):
     """For simultaneously executed events, the order of execution
     must be random."""
     from amici.antimony_import import antimony2amici
 
     model_name = "test_event_prio_rnd"
-    with TemporaryDirectory(prefix=model_name) as outdir:
-        antimony2amici(
-            r"""
-            target_rnd = 0
-            target_first = 0
-            target_last = 0
-            # test time- and state-dependent triggers
-            some_time = time
-            some_time' = 1
-            trigger_time = 1
+    antimony2amici(
+        r"""
+        target_rnd = 0
+        target_first = 0
+        target_last = 0
+        # test time- and state-dependent triggers
+        some_time = time
+        some_time' = 1
+        trigger_time = 1
 
-            # {E1, E2, E3} must be executed in random order after E_first,
-            # but before E_last
-            E1: at some_time >= trigger_time, priority=1, fromTrigger=false:
-                target_rnd = 1;
-            E2: at some_time >= trigger_time, priority=1, fromTrigger=false:
-                target_rnd = 2;
-            E3: at some_time >= trigger_time, priority=1, fromTrigger=false:
-                target_rnd = 3;
-            E_first: \
-                at some_time >= trigger_time, priority=10, fromTrigger=false:
-                target_first = target_rnd + 2;
-            E_last: \
-                at some_time >= trigger_time, priority=-1, fromTrigger=false:
-                target_last = target_rnd >= 1;
-            """,
-            model_name=model_name,
-            output_dir=outdir,
-        )
+        # {E1, E2, E3} must be executed in random order after E_first,
+        # but before E_last
+        E1: at some_time >= trigger_time, priority=1, fromTrigger=false:
+            target_rnd = 1;
+        E2: at some_time >= trigger_time, priority=1, fromTrigger=false:
+            target_rnd = 2;
+        E3: at some_time >= trigger_time, priority=1, fromTrigger=false:
+            target_rnd = 3;
+        E_first: \
+            at some_time >= trigger_time, priority=10, fromTrigger=false:
+            target_first = target_rnd + 2;
+        E_last: \
+            at some_time >= trigger_time, priority=-1, fromTrigger=false:
+            target_last = target_rnd >= 1;
+        """,
+        model_name=model_name,
+        output_dir=tempdir,
+    )
 
-        model_module = import_model_module(model_name, outdir)
+    model_module = import_model_module(model_name, tempdir)
 
-        model = model_module.get_model()
-        model.setTimepoints([0, 2, 3])
-        solver = model.getSolver()
+    model = model_module.get_model()
+    model.setTimepoints([0, 2, 3])
+    solver = model.getSolver()
 
-        # the outcomes of the random assignment
-        outcomes = []
-        N = 1000
-        for i in range(N):
-            rdata = amici.runAmiciSimulation(model, solver)
-            assert np.all(rdata.by_id("target_first") == [0, 2, 2])
-            assert np.all(rdata.by_id("target_last") == [0, 1, 1])
-            traj = rdata.by_id("target_rnd")
-            assert traj[0] == 0
-            assert traj[1] == traj[2]
-            # collect the random outputs
-            outcomes.append(traj[2])
+    # the outcomes of the random assignment
+    outcomes = []
+    N = 1000
+    for i in range(N):
+        rdata = amici.runAmiciSimulation(model, solver)
+        assert np.all(rdata.by_id("target_first") == [0, 2, 2])
+        assert np.all(rdata.by_id("target_last") == [0, 1, 1])
+        traj = rdata.by_id("target_rnd")
+        assert traj[0] == 0
+        assert traj[1] == traj[2]
+        # collect the random outputs
+        outcomes.append(traj[2])
 
-        assert set(outcomes) == {1, 2, 3}
+    assert set(outcomes) == {1, 2, 3}
 
-        # check that the outcomes are about equally distributed
-        # between 1, 2, and 3
-        assert np.allclose(
-            [outcomes.count(1), outcomes.count(2), outcomes.count(3)],
-            [N / 3, N / 3, N / 3],
-            rtol=0.25,
-        )
+    # check that the outcomes are about equally distributed
+    # between 1, 2, and 3
+    assert np.allclose(
+        [outcomes.count(1), outcomes.count(2), outcomes.count(3)],
+        [N / 3, N / 3, N / 3],
+        rtol=0.25,
+    )
 
 
 @skip_on_valgrind
-def test_event_uses_values_from_trigger_time():
+def test_event_uses_values_from_trigger_time(tempdir):
     """For simultaneously executed events, check that values from trigger
     times are used to compute the state update."""
     from amici.antimony_import import antimony2amici
 
     model_name = "test_event_vals_trig_time"
-    with TemporaryDirectory(prefix=model_name) as outdir:
-        antimony2amici(
-            r"""
-            some_time = time
-            some_time' = 1
-            trigger_time = 0.5
-            target1 = 2
-            target2 = 0
-            one = 1
-            three = 3
+    antimony2amici(
+        r"""
+        some_time = time
+        some_time' = 1
+        trigger_time = 0.5
+        target1 = 2
+        target2 = 0
+        one = 1
+        three = 3
 
-            E1: at some_time >= trigger_time, priority=10, fromTrigger=false:
-                target1 = 10,
-                target2 = target1 + one;
+        E1: at some_time >= trigger_time, priority=10, fromTrigger=false:
+            target1 = 10,
+            target2 = target1 + one;
 
-            E2: at some_time >= trigger_time, priority=-10, fromTrigger=true:
-                # this must reset `target1` to its initial value!!
-                target1 = target1,
-                target2 = target2 + three
-            """,
-            model_name=model_name,
-            output_dir=outdir,
-        )
+        E2: at some_time >= trigger_time, priority=-10, fromTrigger=true:
+            # this must reset `target1` to its initial value!!
+            target1 = target1,
+            target2 = target2 + three
+        """,
+        model_name=model_name,
+        output_dir=tempdir,
+    )
 
-        model_module = import_model_module(model_name, outdir)
+    model_module = import_model_module(model_name, tempdir)
 
-        model = model_module.get_model()
-        model.setTimepoints([0, 1.1, 2])
-        solver = model.getSolver()
-        solver.setSensitivityOrder(SensitivityOrder.first)
-        solver.setSensitivityMethod(SensitivityMethod.forward)
+    model = model_module.get_model()
+    model.setTimepoints([0, 1.1, 2])
+    solver = model.getSolver()
+    solver.setSensitivityOrder(SensitivityOrder.first)
+    solver.setSensitivityMethod(SensitivityMethod.forward)
 
-        rdata = amici.runAmiciSimulation(model, solver)
-        assert np.all(rdata.by_id("target1") == [2, 2, 2])
-        assert np.all(rdata.by_id("target2") == [0, 3, 3])
+    rdata = amici.runAmiciSimulation(model, solver)
+    assert np.all(rdata.by_id("target1") == [2, 2, 2])
+    assert np.all(rdata.by_id("target2") == [0, 3, 3])
 
-        # generate synthetic measurements
-        edata = amici.ExpData(rdata, 1, 0)
+    # generate synthetic measurements
+    edata = amici.ExpData(rdata, 1, 0)
 
-        # check forward sensitivities against finite differences
-        # FIXME: sensitivities w.r.t. the bolus parameter of the first event
-        #  are wrong
-        model.setParameterList(
-            [
-                ip
-                for ip, par in enumerate(model.getParameterIds())
-                if par not in ["one"]
-            ]
-        )
+    # check forward sensitivities against finite differences
+    # FIXME: sensitivities w.r.t. the bolus parameter of the first event
+    #  are wrong
+    model.setParameterList(
+        [
+            ip
+            for ip, par in enumerate(model.getParameterIds())
+            if par not in ["one"]
+        ]
+    )
 
-        check_derivatives(
-            model,
-            solver,
-            edata=edata,
-            atol=1e-6,
-            rtol=1e-6,
-            # smaller than the offset from the trigger time
-            epsilon=1e-8,
-        )
+    check_derivatives(
+        model,
+        solver,
+        edata=edata,
+        atol=1e-6,
+        rtol=1e-6,
+        # smaller than the offset from the trigger time
+        epsilon=1e-8,
+    )
 
-        # TODO: test ASA after https://github.com/AMICI-dev/AMICI/pull/1539
+    # TODO: test ASA after https://github.com/AMICI-dev/AMICI/pull/1539

--- a/python/tests/test_petab_import.py
+++ b/python/tests/test_petab_import.py
@@ -3,7 +3,7 @@
 import libsbml
 import pandas as pd
 import pytest
-from amici.testing import TemporaryDirectoryWinSafe, skip_on_valgrind
+from amici.testing import skip_on_valgrind
 
 petab = pytest.importorskip("petab.v1", reason="Missing petab")
 
@@ -115,7 +115,7 @@ def test_get_fixed_parameters(get_fixed_parameters_model):
 
 
 @skip_on_valgrind
-def test_default_output_parameters(simple_sbml_model):
+def test_default_output_parameters(simple_sbml_model, tempdir):
     from amici.petab.petab_import import import_model
     from petab.v1.models.sbml_model import SbmlModel
 
@@ -146,24 +146,23 @@ def test_default_output_parameters(simple_sbml_model):
         observable_df=observable_df,
     )
 
-    with TemporaryDirectoryWinSafe() as outdir:
-        sbml_importer = import_model(
-            petab_problem=petab_problem,
-            output_parameter_defaults={"observableParameter1_obs1": 1.0},
-            compile=False,
-            model_output_dir=outdir,
-        )
-        assert (
-            1.0
-            == sbml_importer.sbml.getParameter(
-                "observableParameter1_obs1"
-            ).getValue()
-        )
+    sbml_importer = import_model(
+        petab_problem=petab_problem,
+        output_parameter_defaults={"observableParameter1_obs1": 1.0},
+        compile=False,
+        model_output_dir=tempdir,
+    )
+    assert (
+        1.0
+        == sbml_importer.sbml.getParameter(
+            "observableParameter1_obs1"
+        ).getValue()
+    )
 
-        with pytest.raises(ValueError):
-            import_model(
-                petab_problem=petab_problem,
-                output_parameter_defaults={"nonExistentParameter": 1.0},
-                compile=False,
-                model_output_dir=outdir,
-            )
+    with pytest.raises(ValueError):
+        import_model(
+            petab_problem=petab_problem,
+            output_parameter_defaults={"nonExistentParameter": 1.0},
+            compile=False,
+            model_output_dir=tempdir,
+        )

--- a/python/tests/test_sbml_import.py
+++ b/python/tests/test_sbml_import.py
@@ -12,11 +12,10 @@ import numpy as np
 import pytest
 from amici.gradient_check import check_derivatives
 from amici.sbml_import import SbmlImporter
-from amici.testing import TemporaryDirectoryWinSafe as TemporaryDirectory
 from amici.testing import skip_on_valgrind
 from numpy.testing import assert_allclose, assert_array_equal
 from amici import import_model_module
-
+from amici.testing import TemporaryDirectoryWinSafe as TemporaryDirectory
 from conftest import MODEL_STEADYSTATE_SCALED_XML
 
 
@@ -42,69 +41,68 @@ def simple_sbml_model():
     return document, model
 
 
-def test_sbml2amici_no_observables():
+def test_sbml2amici_no_observables(tempdir):
     """Test model generation works for model without observables"""
     sbml_doc, sbml_model = simple_sbml_model()
     sbml_importer = SbmlImporter(sbml_source=sbml_model, from_file=False)
     model_name = "test_sbml2amici_no_observables"
-    with TemporaryDirectory() as tmpdir:
-        sbml_importer.sbml2amici(
-            model_name=model_name,
-            output_dir=tmpdir,
-            observables=None,
-            compute_conservation_laws=False,
-        )
+    sbml_importer.sbml2amici(
+        model_name=model_name,
+        output_dir=tempdir,
+        observables=None,
+        compute_conservation_laws=False,
+    )
 
-        # Ensure import succeeds (no missing symbols)
-        module_module = amici.import_model_module(model_name, tmpdir)
-        assert hasattr(module_module, "getModel")
+    # Ensure import succeeds (no missing symbols)
+    module_module = amici.import_model_module(model_name, tempdir)
+    assert hasattr(module_module, "getModel")
 
 
 @skip_on_valgrind
-def test_sbml2amici_nested_observables_fail():
+def test_sbml2amici_nested_observables_fail(tempdir):
     """Test that import fails if nested observables are used."""
     sbml_doc, sbml_model = simple_sbml_model()
     sbml_importer = SbmlImporter(sbml_source=sbml_model, from_file=False)
     model_name = "test_sbml2amici_nested_observables_fail"
-    with TemporaryDirectory() as tmpdir:
-        with pytest.raises(ValueError, match="(?i)nested"):
-            sbml_importer.sbml2amici(
-                model_name=model_name,
-                output_dir=tmpdir,
-                observables={
-                    "outer": {"formula": "inner"},
-                    "inner": {"formula": "S1"},
-                },
-                compute_conservation_laws=False,
-                generate_sensitivity_code=False,
-                compile=False,
-            )
+
+    with pytest.raises(ValueError, match="(?i)nested"):
+        sbml_importer.sbml2amici(
+            model_name=model_name,
+            output_dir=tempdir,
+            observables={
+                "outer": {"formula": "inner"},
+                "inner": {"formula": "S1"},
+            },
+            compute_conservation_laws=False,
+            generate_sensitivity_code=False,
+            compile=False,
+        )
 
 
-def test_nosensi():
+def test_nosensi(tempdir):
     sbml_doc, sbml_model = simple_sbml_model()
     sbml_importer = SbmlImporter(sbml_source=sbml_model, from_file=False)
     model_name = "test_nosensi"
-    with TemporaryDirectory() as tmpdir:
-        sbml_importer.sbml2amici(
-            model_name=model_name,
-            output_dir=tmpdir,
-            observables=None,
-            compute_conservation_laws=False,
-            generate_sensitivity_code=False,
-        )
 
-        model_module = amici.import_model_module(
-            module_name=model_name, module_path=tmpdir
-        )
+    sbml_importer.sbml2amici(
+        model_name=model_name,
+        output_dir=tempdir,
+        observables=None,
+        compute_conservation_laws=False,
+        generate_sensitivity_code=False,
+    )
 
-        model = model_module.getModel()
-        model.setTimepoints(np.linspace(0, 60, 61))
-        solver = model.getSolver()
-        solver.setSensitivityOrder(amici.SensitivityOrder.first)
-        solver.setSensitivityMethod(amici.SensitivityMethod.forward)
-        rdata = amici.runAmiciSimulation(model, solver)
-        assert rdata.status == amici.AMICI_ERROR
+    model_module = amici.import_model_module(
+        module_name=model_name, module_path=tempdir
+    )
+
+    model = model_module.getModel()
+    model.setTimepoints(np.linspace(0, 60, 61))
+    solver = model.getSolver()
+    solver.setSensitivityOrder(amici.SensitivityOrder.first)
+    solver.setSensitivityMethod(amici.SensitivityMethod.forward)
+    rdata = amici.runAmiciSimulation(model, solver)
+    assert rdata.status == amici.AMICI_ERROR
 
 
 @pytest.fixture(scope="session")
@@ -371,7 +369,7 @@ def test_solver_reuse(model_steadystate_module):
 
 
 @pytest.fixture
-def model_test_likelihoods():
+def model_test_likelihoods(tempdir):
     """Test model for various likelihood functions."""
     # load sbml model
     sbml_file = MODEL_STEADYSTATE_SCALED_XML
@@ -401,18 +399,17 @@ def model_test_likelihoods():
     }
 
     module_name = "model_test_likelihoods"
-    with TemporaryDirectory(prefix=module_name) as outdir:
-        sbml_importer.sbml2amici(
-            model_name=module_name,
-            output_dir=outdir,
-            observables=observables,
-            constant_parameters=["k0"],
-            noise_distributions=noise_distributions,
-        )
+    sbml_importer.sbml2amici(
+        model_name=module_name,
+        output_dir=tempdir,
+        observables=observables,
+        constant_parameters=["k0"],
+        noise_distributions=noise_distributions,
+    )
 
-        yield amici.import_model_module(
-            module_name=module_name, module_path=outdir
-        )
+    yield amici.import_model_module(
+        module_name=module_name, module_path=tempdir
+    )
 
 
 @skip_on_valgrind
@@ -522,7 +519,7 @@ def test_units(model_units_module):
 @pytest.mark.skipif(
     os.name == "nt", reason="Avoid `CERTIFICATE_VERIFY_FAILED` error"
 )
-def test_sympy_exp_monkeypatch():
+def test_sympy_exp_monkeypatch(tempdir):
     """
     This model contains a removeable discontinuity at t=0 that requires
     monkeypatching sympy.Pow._eval_derivative in order to be able to compute
@@ -537,38 +534,35 @@ def test_sympy_exp_monkeypatch():
     importer = amici.SbmlImporter(model_file)
     module_name = "BIOMD0000000529"
 
-    with TemporaryDirectory() as outdir:
-        importer.sbml2amici(module_name, outdir)
-        model_module = amici.import_model_module(
-            module_name=module_name, module_path=outdir
+    importer.sbml2amici(module_name, tempdir)
+    model_module = amici.import_model_module(
+        module_name=module_name, module_path=tempdir
+    )
+
+    model = model_module.getModel()
+    model.setTimepoints(np.linspace(0, 8, 250))
+    model.requireSensitivitiesForAllParameters()
+    model.setAlwaysCheckFinite(True)
+    model.setParameterScale(
+        amici.parameterScalingFromIntVector(
+            [
+                amici.ParameterScaling.none
+                if re.match(r"n[0-9]+$", par_id)
+                else amici.ParameterScaling.log10
+                for par_id in model.getParameterIds()
+            ]
         )
+    )
 
-        model = model_module.getModel()
-        model.setTimepoints(np.linspace(0, 8, 250))
-        model.requireSensitivitiesForAllParameters()
-        model.setAlwaysCheckFinite(True)
-        model.setParameterScale(
-            amici.parameterScalingFromIntVector(
-                [
-                    amici.ParameterScaling.none
-                    if re.match(r"n[0-9]+$", par_id)
-                    else amici.ParameterScaling.log10
-                    for par_id in model.getParameterIds()
-                ]
-            )
-        )
+    solver = model.getSolver()
+    solver.setSensitivityMethod(amici.SensitivityMethod.forward)
+    solver.setSensitivityOrder(amici.SensitivityOrder.first)
 
-        solver = model.getSolver()
-        solver.setSensitivityMethod(amici.SensitivityMethod.forward)
-        solver.setSensitivityOrder(amici.SensitivityOrder.first)
+    rdata = amici.runAmiciSimulation(model, solver)
 
-        rdata = amici.runAmiciSimulation(model, solver)
-
-        # print sensitivity-related results
-        assert rdata["status"] == amici.AMICI_SUCCESS
-        check_derivatives(
-            model, solver, None, atol=1e-2, rtol=1e-2, epsilon=1e-3
-        )
+    # print sensitivity-related results
+    assert rdata["status"] == amici.AMICI_SUCCESS
+    check_derivatives(model, solver, None, atol=1e-2, rtol=1e-2, epsilon=1e-3)
 
 
 def normal_nllh(m, y, sigma):
@@ -641,40 +635,38 @@ def _test_set_parameters_by_dict(model_module):
 
 @skip_on_valgrind
 @pytest.mark.parametrize("extract_cse", [True, False])
-def test_code_gen_uses_cse(extract_cse):
+def test_code_gen_uses_cse(extract_cse, tempdir):
     """Check that code generation honors AMICI_EXTRACT_CSE"""
     old_environ = os.environ.copy()
     try:
         os.environ["AMICI_EXTRACT_CSE"] = str(extract_cse)
         sbml_importer = amici.SbmlImporter(MODEL_STEADYSTATE_SCALED_XML)
         model_name = "test_code_gen_uses_cse"
-        with TemporaryDirectory() as tmpdir:
-            sbml_importer.sbml2amici(
-                model_name=model_name,
-                compile=False,
-                generate_sensitivity_code=False,
-                output_dir=tmpdir,
-            )
-            xdot = Path(tmpdir, "xdot.cpp").read_text()
+        sbml_importer.sbml2amici(
+            model_name=model_name,
+            compile=False,
+            generate_sensitivity_code=False,
+            output_dir=tempdir,
+        )
+        xdot = Path(tempdir, "xdot.cpp").read_text()
         assert ("__amici_cse_0 = " in xdot) == extract_cse
     finally:
         os.environ = old_environ
 
 
 @skip_on_valgrind
-def test_code_gen_uses_lhs_symbol_ids():
+def test_code_gen_uses_lhs_symbol_ids(tempdir):
     """Check that code generation uses symbol IDs instead of plain array
     indices"""
     sbml_importer = amici.SbmlImporter(MODEL_STEADYSTATE_SCALED_XML)
     model_name = "test_code_gen_uses_lhs_symbol_ids"
-    with TemporaryDirectory() as tmpdir:
-        sbml_importer.sbml2amici(
-            model_name=model_name,
-            compile=False,
-            generate_sensitivity_code=False,
-            output_dir=tmpdir,
-        )
-        dwdx = Path(tmpdir, "dwdx.cpp").read_text()
+    sbml_importer.sbml2amici(
+        model_name=model_name,
+        compile=False,
+        generate_sensitivity_code=False,
+        output_dir=tempdir,
+    )
+    dwdx = Path(tempdir, "dwdx.cpp").read_text()
     assert "dobservable_x1_dx1 = " in dwdx
 
 
@@ -710,7 +702,7 @@ def test_hardcode_parameters():
         )
 
 
-def test_constraints():
+def test_constraints(tempdir):
     """Test non-negativity constraint handling."""
     from amici.antimony_import import antimony2amici
     from amici import Constraint
@@ -725,43 +717,42 @@ def test_constraints():
     end
     """
     module_name = "test_non_negative_species"
-    with TemporaryDirectory(prefix=module_name) as outdir:
-        antimony2amici(
-            ant_model,
-            model_name=module_name,
-            output_dir=outdir,
-            compute_conservation_laws=False,
-        )
-        model_module = amici.import_model_module(
-            module_name=module_name, module_path=outdir
-        )
-        amici_model = model_module.getModel()
-        amici_model.setTimepoints(np.linspace(0, 100, 200))
-        amici_solver = amici_model.getSolver()
-        rdata = amici.runAmiciSimulation(amici_model, amici_solver)
-        assert rdata.status == amici.AMICI_SUCCESS
-        # should be non-negative in theory, but is expected to become negative
-        #  in practice
-        assert np.any(rdata.x < 0)
+    antimony2amici(
+        ant_model,
+        model_name=module_name,
+        output_dir=tempdir,
+        compute_conservation_laws=False,
+    )
+    model_module = amici.import_model_module(
+        module_name=module_name, module_path=tempdir
+    )
+    amici_model = model_module.getModel()
+    amici_model.setTimepoints(np.linspace(0, 100, 200))
+    amici_solver = amici_model.getSolver()
+    rdata = amici.runAmiciSimulation(amici_model, amici_solver)
+    assert rdata.status == amici.AMICI_SUCCESS
+    # should be non-negative in theory, but is expected to become negative
+    #  in practice
+    assert np.any(rdata.x < 0)
 
-        amici_solver.setRelativeTolerance(1e-13)
-        amici_solver.setConstraints(
-            [Constraint.non_negative, Constraint.non_negative]
+    amici_solver.setRelativeTolerance(1e-13)
+    amici_solver.setConstraints(
+        [Constraint.non_negative, Constraint.non_negative]
+    )
+    rdata = amici.runAmiciSimulation(amici_model, amici_solver)
+    assert rdata.status == amici.AMICI_SUCCESS
+    assert np.all(rdata.x >= 0)
+    assert np.all(
+        np.sum(rdata.x, axis=1) - np.sum(rdata.x[0])
+        < max(
+            np.sum(rdata.x[0]) * amici_solver.getRelativeTolerance(),
+            amici_solver.getAbsoluteTolerance(),
         )
-        rdata = amici.runAmiciSimulation(amici_model, amici_solver)
-        assert rdata.status == amici.AMICI_SUCCESS
-        assert np.all(rdata.x >= 0)
-        assert np.all(
-            np.sum(rdata.x, axis=1) - np.sum(rdata.x[0])
-            < max(
-                np.sum(rdata.x[0]) * amici_solver.getRelativeTolerance(),
-                amici_solver.getAbsoluteTolerance(),
-            )
-        )
+    )
 
 
 @skip_on_valgrind
-def test_import_same_model_name():
+def test_import_same_model_name(tempdir):
     """Test for error when loading a model with the same extension name as an
     already loaded model."""
     from amici.antimony_import import antimony2amici
@@ -779,131 +770,127 @@ def test_import_same_model_name():
     ant_model_3 = ant_model_1.replace("1", "3")
 
     module_name = "test_same_extension"
-    with TemporaryDirectory(prefix=module_name) as outdir:
-        outdir_1 = Path(outdir, "model_1")
-        outdir_2 = Path(outdir, "model_2")
+    outdir_1 = Path(tempdir, "model_1")
+    outdir_2 = Path(tempdir, "model_2")
 
-        # import the first two models, with the same name,
-        #  but in different location (this is now supported)
-        antimony2amici(
-            ant_model_1,
-            model_name=module_name,
-            output_dir=outdir_1,
-            compute_conservation_laws=False,
-        )
+    # import the first two models, with the same name,
+    #  but in different location (this is now supported)
+    antimony2amici(
+        ant_model_1,
+        model_name=module_name,
+        output_dir=outdir_1,
+        compute_conservation_laws=False,
+    )
 
-        antimony2amici(
-            ant_model_2,
-            model_name=module_name,
-            output_dir=outdir_2,
-            compute_conservation_laws=False,
-        )
+    antimony2amici(
+        ant_model_2,
+        model_name=module_name,
+        output_dir=outdir_2,
+        compute_conservation_laws=False,
+    )
 
-        model_module_1 = import_model_module(
-            module_name=module_name, module_path=outdir_1
-        )
-        assert model_module_1.get_model().getParameters()[0] == 1.0
+    model_module_1 = import_model_module(
+        module_name=module_name, module_path=outdir_1
+    )
+    assert model_module_1.get_model().getParameters()[0] == 1.0
 
-        # no error if the same model is loaded again without changes on disk
-        model_module_1b = import_model_module(
-            module_name=module_name, module_path=outdir_1
-        )
-        # downside: the modules will compare as different
-        assert (model_module_1 == model_module_1b) is False
-        assert model_module_1.__file__ == model_module_1b.__file__
-        assert model_module_1b.get_model().getParameters()[0] == 1.0
+    # no error if the same model is loaded again without changes on disk
+    model_module_1b = import_model_module(
+        module_name=module_name, module_path=outdir_1
+    )
+    # downside: the modules will compare as different
+    assert (model_module_1 == model_module_1b) is False
+    assert model_module_1.__file__ == model_module_1b.__file__
+    assert model_module_1b.get_model().getParameters()[0] == 1.0
 
-        model_module_2 = import_model_module(
-            module_name=module_name, module_path=outdir_2
-        )
-        assert model_module_1.get_model().getParameters()[0] == 1.0
-        assert model_module_2.get_model().getParameters()[0] == 2.0
+    model_module_2 = import_model_module(
+        module_name=module_name, module_path=outdir_2
+    )
+    assert model_module_1.get_model().getParameters()[0] == 1.0
+    assert model_module_2.get_model().getParameters()[0] == 2.0
 
-        # import the third model, with the same name and location as the second
-        #  model -- this is not supported, because there is some caching at
-        #  the C level we cannot control (or don't know how to)
+    # import the third model, with the same name and location as the second
+    #  model -- this is not supported, because there is some caching at
+    #  the C level we cannot control (or don't know how to)
 
-        # On Windows, this will give "permission denied" when building the
-        #  extension, because we cannot delete a shared library that is in use
+    # On Windows, this will give "permission denied" when building the
+    #  extension, because we cannot delete a shared library that is in use
 
-        if sys.platform == "win32":
-            return
+    if sys.platform == "win32":
+        return
 
-        antimony2amici(
-            ant_model_3,
-            model_name=module_name,
-            output_dir=outdir_2,
-        )
+    antimony2amici(
+        ant_model_3,
+        model_name=module_name,
+        output_dir=outdir_2,
+    )
 
-        with pytest.raises(RuntimeError, match="in the same location"):
-            import_model_module(module_name=module_name, module_path=outdir_2)
+    with pytest.raises(RuntimeError, match="in the same location"):
+        import_model_module(module_name=module_name, module_path=outdir_2)
 
-        # this should not affect the previously loaded models
-        assert model_module_1.get_model().getParameters()[0] == 1.0
-        assert model_module_2.get_model().getParameters()[0] == 2.0
+    # this should not affect the previously loaded models
+    assert model_module_1.get_model().getParameters()[0] == 1.0
+    assert model_module_2.get_model().getParameters()[0] == 2.0
 
-        # test that we can still import the model classically if we wanted to:
-        with amici.set_path(outdir_1):
-            import test_same_extension as model_module_1c  # noqa: F401
+    # test that we can still import the model classically if we wanted to:
+    with amici.set_path(outdir_1):
+        import test_same_extension as model_module_1c  # noqa: F401
 
-            assert model_module_1c.get_model().getParameters()[0] == 1.0
-            assert model_module_1c.get_model().module is model_module_1c
+        assert model_module_1c.get_model().getParameters()[0] == 1.0
+        assert model_module_1c.get_model().module is model_module_1c
 
 
 @skip_on_valgrind
-def test_regression_2642():
+def test_regression_2642(tempdir):
     sbml_file = Path(__file__).parent / "sbml_models" / "regression_2642.xml"
     sbml_importer = amici.SbmlImporter(sbml_file)
     model_name = "regression_2642"
-    with TemporaryDirectory(prefix="regression_2642") as outdir:
-        sbml_importer.sbml2amici(
-            model_name=model_name,
-            output_dir=outdir,
-        )
-        module = amici.import_model_module(
-            module_name=model_name, module_path=outdir
-        )
-        model = module.getModel()
-        solver = model.getSolver()
-        model.setTimepoints(np.linspace(0, 1, 3))
-        r = amici.runAmiciSimulation(model, solver)
-        assert (
-            len(np.unique(r.w[:, model.getExpressionIds().index("binding")]))
-            == 1
-        )
+    sbml_importer.sbml2amici(
+        model_name=model_name,
+        output_dir=tempdir,
+    )
+    module = amici.import_model_module(
+        module_name=model_name, module_path=tempdir
+    )
+    model = module.getModel()
+    solver = model.getSolver()
+    model.setTimepoints(np.linspace(0, 1, 3))
+    r = amici.runAmiciSimulation(model, solver)
+    assert (
+        len(np.unique(r.w[:, model.getExpressionIds().index("binding")])) == 1
+    )
 
 
 @skip_on_valgrind
-def test_regression_2700():
+def test_regression_2700(tempdir):
     """Check comparison operators."""
     from amici.antimony_import import antimony2amici
 
     model_name = "regression_2700"
-    with TemporaryDirectory(prefix=model_name) as outdir:
-        antimony2amici(
-            """
-        a = 1
-        # condition is always true, so `pp` should be 1
-        pp := piecewise(1, a >= 1 && a <= 1, 0)
-        """,
-            model_name=model_name,
-            output_dir=outdir,
-        )
+    antimony2amici(
+        """
+    a = 1
+    # condition is always true, so `pp` should be 1
+    pp := piecewise(1, a >= 1 && a <= 1, 0)
+    """,
+        model_name=model_name,
+        output_dir=tempdir,
+    )
 
-        model_module = import_model_module(model_name, outdir)
+    model_module = import_model_module(model_name, tempdir)
 
-        model = model_module.get_model()
+    model = model_module.get_model()
 
-        model.setTimepoints([0, 1, 2])
+    model.setTimepoints([0, 1, 2])
 
-        solver = model.getSolver()
+    solver = model.getSolver()
 
-        rdata = amici.runAmiciSimulation(model, solver)
+    rdata = amici.runAmiciSimulation(model, solver)
 
-        assert np.all(rdata.by_id("pp") == [1, 1, 1])
+    assert np.all(rdata.by_id("pp") == [1, 1, 1])
 
 
-def test_heaviside_init_values_and_bool_to_float_conversion():
+def test_heaviside_init_values_and_bool_to_float_conversion(tempdir):
     """
     Test that Boolean expressions are properly converted in a float context.
 
@@ -913,37 +900,32 @@ def test_heaviside_init_values_and_bool_to_float_conversion():
     from amici.antimony_import import antimony2amici
 
     model_name = "test_bool2float"
-    with TemporaryDirectory(prefix=model_name) as outdir:
-        antimony2amici(
-            """
-        # https://github.com/AMICI-dev/AMICI/issues/2717
-        a := 2 * (time >= t_a)  # TODO: change '>=' to '>' to trigger gh-2724
-        b := time >= t_b
+    antimony2amici(
+        """
+    # https://github.com/AMICI-dev/AMICI/issues/2717
+    a := 2 * (time >= t_a)  # TODO: change '>=' to '>' to trigger gh-2724
+    b := time >= t_b
 
-        # to trigger at t_0, to test for proper root function initial value
-        #  see https://github.com/AMICI-dev/AMICI/issues/2724
-        t_a = 0
-        # we need some differential state, otherwise root-finding won't work
-        t_a' = 0
+    # to trigger at t_0, to test for proper root function initial value
+    #  see https://github.com/AMICI-dev/AMICI/issues/2724
+    t_a = 0
+    # we need some differential state, otherwise root-finding won't work
+    t_a' = 0
 
-        # trigger after t_0
-        t_b = 1
-        """,
-            model_name=model_name,
-            output_dir=outdir,
-        )
+    # trigger after t_0
+    t_b = 1
+    """,
+        model_name=model_name,
+        output_dir=tempdir,
+    )
 
-        model_module = import_model_module(model_name, outdir)
+    model_module = import_model_module(model_name, tempdir)
 
-        model = model_module.get_model()
-        model.setTimepoints([0, 1, 2])
+    model = model_module.get_model()
+    model.setTimepoints([0, 1, 2])
 
-        solver = model.getSolver()
-        rdata = amici.runAmiciSimulation(model, solver)
+    solver = model.getSolver()
+    rdata = amici.runAmiciSimulation(model, solver)
 
-        assert np.all(rdata.by_id("a") == np.array([2, 2, 2])), rdata.by_id(
-            "a"
-        )
-        assert np.all(rdata.by_id("b") == np.array([0, 1, 1])), rdata.by_id(
-            "b"
-        )
+    assert np.all(rdata.by_id("a") == np.array([2, 2, 2])), rdata.by_id("a")
+    assert np.all(rdata.by_id("b") == np.array([0, 1, 1])), rdata.by_id("b")

--- a/python/tests/test_sbml_import_special_functions.py
+++ b/python/tests/test_sbml_import_special_functions.py
@@ -9,7 +9,7 @@ import numpy as np
 import pytest
 from amici.antimony_import import antimony2amici
 from amici.gradient_check import check_derivatives
-from amici.testing import TemporaryDirectoryWinSafe, skip_on_valgrind
+from amici.testing import skip_on_valgrind, TemporaryDirectoryWinSafe
 from numpy.testing import (
     assert_approx_equal,
     assert_array_almost_equal_nulp,
@@ -161,7 +161,7 @@ def negative_binomial_nllh(m: np.ndarray, y: np.ndarray, p: float):
 
 
 @skip_on_valgrind
-def test_rateof():
+def test_rateof(tempdir):
     """Test chained rateOf to verify that model expressions are evaluated in the correct order."""
     ant_model = """
     model test_chained_rateof
@@ -180,48 +180,43 @@ def test_rateof():
     end
     """
     module_name = "test_chained_rateof"
-    with TemporaryDirectoryWinSafe(prefix=module_name) as outdir:
-        antimony2amici(
-            ant_model,
-            model_name=module_name,
-            output_dir=outdir,
-        )
-        model_module = amici.import_model_module(
-            module_name=module_name, module_path=outdir
-        )
-        amici_model = model_module.getModel()
-        t = np.linspace(0, 10, 11)
-        amici_model.setTimepoints(t)
-        amici_solver = amici_model.getSolver()
-        rdata = amici.runAmiciSimulation(amici_model, amici_solver)
+    antimony2amici(
+        ant_model,
+        model_name=module_name,
+        output_dir=tempdir,
+    )
+    model_module = amici.import_model_module(
+        module_name=module_name, module_path=tempdir
+    )
+    amici_model = model_module.getModel()
+    t = np.linspace(0, 10, 11)
+    amici_model.setTimepoints(t)
+    amici_solver = amici_model.getSolver()
+    rdata = amici.runAmiciSimulation(amici_model, amici_solver)
 
-        state_ids_solver = amici_model.getStateIdsSolver()
-        i_S1 = state_ids_solver.index("S1")
-        i_S2 = state_ids_solver.index("S2")
-        i_S3 = state_ids_solver.index("S3")
-        i_p2 = state_ids_solver.index("p2")
-        assert_approx_equal(rdata["xdot"][i_S3], 1)
-        assert_approx_equal(rdata["xdot"][i_S2], 2)
-        assert_approx_equal(
-            rdata["xdot"][i_S1], rdata.by_id("S2")[-1] + rdata["xdot"][i_S2]
-        )
-        assert_approx_equal(rdata["xdot"][i_S1], rdata["xdot"][i_p2])
+    state_ids_solver = amici_model.getStateIdsSolver()
+    i_S1 = state_ids_solver.index("S1")
+    i_S2 = state_ids_solver.index("S2")
+    i_S3 = state_ids_solver.index("S3")
+    i_p2 = state_ids_solver.index("p2")
+    assert_approx_equal(rdata["xdot"][i_S3], 1)
+    assert_approx_equal(rdata["xdot"][i_S2], 2)
+    assert_approx_equal(
+        rdata["xdot"][i_S1], rdata.by_id("S2")[-1] + rdata["xdot"][i_S2]
+    )
+    assert_approx_equal(rdata["xdot"][i_S1], rdata["xdot"][i_p2])
 
-        assert_array_almost_equal_nulp(rdata.by_id("S3"), t, 10)
-        assert_array_almost_equal_nulp(
-            rdata.by_id("S2"), 2 * rdata.by_id("S3")
-        )
-        assert_array_almost_equal_nulp(
-            rdata.by_id("S4")[1:], 0.5 * np.diff(rdata.by_id("S3")), 10
-        )
-        assert_array_almost_equal_nulp(rdata.by_id("p3"), 0)
-        assert_array_almost_equal_nulp(
-            rdata.by_id("p2"), 1 + rdata.by_id("S1")
-        )
+    assert_array_almost_equal_nulp(rdata.by_id("S3"), t, 10)
+    assert_array_almost_equal_nulp(rdata.by_id("S2"), 2 * rdata.by_id("S3"))
+    assert_array_almost_equal_nulp(
+        rdata.by_id("S4")[1:], 0.5 * np.diff(rdata.by_id("S3")), 10
+    )
+    assert_array_almost_equal_nulp(rdata.by_id("p3"), 0)
+    assert_array_almost_equal_nulp(rdata.by_id("p2"), 1 + rdata.by_id("S1"))
 
 
 @skip_on_valgrind
-def test_rateof_with_expression_dependent_rate():
+def test_rateof_with_expression_dependent_rate(tempdir):
     """Test rateOf, where the rateOf argument depends on `w` and requires
     toposorting."""
     ant_model = """
@@ -238,31 +233,30 @@ def test_rateof_with_expression_dependent_rate():
     end
     """
     module_name = "test_rateof_with_expression_dependent_rate"
-    with TemporaryDirectoryWinSafe(prefix=module_name) as outdir:
-        antimony2amici(
-            ant_model,
-            model_name=module_name,
-            output_dir=outdir,
-        )
-        model_module = amici.import_model_module(
-            module_name=module_name, module_path=outdir
-        )
-        amici_model = model_module.getModel()
-        t = np.linspace(0, 10, 11)
-        amici_model.setTimepoints(t)
-        amici_solver = amici_model.getSolver()
-        rdata = amici.runAmiciSimulation(amici_model, amici_solver)
+    antimony2amici(
+        ant_model,
+        model_name=module_name,
+        output_dir=tempdir,
+    )
+    model_module = amici.import_model_module(
+        module_name=module_name, module_path=tempdir
+    )
+    amici_model = model_module.getModel()
+    t = np.linspace(0, 10, 11)
+    amici_model.setTimepoints(t)
+    amici_solver = amici_model.getSolver()
+    rdata = amici.runAmiciSimulation(amici_model, amici_solver)
 
-        state_ids_solver = amici_model.getStateIdsSolver()
+    state_ids_solver = amici_model.getStateIdsSolver()
 
-        assert_array_almost_equal_nulp(rdata.by_id("e1"), 2 * t, 1)
+    assert_array_almost_equal_nulp(rdata.by_id("e1"), 2 * t, 1)
 
-        i_S1 = state_ids_solver.index("S1")
-        i_S2 = state_ids_solver.index("S2")
-        assert_approx_equal(rdata["xdot"][i_S1], t[-1])
-        assert_approx_equal(rdata["xdot"][i_S2], 2 * t[-1])
+    i_S1 = state_ids_solver.index("S1")
+    i_S2 = state_ids_solver.index("S2")
+    assert_approx_equal(rdata["xdot"][i_S1], t[-1])
+    assert_approx_equal(rdata["xdot"][i_S2], 2 * t[-1])
 
-        assert_allclose(np.diff(rdata.by_id("S1")), t[:-1] + 0.5, atol=1e-9)
-        assert_array_almost_equal_nulp(
-            rdata.by_id("S2"), 2 * rdata.by_id("S1"), 10
-        )
+    assert_allclose(np.diff(rdata.by_id("S1")), t[:-1] + 0.5, atol=1e-9)
+    assert_array_almost_equal_nulp(
+        rdata.by_id("S2"), 2 * rdata.by_id("S1"), 10
+    )


### PR DESCRIPTION
Add a `tempdir` fixture to replace the context managers to make tests more readable. 
Update some tests accordingly.