### PR TITLE
Add warnings for presimulation and steady state simulation with events

### DIFF
--- a/src/forwardproblem.cpp
+++ b/src/forwardproblem.cpp
@@ -96,6 +96,14 @@ void ForwardProblem::workForwardProblem() {
                 "Presimulation with adjoint sensitivities"
                 " is currently not implemented."
             );
+        if (model->ne > 0) {
+            solver->logger->log(
+                LogSeverity::warning, "PRESIMULATION",
+                "Presimulation with events is not supported. "
+                "Events will be ignored during pre- and post-equilibration. "
+                "This is subject to change."
+                );
+        }
         handlePresimulation();
         t_ = model->t0();
         if (model->ne) {

--- a/src/steadystateproblem.cpp
+++ b/src/steadystateproblem.cpp
@@ -84,6 +84,15 @@ SteadystateProblem::SteadystateProblem(Solver const& solver, Model const& model)
 void SteadystateProblem::workSteadyStateProblem(
     Solver const& solver, Model& model, int it
 ) {
+    if (model.ne > 0) {
+        solver.logger->log(
+            LogSeverity::warning, "STEADY_STATE_SIMULATION",
+            "Steady-state simulation with events is not supported. "
+            "Events will be ignored during pre- and post-equilibration. "
+            "This is subject to change."
+            );
+    }
+
     initializeForwardProblem(it, solver, model);
 
     /* Compute steady state, track computation time */
@@ -111,7 +120,6 @@ void SteadystateProblem::workSteadyStateProblem(
 void SteadystateProblem::workSteadyStateBackwardProblem(
     Solver const& solver, Model& model, BackwardProblem const* bwd
 ) {
-
     if (!initializeBackwardProblem(solver, model, bwd))
         return;
 


### PR DESCRIPTION
Currently, events aren't handled during presimulation and steady state simulation. This will change. See https://github.com/AMICI-dev/AMICI/issues/2386.