### PR TITLE
CI: parallelize simulations for benchmark collection tests

### DIFF
--- a/tests/benchmark-models/test_petab_benchmark.py
+++ b/tests/benchmark-models/test_petab_benchmark.py
@@ -9,6 +9,7 @@ import copy
 from functools import partial
 from pathlib import Path
 
+import os
 import fiddy
 import amici
 import numpy as np
@@ -595,6 +596,7 @@ def test_benchmark_gradient(
         #  but not with cache=False
         # cache=not debug,
         cache=False,
+        num_threads=os.cpu_count(),
     )
     np.random.seed(cur_settings.rng_seed)
 


### PR DESCRIPTION
May reduce run time for then benchmark collection tests. Related to #2750.

No substantial impact, but doesn't hurt either.