### PR TITLE
Refactor dJydx handling

### DIFF
--- a/include/amici/forwardproblem.h
+++ b/include/amici/forwardproblem.h
@@ -95,12 +95,13 @@ class ForwardProblem {
     void workForwardProblem();
 
     /**
-     * @brief computes adjoint updates dJydx according to provided model and
-     * expdata
+     * @brief Computes adjoint updates dJydx according to the provided model
+     * and ExpData.
      * @param model Model instance
      * @param edata experimental data
+     * @return dJydx
      */
-    void getAdjointUpdates(Model& model, ExpData const& edata);
+    std::vector<realtype> getAdjointUpdates(Model& model, ExpData const& edata);
 
     /**
      * @brief Accessor for t
@@ -139,12 +140,6 @@ class ForwardProblem {
     std::vector<Discontinuity> const& getDiscontinuities() const {
         return discs_;
     }
-
-    /**
-     * @brief Accessor for dJydx
-     * @return dJydx
-     */
-    std::vector<realtype> const& getDJydx() const { return dJydx_; }
 
     /**
      * @brief Accessor for dJzdx
@@ -395,10 +390,6 @@ class ForwardProblem {
 
     /** Events that are waiting to be handled at the current timepoint. */
     EventQueue pending_events_;
-
-    /** state derivative of data likelihood
-     * (dimension nJ x nx x nt, ordering =?) */
-    std::vector<realtype> dJydx_;
 
     /** state derivative of event likelihood
      * (dimension nJ x nx x nMaxEvent, ordering =?) */

--- a/include/amici/steadystateproblem.h
+++ b/include/amici/steadystateproblem.h
@@ -244,11 +244,11 @@ class SteadystateProblem {
      *
      * @param solver The solver instance
      * @param model The model instance
-     * @param bwd The backward problem instance in case of pre-equilibration,
-     * or nullptr otherwise.
+     * @param xB0 Initial adjoint state vector.
+     * @param is_preeq Flag indicating whether this is a preequilibration.
      */
     void workSteadyStateBackwardProblem(
-        Solver const& solver, Model& model, BackwardProblem const* bwd
+        Solver const& solver, Model& model, AmiVector const& xB0, bool is_preeq
     );
 
     /**
@@ -279,14 +279,6 @@ class SteadystateProblem {
     [[nodiscard]] AmiVectorArray const& getStateSensitivity() const {
         return state_.sx;
     };
-
-    /**
-     * @brief Accessor for dJydx
-     * @return dJydx
-     */
-    [[nodiscard]] std::vector<realtype> const& getDJydx() const {
-        return dJydx_;
-    }
 
     /**
      * @brief Get the CPU time taken to solve the forward problem.
@@ -343,8 +335,11 @@ class SteadystateProblem {
      * data.
      * @param model Model instance
      * @param edata Experimental data
+     * @param dJydx output argument for dJydx
      */
-    void getAdjointUpdates(Model& model, ExpData const& edata);
+    void getAdjointUpdates(
+        Model& model, ExpData const& edata, std::vector<realtype>& dJydx
+    );
 
     /**
      * @brief Return the adjoint state
@@ -506,17 +501,6 @@ class SteadystateProblem {
     void initializeForwardProblem(int it, Solver const& solver, Model& model);
 
     /**
-     * @brief Initialize backward computation.
-     * @param solver Solver instance
-     * @param model Model instance.
-     * @param bwd pointer to the backward problem
-     * @return flag indicating whether backward computation to be carried out
-     */
-    bool initializeBackwardProblem(
-        Solver const& solver, Model& model, BackwardProblem const* bwd
-    );
-
-    /**
      * @brief Update member variables to indicate that state_.x has been
      * updated and xdot_, delta_, etc. need to be recomputed.
      */
@@ -559,12 +543,6 @@ class SteadystateProblem {
 
     /** weighted root-mean-square error */
     realtype wrms_{NAN};
-
-    /**
-     * state derivative of data likelihood
-     * (dimension nJ x nx x nt, ordering =?)
-     */
-    std::vector<realtype> dJydx_;
 
     SimulationState state_;
 


### PR DESCRIPTION
Maintain only one single instance of dJydx in BackwardProblem instead of up to four separate ones in SteadyStateProblem (preeq+posteq), ForwardProblem, BackwardProblem.

Saves space and reduces complexity.