### PR TITLE
Handle events during presimulation

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -1,0 +1,4 @@
+---
+CheckOptions:
+  performance-unnecessary-value-param.AllowedTypes: "gsl::not_null"
+  modernize-pass-by-value.AllowedTypes: "gsl::not_null"

--- a/include/amici/forwardproblem.h
+++ b/include/amici/forwardproblem.h
@@ -69,6 +69,11 @@ struct Discontinuity {
  * state during forward simulations.
  */
 struct FwdSimWorkspace {
+    /**
+     * @brief Constructor
+     * @param model The model for which to set up the workspace.
+     * @param solver The solver for which to set up this workspace.
+     */
     FwdSimWorkspace(gsl::not_null<Model*> model, gsl::not_null<Solver*> solver)
         : x(model->nx_solver, solver->getSunContext())
         , x_old(model->nx_solver, solver->getSunContext())
@@ -78,6 +83,11 @@ struct FwdSimWorkspace {
         , sx(model->nx_solver, model->nplist(), solver->getSunContext())
         , sdx(model->nx_solver, model->nplist(), solver->getSunContext())
         , stau(model->nplist())
+        , roots_found(model->ne, 0)
+        , rval_tmp(gsl::narrow<decltype(rval_tmp)::size_type>(model->ne), 0.0)
+        , nroots(gsl::narrow<decltype(nroots)::size_type>(model->ne), 0)
+        , rootvals(gsl::narrow<decltype(rootvals)::size_type>(model->ne), 0.0)
+
     {};
 
     /** state vector (dimension: nx_solver) */
@@ -105,8 +115,204 @@ struct FwdSimWorkspace {
     /** sensitivity of the event timepoint (dimension: nplist) */
     std::vector<realtype> stau;
 
-    /** storage for last found root */
+    /**
+     * @brief Array of flags indicating which root has been found.
+     *
+     * Array of length nr (ne) with the indices of the user functions gi found
+     * to have a root. For i = 0, . . . ,nr 1 or -1 if gi has a root, and = 0
+     * if not. See CVodeGetRootInfo for details.
+     */
+    std::vector<int> roots_found;
+
+    /** Timepoint at which the last root was found */
     realtype tlastroot{0.0};
+
+    /** Events that are waiting to be handled at the current timepoint. */
+    EventQueue pending_events;
+
+    /** temporary rootval storage to check crossing in secondary event
+     * (dimension: ne) */
+    std::vector<realtype> rval_tmp;
+
+    /** array of number of found roots for a certain event type
+     * (dimension: ne) */
+    std::vector<int> nroots;
+
+    /** array of values of the root function (dimension: ne) */
+    std::vector<realtype> rootvals;
+};
+
+/**
+ * @brief The PeriodResult class stores the result of a simulation period.
+ */
+struct PeriodResult {
+
+    /** Discontinuities encountered so far (dimension: dynamic) */
+    std::vector<Discontinuity> discs;
+    /** array of number of found roots for a certain event type
+     * (dimension: ne) */
+    std::vector<int> nroots;
+
+    /** simulation states history at timepoints */
+    std::map<realtype, SimulationState> timepoint_states_;
+
+    /** simulation state history at events */
+    std::vector<SimulationState> event_states_;
+
+    /** simulation state after initialization*/
+    SimulationState initial_state_;
+
+    /** simulation state after simulation */
+    SimulationState final_state_;
+};
+
+/**
+ * @brief The EventHandlingSimulator class runs a forward simulation
+ * and processes events, measurements or output timepoints in general.
+ */
+class EventHandlingSimulator {
+  public:
+    /**
+     * @brief EventHandlingSimulator
+     * @param model The model to simulate.
+     * @param solver The solver to use for the simulation.
+     * @param ws The workspace to use for the simulation.
+     * @param dJzdx State-derivative of event likelihood
+     * (dimension nJ x nx x nMaxEvent, ordering =?)
+     */
+    EventHandlingSimulator(
+        gsl::not_null<Model*> model, gsl::not_null<Solver*> solver,
+        gsl::not_null<FwdSimWorkspace*> ws,
+        gsl::not_null<std::vector<realtype>*> dJzdx
+    )
+        : model_(model)
+        , solver_(solver)
+        , ws_(ws)
+        , dJzdx_(dJzdx) {};
+
+    /**
+     * @brief run Run the simulation.
+     *
+     * It will run the simulation from the initial time of this period
+     * to the final timepoint of this period, handling events
+     * and data points as they occur.
+     *
+     * Expects the model and the solver to be set up, and `ws` to be initialized
+     * for this period.
+     *
+     * @param t The initial time of this period.
+     * @param edata Any experimental data associated with this simulation.
+     * `nullptr` if no experimental data is associated with this
+     * period.
+     * @param timepoints The output timepoints or measurement timepoints of
+     * this period. This must contain at least the final timepoint of this
+     * period.
+     */
+    void
+    run(realtype t, ExpData const* edata,
+        std::vector<amici::realtype> const& timepoints);
+
+    /**
+     * @brief Returns maximal event index for which the timepoint is available
+     * @return index
+     */
+    int getRootCounter() const {
+        return gsl::narrow<int>(result.discs.size()) - 1;
+    }
+
+    /**
+     * @brief Returns maximal event index for which simulations are available
+     * @return index
+     */
+    int getEventCounter() const {
+        return gsl::narrow<int>(result.event_states_.size()) - 1;
+    }
+
+    /**
+     * @brief Creates a carbon copy of the current simulation state variables
+     * @return state
+     */
+    SimulationState getSimulationState();
+
+    /** Results for the currentb simulation period. */
+    PeriodResult result;
+    /** The current time. */
+    realtype t_;
+    /** Initial time of the current period. */
+    realtype t0_;
+    /** Time index in the current list of timepoints */
+    int it_;
+
+  private:
+    /**
+     * @brief Execute everything necessary for the handling of events
+     *
+     * @param initial_event initial event flag
+     */
+    void handleEvent(bool initial_event, amici::ExpData const* edata);
+
+    /**
+     * @brief Store pre-event model state
+     *
+     * @param seflag Secondary event flag
+     * @param initial_event initial event flag
+     */
+    void store_pre_event_state(bool seflag, bool initial_event);
+
+    /**
+     * @brief Check for, and if applicable, handle any secondary events
+     * @return the number of secondary events found
+     */
+    int detect_secondary_events();
+
+    /**
+     * @brief Extract output information for events
+     */
+    void storeEvent(amici::ExpData const* edata);
+
+    /**
+     * @brief Execute everything necessary for the handling of data points
+     *
+     * @param t measurement timepoint
+     */
+    void handleDataPoint(realtype t);
+
+    /**
+     * @brief fills events at final timepoint if necessary
+     *
+     * @param nmaxevent maximal number of events
+     */
+    void fillEvents(int nmaxevent, amici::ExpData const* edata) {
+        if (checkEventsToFill(nmaxevent)) {
+            result.discs.emplace_back(t_);
+            storeEvent(edata);
+        }
+    }
+
+    /**
+     * @brief checks whether there are any events to fill
+     *
+     * @param nmaxevent maximal number of events
+     */
+    bool checkEventsToFill(int nmaxevent) const {
+        return std::any_of(
+            ws_->nroots.cbegin(), ws_->nroots.cend(),
+            [nmaxevent](int curNRoots) { return curNRoots < nmaxevent; }
+        );
+    };
+
+    /** The model to simulate. */
+    Model* model_;
+
+    /** The solver to use for the simulation. */
+    Solver* solver_;
+
+    /** The workspace to use for the simulation. */
+    gsl::not_null<FwdSimWorkspace*> ws_;
+
+    /** state derivative of event likelihood
+     * (dimension nJ x nx x nMaxEvent, ordering =?) */
+    std::vector<realtype>* dJzdx_ = nullptr;
 };
 
 /**
@@ -155,7 +361,6 @@ class ForwardProblem {
      */
     realtype getTime() const { return t_; }
 
-
     /**
      * @brief Accessor for sx
      * @return sx
@@ -166,14 +371,16 @@ class ForwardProblem {
      * @brief Accessor for nroots
      * @return nroots
      */
-    std::vector<int> const& getNumberOfRoots() const { return nroots_; }
+    std::vector<int> const& getNumberOfRoots() const {
+        return main_simulator_.result.nroots;
+    }
 
     /**
      * @brief Get information on the discontinuities encountered so far.
      * @return The vector of discontinuities.
      */
     std::vector<Discontinuity> const& getDiscontinuities() const {
-        return discs_;
+        return main_simulator_.result.discs;
     }
 
     /**
@@ -192,21 +399,15 @@ class ForwardProblem {
      * @brief Returns final time point for which simulations are available
      * @return time point
      */
-    realtype getFinalTime() const { return final_state_.t; }
+    realtype getFinalTime() const {
+        return main_simulator_.result.final_state_.t;
+    }
 
     /**
      * @brief Returns maximal event index for which simulations are available
      * @return index
      */
-    int getEventCounter() const {
-        return gsl::narrow<int>(event_states_.size()) - 1;
-    }
-
-    /**
-     * @brief Returns maximal event index for which the timepoint is available
-     * @return index
-     */
-    int getRootCounter() const { return gsl::narrow<int>(discs_.size()) - 1; }
+    int getEventCounter() const { return main_simulator_.getEventCounter(); }
 
     /**
      * @brief Retrieves the carbon copy of the simulation state variables at
@@ -215,10 +416,12 @@ class ForwardProblem {
      * @return state
      */
     SimulationState const& getSimulationStateTimepoint(int it) const {
-        if (model->getTimepoint(it) == initial_state_.t)
+        if (model->getTimepoint(it) == main_simulator_.result.initial_state_.t)
             return getInitialSimulationState();
-        auto map_iter = timepoint_states_.find(model->getTimepoint(it));
-        Ensures(map_iter != timepoint_states_.end());
+        auto map_iter = main_simulator_.result.timepoint_states_.find(
+            model->getTimepoint(it)
+        );
+        Ensures(map_iter != main_simulator_.result.timepoint_states_.end());
         return map_iter->second;
     };
 
@@ -229,7 +432,7 @@ class ForwardProblem {
      * @return SimulationState
      */
     SimulationState const& getSimulationStateEvent(int iroot) const {
-        return event_states_.at(iroot);
+        return main_simulator_.result.event_states_.at(iroot);
     };
 
     /**
@@ -238,7 +441,7 @@ class ForwardProblem {
      * @return SimulationState
      */
     SimulationState const& getInitialSimulationState() const {
-        return initial_state_;
+        return main_simulator_.result.initial_state_;
     };
 
     /**
@@ -247,7 +450,7 @@ class ForwardProblem {
      * @return SimulationState
      */
     SimulationState const& getFinalSimulationState() const {
-        return final_state_;
+        return main_simulator_.result.final_state_;
     };
 
     /**
@@ -310,12 +513,6 @@ class ForwardProblem {
     void handlePreequilibration();
 
     /**
-     * @brief Initialize model and solver for presimulation or
-     * the main simulation if there is no presimulation.
-     */
-    void initialize();
-
-    /**
      * @brief Handle pre-simulation if required.
      *
      * Pre-simulation starts at `Model::t0() - ExpData::t_presim`.
@@ -344,115 +541,12 @@ class ForwardProblem {
      */
     void handlePostequilibration();
 
-    /**
-     * @brief Execute everything necessary for the handling of events
-     *
-     * @param tlastroot Reference to the timepoint of the last event
-     * @param initial_event initial event flag
-     */
-
-    void handleEvent(realtype& tlastroot, bool initial_event);
-
-    /**
-     * @brief Store pre-event model state
-     *
-     * @param seflag Secondary event flag
-     * @param initial_event initial event flag
-     */
-    void store_pre_event_state(bool seflag, bool initial_event);
-
-    /**
-     * @brief Check for, and if applicable, handle any secondary events
-     * @return the number of secondary events found
-     */
-    int detect_secondary_events();
-
-    /**
-     * @brief Extract output information for events
-     */
-    void storeEvent();
-
-    /**
-     * @brief Execute everything necessary for the handling of data points
-     *
-     * @param t measurement timepoint
-     */
-    void handleDataPoint(realtype t);
-
-    /**
-     * @brief checks whether there are any events to fill
-     *
-     * @param nmaxevent maximal number of events
-     */
-    bool checkEventsToFill(int nmaxevent) const {
-        return std::any_of(
-            nroots_.cbegin(), nroots_.cend(),
-            [nmaxevent](int curNRoots) { return curNRoots < nmaxevent; }
-        );
-    };
-
-    /**
-     * @brief fills events at final timepoint if necessary
-     *
-     * @param nmaxevent maximal number of events
-     */
-    void fillEvents(int nmaxevent) {
-        if (checkEventsToFill(nmaxevent)) {
-            discs_.emplace_back(t_);
-            storeEvent();
-        }
-    }
-
-    /**
-     * @brief Creates a carbon copy of the current simulation state variables
-     * @return state
-     */
-    SimulationState getSimulationState();
-
-    /** array of number of found roots for a certain event type
-     * (dimension: ne) */
-    std::vector<int> nroots_;
-
-    /** array of values of the root function (dimension: ne) */
-    std::vector<realtype> rootvals_;
-
-    /** temporary rootval storage to check crossing in secondary event
-     * (dimension: ne) */
-    std::vector<realtype> rval_tmp_;
-
-    /** Discontinuities encountered so far (dimension: dynamic) */
-    std::vector<Discontinuity> discs_;
-
-    /** Events that are waiting to be handled at the current timepoint. */
-    EventQueue pending_events_;
-
     /** state derivative of event likelihood
      * (dimension nJ x nx x nMaxEvent, ordering =?) */
     std::vector<realtype> dJzdx_;
 
     /** current time */
     realtype t_;
-
-    /**
-     * @brief Array of flags indicating which root has been found.
-     *
-     * Array of length nr (ne) with the indices of the user functions gi found
-     * to have a root. For i = 0, . . . ,nr 1 or -1 if gi has a root, and = 0
-     * if not. See CVodeGetRootInfo for details.
-     */
-    std::vector<int> roots_found_;
-
-    /** simulation states history at timepoints */
-    std::map<realtype, SimulationState> timepoint_states_;
-
-    /** simulation state history at events */
-    std::vector<SimulationState> event_states_;
-
-    /** simulation state after initialization*/
-    SimulationState initial_state_;
-
-    /** simulation state after simulation */
-    SimulationState final_state_;
 
     /** flag to indicate whether solver was preeinitialized via preequilibration
      */
@@ -471,6 +565,8 @@ class ForwardProblem {
     std::optional<SteadystateProblem> posteq_problem_;
 
     FwdSimWorkspace ws_;
+    EventHandlingSimulator main_simulator_;
+    EventHandlingSimulator pre_simulator_;
 };
 
 /**
@@ -497,18 +593,22 @@ class FinalStateStorer : public ContextManager {
                 // due to https://github.com/LLNL/sundials/issues/82.
                 // Therefore, this dtor must be `noexcept(false)` to avoid
                 // programm termination.
-                fwd_->final_state_ = fwd_->getSimulationState();
+                fwd_->main_simulator_.result.final_state_
+                    = fwd_->main_simulator_.getSimulationState();
                 // if there is an associated output timepoint, also store it in
                 // timepoint_states if it's not present there.
                 // this may happen if there is an error just at
                 // (or indistinguishably before) an output timepoint
                 auto final_time = fwd_->getFinalTime();
                 auto const timepoints = fwd_->model->getTimepoints();
-                if (!fwd_->timepoint_states_.count(final_time)
+                if (!fwd_->main_simulator_.result.timepoint_states_.count(
+                        final_time
+                    )
                     && std::find(
                            timepoints.cbegin(), timepoints.cend(), final_time
                        ) != timepoints.cend()) {
-                    fwd_->timepoint_states_[final_time] = fwd_->final_state_;
+                    fwd_->main_simulator_.result.timepoint_states_[final_time]
+                        = fwd_->main_simulator_.result.final_state_;
                 }
             } catch (std::exception const&) {
                 // We must not throw in case we are already in the stack

--- a/include/amici/forwardproblem.h
+++ b/include/amici/forwardproblem.h
@@ -71,7 +71,8 @@ struct Discontinuity {
  * @param nmaxevents Maximum number of events to track (nmaxevents).
  * @return The number of roots for each root function.
  */
-std::vector<int> compute_nroots(std::vector<Discontinuity> const& discs, int ne, int nmaxevents);
+std::vector<int>
+compute_nroots(std::vector<Discontinuity> const& discs, int ne, int nmaxevents);
 
 /**
  * @brief The FwdSimWorkspace class is used to store temporary simulation
@@ -321,7 +322,6 @@ class EventHandlingSimulator {
      * (dimension nJ x nx x nMaxEvent, ordering =?) */
     std::vector<realtype>* dJzdx_ = nullptr;
 };
-
 
 /**
  * @brief The ForwardProblem class groups all functions for solving the

--- a/include/amici/forwardproblem.h
+++ b/include/amici/forwardproblem.h
@@ -234,7 +234,7 @@ class EventHandlingSimulator {
      */
     SimulationState getSimulationState();
 
-    /** Results for the currentb simulation period. */
+    /** Results for the current simulation period. */
     PeriodResult result;
     /** The current time. */
     realtype t_;

--- a/include/amici/model.h
+++ b/include/amici/model.h
@@ -221,6 +221,7 @@ class Model : public AbstractModel, public ModelDimensions {
 
     /**
      * @brief Initialize model properties.
+     * @param t Timepoint
      * @param x Reference to state variables
      * @param dx Reference to time derivative of states (DAE only)
      * @param sx Reference to state variable sensitivities
@@ -231,8 +232,9 @@ class Model : public AbstractModel, public ModelDimensions {
      * at t0 by this fun
      */
     void initialize(
-        AmiVector& x, AmiVector& dx, AmiVectorArray& sx, AmiVectorArray& sdx,
-        bool computeSensitivities, std::vector<int>& roots_found
+        realtype t, AmiVector& x, AmiVector& dx, AmiVectorArray& sx,
+        AmiVectorArray& sdx, bool computeSensitivities,
+        std::vector<int>& roots_found
     );
 
     /**
@@ -260,16 +262,20 @@ class Model : public AbstractModel, public ModelDimensions {
 
     /**
      * @brief Initialize initial states.
+     * @param t Timepoint
      * @param x State vector to be initialized
      */
-    void initializeStates(AmiVector& x);
+    void initializeStates(realtype t, AmiVector& x);
 
     /**
      * @brief Initialize initial state sensitivities.
+     * @param t Timepoint.
      * @param sx Reference to state variable sensitivities
      * @param x Reference to state variables
      */
-    void initializeStateSensitivities(AmiVectorArray& sx, AmiVector const& x);
+    void initializeStateSensitivities(
+        realtype t, AmiVectorArray& sx, AmiVector const& x
+    );
 
     /**
      * @brief Initialization of spline functions
@@ -286,13 +292,15 @@ class Model : public AbstractModel, public ModelDimensions {
      *
      * Heaviside variables activate/deactivate on event occurrences.
      *
+     * @param t Timepoint
      * @param x Reference to state variables
      * @param dx Reference to time derivative of states (DAE only)
      * @param roots_found boolean indicators indicating whether roots were found
      * at t0 by this fun
      */
     void initEvents(
-        AmiVector const& x, AmiVector const& dx, std::vector<int>& roots_found
+        realtype t, AmiVector const& x, AmiVector const& dx,
+        std::vector<int>& roots_found
     );
 
     /**
@@ -827,9 +835,16 @@ class Model : public AbstractModel, public ModelDimensions {
 
     /**
      * @brief Get the initial states.
+     * @param t0 Custom t0 for which to get initial states.
      * @return Initial state vector
      */
-    std::vector<realtype> getInitialStates();
+    std::vector<realtype> getInitialStates(realtype t0);
+
+    /**
+     * @brief Get the initial states.
+     * @return Initial state vector
+     */
+    std::vector<realtype> getInitialStates() { return getInitialStates(t0()); };
 
     /**
      * @brief Set the initial states.
@@ -847,7 +862,16 @@ class Model : public AbstractModel, public ModelDimensions {
      * @brief Get the initial states sensitivities.
      * @return vector of initial state sensitivities
      */
-    std::vector<realtype> getInitialStateSensitivities();
+    std::vector<realtype> getInitialStateSensitivities() {
+        return getInitialStateSensitivities(t0());
+    };
+
+    /**
+     * @brief Get the initial states sensitivities.
+     * @param t0 Custom t0 for which to get initial states.
+     * @return vector of initial state sensitivities
+     */
+    std::vector<realtype> getInitialStateSensitivities(realtype t0);
 
     /**
      * @brief Set the initial state sensitivities.
@@ -1389,31 +1413,36 @@ class Model : public AbstractModel, public ModelDimensions {
 
     /**
      * @brief Compute/get initial states.
+     * @param t Timepoint.
      * @param x Output buffer.
      */
-    void fx0(AmiVector& x);
+    void fx0(realtype t, AmiVector& x);
 
     /**
      * @brief Set only those initial states that are specified via
      * fixed parameters.
+     * @param t Timepoint.
      * @param x Output buffer.
      */
-    void fx0_fixedParameters(AmiVector& x);
+    void fx0_fixedParameters(realtype t, AmiVector& x);
 
     /**
      * @brief Compute/get initial value for initial state sensitivities.
+     * @param t Timepoint.
      * @param sx Output buffer for state sensitivities
      * @param x State variables
      */
-    void fsx0(AmiVectorArray& sx, AmiVector const& x);
+    void fsx0(realtype t, AmiVectorArray& sx, AmiVector const& x);
 
     /**
      * @brief Get only those initial states sensitivities that are affected
      * from `amici::Model::fx0_fixedParameters`.
+     * @param t Timepoint
      * @param sx Output buffer for state sensitivities
      * @param x State variables
      */
-    void fsx0_fixedParameters(AmiVectorArray& sx, AmiVector const& x);
+    void
+    fsx0_fixedParameters(realtype t, AmiVectorArray& sx, AmiVector const& x);
 
     /**
      * @brief Compute sensitivity of derivative initial states sensitivities

--- a/include/amici/model.h
+++ b/include/amici/model.h
@@ -261,15 +261,15 @@ class Model : public AbstractModel, public ModelDimensions {
     ) const;
 
     /**
-     * @brief Initialize initial states.
-     * @param t Timepoint
-     * @param x State vector to be initialized
+     * @brief Initialize model state.
+     * @param t Initial timepoint
+     * @param x State vector to be initialized (size: nx_solver).
      */
     void initializeStates(realtype t, AmiVector& x);
 
     /**
      * @brief Initialize initial state sensitivities.
-     * @param t Timepoint.
+     * @param t Initial timepoint.
      * @param sx Reference to state variable sensitivities
      * @param x Reference to state variables
      */
@@ -834,32 +834,32 @@ class Model : public AbstractModel, public ModelDimensions {
     void setParameterList(std::vector<int> const& plist);
 
     /**
-     * @brief Get the initial states.
+     * @brief Get the initial state.
      * @param t0 Custom t0 for which to get initial states.
-     * @return Initial state vector
+     * @return Initial state vector, before any events are executed.
      */
     std::vector<realtype> getInitialStates(realtype t0);
 
     /**
-     * @brief Get the initial states.
-     * @return Initial state vector
+     * @brief Get the initial state for Model::t0()`.
+     * @return Initial state vector, before any events are executed.
      */
     std::vector<realtype> getInitialStates() { return getInitialStates(t0()); };
 
     /**
-     * @brief Set the initial states.
+     * @brief Set the pre-event initial state.
      * @param x0 Initial state vector
      */
     void setInitialStates(std::vector<realtype> const& x0);
 
     /**
-     * @brief Return whether custom initial states have been set.
-     * @return `true` if has custom initial states, otherwise `false`
+     * @brief Return whether custom initial state have been set.
+     * @return `true` if has custom initial state, otherwise `false`
      */
     bool hasCustomInitialStates() const;
 
     /**
-     * @brief Get the initial states sensitivities.
+     * @brief Get the initial state sensitivities.
      * @return vector of initial state sensitivities
      */
     std::vector<realtype> getInitialStateSensitivities() {
@@ -1412,9 +1412,9 @@ class Model : public AbstractModel, public ModelDimensions {
     bool getAlwaysCheckFinite() const;
 
     /**
-     * @brief Compute/get initial states.
+     * @brief Compute/get pre-event initial state.
      * @param t Timepoint.
-     * @param x Output buffer.
+     * @param x Output buffer (size: nx_solver).
      */
     void fx0(realtype t, AmiVector& x);
 

--- a/python/tests/test_sbml_import.py
+++ b/python/tests/test_sbml_import.py
@@ -251,6 +251,91 @@ def test_presimulation(sbml_example_presimulation_module):
     check_derivatives(model, solver, edata, epsilon=1e-4)
 
 
+def test_presimulation_events(tempdir):
+    """Test that events are handled during presimulation."""
+
+    from amici.antimony_import import antimony2amici
+
+    model_name = "test_presim_events"
+    antimony2amici(
+        """
+    t_initial_presim = -2
+    one = 1
+    presim_indicator = -1
+    presim_target_initial = 0
+    presim_target_1 = 0
+    mainsim_target = 0
+
+    some_time = time
+    some_time' = 1
+
+    at time >= t_initial_presim and presim_indicator == 1, t0=false: presim_target_initial = time
+    at time >= -one and presim_indicator == 1: presim_target_1 = presim_target_1 + one
+    at time >= one and presim_indicator == 0: mainsim_target = mainsim_target + 1
+    """,
+        constant_parameters=["presim_indicator"],
+        model_name=model_name,
+        output_dir=tempdir,
+    )
+
+    model_module = import_model_module(model_name, tempdir)
+
+    model = model_module.get_model()
+    model.setTimepoints([0, 1, 2])
+    edata = amici.ExpData(model)
+    edata.t_presim = 2
+    edata.fixedParametersPresimulation = [1]
+    edata.fixedParameters = [0]
+    solver = model.getSolver()
+
+    # generate artificial data
+    rdata = amici.runAmiciSimulation(model, solver, edata)
+    edata_tmp = amici.ExpData(rdata, 1, 0)
+    edata.setTimepoints(np.array(edata_tmp.getTimepoints()) + 0.1)
+    edata.setObservedData(edata_tmp.getObservedData())
+    edata.setObservedDataStdDev(edata_tmp.getObservedDataStdDev())
+
+    # sensitivities w.r.t. t_initial_presim (trigger time of an initial event)
+    #  are not supported
+    edata.plist = [
+        ip
+        for ip, p in enumerate(model.getParameterIds())
+        if p != "t_initial_presim"
+    ]
+    solver.setSensitivityOrder(amici.SensitivityOrder.first)
+
+    for sensi_method in (
+        amici.SensitivityMethod.forward,
+        # TODO ASA
+        # amici.SensitivityMethod.adjoint,
+    ):
+        solver.setSensitivityMethod(sensi_method)
+        rdata = amici.runAmiciSimulation(model, solver, edata)
+
+        assert rdata.status == amici.AMICI_SUCCESS
+        assert_allclose(
+            rdata.by_id("some_time"), np.array([0, 1, 2]) + 0.1, atol=1e-14
+        )
+        assert np.all(
+            rdata.by_id("presim_target_initial") == np.array([-2, -2, -2])
+        ), rdata.by_id("presim_target_initial")
+        assert np.all(
+            rdata.by_id("presim_target_1") == np.array([1, 1, 1])
+        ), rdata.by_id("presim_target_1")
+        assert np.all(
+            rdata.by_id("mainsim_target") == np.array([0, 1, 1])
+        ), rdata.by_id("mainsim_target")
+
+        check_derivatives(
+            model,
+            solver,
+            edata=edata,
+            atol=1e-6,
+            rtol=1e-6,
+            epsilon=1e-8,
+        )
+
+
 def test_steadystate_simulation(model_steadystate_module):
     model = model_steadystate_module.getModel()
     model.setTimepoints(np.linspace(0, 60, 60))

--- a/src/backwardproblem.cpp
+++ b/src/backwardproblem.cpp
@@ -36,7 +36,7 @@ void BackwardProblem::workBackwardProblem() {
 
     // If we have posteq, infinity timepoints were already treated
     int it = model_->nt() - 1;
-    while(it >= 0 && std::isinf(model_->getTimepoint(it))) {
+    while (it >= 0 && std::isinf(model_->getTimepoint(it))) {
         --it;
     }
 

--- a/src/forwardproblem.cpp
+++ b/src/forwardproblem.cpp
@@ -573,7 +573,7 @@ SimulationState EventHandlingSimulator::get_simulation_state() {
 
 std::vector<int> compute_nroots(
     std::vector<Discontinuity> const& discs, int ne, int nmaxevents
-    ) {
+) {
     auto size = gsl::narrow<std::vector<int>::size_type>(ne);
     std::vector<int> nroots(size, 0);
     for (auto const& disc : discs) {
@@ -591,6 +591,5 @@ std::vector<int> compute_nroots(
     }
     return nroots;
 }
-
 
 } // namespace amici

--- a/src/forwardproblem.cpp
+++ b/src/forwardproblem.cpp
@@ -9,6 +9,7 @@
 
 #include <algorithm>
 #include <cmath>
+#include <ranges>
 
 namespace amici {
 
@@ -41,14 +42,111 @@ ForwardProblem::ForwardProblem(
     : model(model)
     , solver(solver)
     , edata(edata)
-    , nroots_(gsl::narrow<decltype(nroots_)::size_type>(model->ne), 0)
-    , rootvals_(gsl::narrow<decltype(rootvals_)::size_type>(model->ne), 0.0)
-    , rval_tmp_(gsl::narrow<decltype(rval_tmp_)::size_type>(model->ne), 0.0)
     , dJzdx_(model->nJ * model->nx_solver * model->nMaxEvent(), 0.0)
     , t_(model->t0())
-    , roots_found_(model->ne, 0)
     , uses_presimulation_(edata && edata->t_presim > 0)
-    , ws_(model, solver){}
+    , ws_(model, solver)
+    , main_simulator_(model, solver, &ws_, &dJzdx_)
+    , pre_simulator_(model, solver, &ws_, &dJzdx_) {}
+
+void EventHandlingSimulator::run(
+    realtype const t0, ExpData const* edata,
+    std::vector<realtype> const& timepoints
+) {
+    std::ranges::fill(ws_->nroots, 0);
+
+    t0_ = t0;
+    t_ = t0;
+    ws_->tlastroot = t0;
+
+    // handle initial events
+    if (model_->ne && std::ranges::any_of(ws_->roots_found, [](int rf) {
+            return rf == 1;
+        })) {
+        handleEvent(true, edata);
+    }
+
+    // store initial state and sensitivity
+    result.initial_state_ = getSimulationState();
+    // store root information at t0
+    model_->froot(t_, ws_->x, ws_->dx, ws_->rootvals);
+
+    // get list of trigger timepoints for fixed-time triggered events
+    // and filter for timepoints that are within the simulation time range
+    auto trigger_timepoints_tmp = model_->get_trigger_timepoints();
+    auto trigger_timepoints = std::ranges::views::filter(
+        trigger_timepoints_tmp,
+        [this, timepoints](auto t) {
+            return t > t_ && t <= timepoints.at(timepoints.size() - 1);
+        }
+    );
+    auto it_trigger_timepoints = trigger_timepoints.begin();
+
+    // loop over timepoints
+    for (it_ = 0; it_ < gsl::narrow<int>(timepoints.size()); it_++) {
+        // next output time-point
+        auto next_t_out = timepoints[it_];
+
+        if (std::isinf(next_t_out)) {
+            // post-equilibration is handled elsewhere
+            break;
+        }
+
+        if (next_t_out > t0) {
+            // Solve for next output timepoint
+            while (t_ < next_t_out) {
+                if (is_next_t_too_close(t_, next_t_out)) {
+                    // next timepoint is too close to current timepoint.
+                    // we use the state of the current timepoint.
+                    break;
+                }
+
+                // next stop time is next output timepoint or next
+                // time-triggered event
+                auto next_t_event
+                    = it_trigger_timepoints != trigger_timepoints.end()
+                          ? *it_trigger_timepoints
+                          : std::numeric_limits<realtype>::infinity();
+                auto next_t_stop = std::min(next_t_out, next_t_event);
+
+                int status = solver_->run(next_t_stop);
+                // sx will be copied from solver on demand if sensitivities
+                // are computed
+                solver_->writeSolution(&t_, ws_->x, ws_->dx, ws_->sx, ws_->dx);
+
+                if (status == AMICI_ILL_INPUT) {
+                    // clustering of roots => turn off root-finding
+                    solver_->turnOffRootFinding();
+                } else if (status == AMICI_ROOT_RETURN || t_ == next_t_event) {
+                    // solver-tracked or time-triggered event
+                    solver_->getRootInfo(ws_->roots_found.data());
+
+                    // check if we are at a trigger timepoint.
+                    // if so, set the root-found flag
+                    if (t_ == next_t_event) {
+                        for (auto ie : model_->state_independent_events_[t_]) {
+                            // determine direction of root crossing from
+                            // root function value at the previous event
+                            ws_->roots_found[ie]
+                                = std::copysign(1, -ws_->rootvals[ie]);
+                        }
+                        ++it_trigger_timepoints;
+                    }
+
+                    handleEvent(false, edata);
+                }
+            }
+        }
+        handleDataPoint(next_t_out);
+    }
+
+    // fill events
+    if (model_->nz > 0 && model_->nt() > 0) {
+        fillEvents(model_->nMaxEvent(), edata);
+    }
+
+    result.nroots = ws_->nroots;
+}
 
 void ForwardProblem::workForwardProblem() {
     handlePreequilibration();
@@ -56,7 +154,6 @@ void ForwardProblem::workForwardProblem() {
     {
         FinalStateStorer fss(this);
 
-        initialize();
         handlePresimulation();
         handleMainSimulation();
     }
@@ -79,30 +176,6 @@ void ForwardProblem::handlePreequilibration() {
     preequilibrated_ = true;
 }
 
-void ForwardProblem::initialize() {
-    // if preequilibration was done, model was already initialized
-    if (!preequilibrated_)
-        model->initialize(
-            ws_.x, ws_.dx, ws_.sx, ws_.sdx,
-            solver->getSensitivityOrder() >= SensitivityOrder::first,
-            roots_found_
-        );
-    else if (model->ne) {
-        model->initEvents(ws_.x, ws_.dx, roots_found_);
-    }
-
-    // compute initial time and setup solver for (pre-)simulation
-    auto t0 = model->t0();
-    if (uses_presimulation_)
-        t0 -= edata->t_presim;
-    solver->setup(t0, model, ws_.x, ws_.dx, ws_.sx, ws_.sdx);
-
-    if (model->ne
-        && std::ranges::any_of(roots_found_, [](int rf) { return rf == 1; })) {
-        handleEvent(t0, true);
-    }
-}
-
 void ForwardProblem::handlePresimulation() {
     if (!uses_presimulation_)
         return;
@@ -114,34 +187,31 @@ void ForwardProblem::handlePresimulation() {
         );
     }
 
-    if (model->ne > 0) {
-        solver->logger->log(
-            LogSeverity::warning, "PRESIMULATION",
-            "Presimulation with events is not supported. "
-            "Events will be ignored during pre- and post-equilibration. "
-            "This is subject to change."
-        );
-    }
-
     {
         // Are there dedicated condition preequilibration parameters provided?
         ConditionContext cond(
             model, edata, FixedParameterContext::presimulation
         );
+
+        // compute initial time and setup solver for (pre-)simulation
+        t_ = model->t0() - edata->t_presim;
+
+        // if preequilibration was done, model was already initialized
+        if (!preequilibrated_) {
+            model->initialize(
+                t_, ws_.x, ws_.dx, ws_.sx, ws_.sdx,
+                solver->getSensitivityOrder() >= SensitivityOrder::first,
+                ws_.roots_found
+            );
+        } else if (model->ne) {
+            model->initEvents(t_, ws_.x, ws_.dx, ws_.roots_found);
+        }
+        solver->setup(t_, model, ws_.x, ws_.dx, ws_.sx, ws_.sdx);
         solver->updateAndReinitStatesAndSensitivities(model);
 
-        solver->run(model->t0());
+        std::vector<realtype> timepoints{model->t0()};
+        pre_simulator_.run(t_, edata, timepoints);
         solver->writeSolution(&t_, ws_.x, ws_.dx, ws_.sx, ws_.dx);
-    }
-
-    // Reset the time and re-initialize events for the main simulation
-    t_ = model->t0();
-    if (model->ne) {
-        model->initEvents(ws_.x, ws_.dx, roots_found_);
-        if (std::ranges::any_of(roots_found_, [](int rf) { return rf == 1; })) {
-            auto t0 = model->t0();
-            handleEvent(t0, true);
-        }
     }
 }
 
@@ -153,8 +223,27 @@ void ForwardProblem::handleMainSimulation() {
     if (solver->computingASA() && uses_presimulation_)
         ws_.sx = solver->getStateSensitivity(model->t0());
 
-    if (uses_presimulation_ || preequilibrated_)
+    if (!preequilibrated_ && !uses_presimulation_) {
+        // if preequilibration or presimulation was done, model was already
+        // initialized
+        model->initialize(
+            model->t0(), ws_.x, ws_.dx, ws_.sx, ws_.sdx,
+            solver->getSensitivityOrder() >= SensitivityOrder::first,
+            ws_.roots_found
+        );
+    }
+
+    t_ = model->t0();
+
+    solver->setup(t_, model, ws_.x, ws_.dx, ws_.sx, ws_.sdx);
+
+    if (preequilibrated_ || uses_presimulation_) {
+        // Reset the time and re-initialize events for the main simulation
         solver->updateAndReinitStatesAndSensitivities(model);
+        if (model->ne) {
+            model->initEvents(model->t0(), ws_.x, ws_.dx, ws_.roots_found);
+        }
+    }
 
     // update x0 after computing consistence IC/reinitialization
     ws_.x = solver->getState(model->t0());
@@ -166,77 +255,9 @@ void ForwardProblem::handleMainSimulation() {
         || (solver->computingASA() && !uses_presimulation_))
         ws_.sx = solver->getStateSensitivity(model->t0());
 
-    // store initial state and sensitivity
-    initial_state_ = getSimulationState();
-    // store root information at t0
-    model->froot(t_, ws_.x, ws_.dx, rootvals_);
-
-    // get list of trigger timepoints for fixed-time triggered events
-    auto trigger_timepoints = model->get_trigger_timepoints();
-    auto it_trigger_timepoints
-        = std::ranges::find_if(trigger_timepoints, [this](auto t) {
-              return t > this->t_;
-          });
-
-    // loop over timepoints
-    for (it_ = 0; it_ < model->nt(); it_++) {
-        // next output time-point
-        auto next_t_out = model->getTimepoint(it_);
-
-        if (std::isinf(next_t_out))
-            break;
-
-        if (next_t_out > model->t0()) {
-            // Solve for next output timepoint
-            while (t_ < next_t_out) {
-                if (is_next_t_too_close(t_, next_t_out)) {
-                    // next timepoint is too close to current timepoint.
-                    // we use the state of the current timepoint.
-                    break;
-                }
-
-                // next stop time is next output timepoint or next
-                // time-triggered event
-                auto next_t_event
-                    = it_trigger_timepoints != trigger_timepoints.end()
-                          ? *it_trigger_timepoints
-                          : std::numeric_limits<realtype>::infinity();
-                auto next_t_stop = std::min(next_t_out, next_t_event);
-
-                int status = solver->run(next_t_stop);
-                // sx will be copied from solver on demand if sensitivities
-                // are computed
-                solver->writeSolution(&t_, ws_.x, ws_.dx, ws_.sx, ws_.dx);
-
-                if (status == AMICI_ILL_INPUT) {
-                    // clustering of roots => turn off root-finding
-                    solver->turnOffRootFinding();
-                } else if (status == AMICI_ROOT_RETURN || t_ == next_t_event) {
-                    // solver-tracked or time-triggered event
-                    solver->getRootInfo(roots_found_.data());
-
-                    // check if we are at a trigger timepoint.
-                    // if so, set the root-found flag
-                    if (t_ == next_t_event) {
-                        for (auto ie : model->state_independent_events_[t_]) {
-                            // determine direction of root crossing from
-                            // root function value at the previous event
-                            roots_found_[ie] = std::copysign(1, -rootvals_[ie]);
-                        }
-                        ++it_trigger_timepoints;
-                    }
-
-                    handleEvent(ws_.tlastroot, false);
-                }
-            }
-        }
-        handleDataPoint(next_t_out);
-    }
-
-    // fill events
-    if (model->nz > 0 && model->nt() > 0) {
-        fillEvents(model->nMaxEvent());
-    }
+    main_simulator_.run(t_, edata, model->getTimepoints());
+    t_ = main_simulator_.t_;
+    it_ = main_simulator_.it_;
 }
 
 void ForwardProblem::handlePostequilibration() {
@@ -248,42 +269,40 @@ void ForwardProblem::handlePostequilibration() {
     }
 }
 
-void ForwardProblem::handleEvent(
-    realtype& tlastroot, bool const initial_event
+void EventHandlingSimulator::handleEvent(
+    bool const initial_event, amici::ExpData const* edata
 ) {
     // Some event triggered. This may be due to some discontinuity, a bolus to
     // be applied, or an event observable to process.
 
-    if (!initial_event) {
-        if (t_ == tlastroot) {
-            throw AmiException(
-                "AMICI is stuck in an event, as the initial "
-                "step-size after the event is too small. "
-                "To fix this, increase absolute and relative "
-                "tolerances!"
-            );
-        }
-        tlastroot = t_;
+    if (!initial_event && t_ == ws_->tlastroot) {
+        throw AmiException(
+            "AMICI is stuck in an event, as the initial "
+            "step-size after the event is too small. "
+            "To fix this, increase absolute and relative "
+            "tolerances!"
+        );
     }
+    ws_->tlastroot = t_;
 
     // store the event info and pre-event simulation state
     // whenever a new event is triggered
-    auto store_pre_event_info = [this, initial_event](bool seflag) {
+    auto store_pre_event_info = [this, initial_event, edata](bool seflag) {
         // store Heaviside information at event occurrence
-        model->froot(t_, ws_.x, ws_.dx, rootvals_);
+        model_->froot(t_, ws_->x, ws_->dx, ws_->rootvals);
 
         // store timepoint at which the event occurred, the root function
         // values, and the direction of any zero crossings of the root function
-        discs_.emplace_back(t_, roots_found_);
-        rval_tmp_ = rootvals_;
+        result.discs.emplace_back(t_, ws_->roots_found);
+        ws_->rval_tmp = ws_->rootvals;
 
-        if (model->nz > 0)
-            storeEvent();
+        if (model_->nz > 0)
+            storeEvent(edata);
 
         store_pre_event_state(seflag, initial_event);
 
         if (!initial_event) {
-            model->updateHeaviside(roots_found_);
+            model_->updateHeaviside(ws_->roots_found);
         }
     };
 
@@ -291,21 +310,21 @@ void ForwardProblem::handleEvent(
     //  not after processing every single event, but after processing all events
     //  that did not trigger a secondary event
     auto store_post_event_info = [this]() {
-        if (solver->computingASA()) {
+        if (solver_->computingASA()) {
             // store updated x to compute jump in discontinuity
-            discs_.back().x_post = ws_.x;
-            discs_.back().xdot_post = ws_.xdot;
+            result.discs.back().x_post = ws_->x;
+            result.discs.back().xdot_post = ws_->xdot;
         }
     };
 
     store_pre_event_info(false);
 
     // Collect all triggered events waiting for execution
-    for (int ie = 0; ie < model->ne; ie++) {
+    for (int ie = 0; ie < model_->ne; ie++) {
         // only consider transitions false -> true
-        if (roots_found_.at(ie) == 1) {
-            auto const& event = model->get_event(ie);
-            pending_events_.push(
+        if (ws_->roots_found.at(ie) == 1) {
+            auto const& event = model_->get_event(ie);
+            ws_->pending_events.push(
                 {.event = event,
                  .idx = ie,
                  .state_old
@@ -316,9 +335,9 @@ void ForwardProblem::handleEvent(
         }
     }
 
-    while (!pending_events_.empty()) {
+    while (!ws_->pending_events.empty()) {
         // get the next event to be handled
-        auto const& pending_event = pending_events_.pop();
+        auto const& pending_event = ws_->pending_events.pop();
         auto ie = pending_event.idx;
         auto const& state_old = pending_event.state_old;
 
@@ -336,17 +355,17 @@ void ForwardProblem::handleEvent(
 
         // Execute the event
         // Apply bolus to the state and the sensitivities
-        model->addStateEventUpdate(
-            ws_.x, ie, t_, ws_.xdot, ws_.xdot_old,
-            state_old.has_value() ? state_old->x : ws_.x,
-            state_old.has_value() ? state_old->state : model->getModelState()
+        model_->addStateEventUpdate(
+            ws_->x, ie, t_, ws_->xdot, ws_->xdot_old,
+            state_old.has_value() ? state_old->x : ws_->x,
+            state_old.has_value() ? state_old->state : model_->getModelState()
         );
-        if (solver->computingFSA()) {
+        if (solver_->computingFSA()) {
             // compute the new xdot
-            model->fxdot(t_, ws_.x, ws_.dx, ws_.xdot);
-            model->addStateSensitivityEventUpdate(
-                ws_.sx, ie, t_, ws_.x, ws_.x_old, ws_.xdot, ws_.xdot_old,
-                state_old.has_value() ? state_old->sx : ws_.sx, ws_.stau
+            model_->fxdot(t_, ws_->x, ws_->dx, ws_->xdot);
+            model_->addStateSensitivityEventUpdate(
+                ws_->sx, ie, t_, ws_->x, ws_->x_old, ws_->xdot, ws_->xdot_old,
+                state_old.has_value() ? state_old->sx : ws_->sx, ws_->stau
             );
         }
 
@@ -360,104 +379,111 @@ void ForwardProblem::handleEvent(
     store_post_event_info();
 
     // reinitialize the solver after all events have been processed
-    solver->reInit(t_, ws_.x, ws_.dx);
-    if (solver->computingFSA()) {
-        solver->sensReInit(ws_.sx, ws_.sdx);
+    solver_->reInit(t_, ws_->x, ws_->dx);
+    if (solver_->computingFSA()) {
+        solver_->sensReInit(ws_->sx, ws_->sdx);
     }
 }
 
-void ForwardProblem::storeEvent() {
-    bool is_last_timepoint = (t_ == model->getTimepoint(model->nt() - 1));
+void EventHandlingSimulator::storeEvent(ExpData const* edata) {
+    bool is_last_timepoint = (t_ == model_->getTimepoint(model_->nt() - 1));
 
     if (is_last_timepoint) {
         // call from fillEvent at last timepoint
-        model->froot(t_, ws_.x, ws_.dx, rootvals_);
-        for (int ie = 0; ie < model->ne; ie++) {
-            roots_found_.at(ie) = (nroots_.at(ie) < model->nMaxEvent()) ? 1 : 0;
+        model_->froot(t_, ws_->x, ws_->dx, ws_->rootvals);
+        for (int ie = 0; ie < model_->ne; ie++) {
+            ws_->roots_found.at(ie)
+                = (ws_->nroots.at(ie) < model_->nMaxEvent()) ? 1 : 0;
         }
-        discs_.back().root_info = roots_found_;
+        result.discs.back().root_info = ws_->roots_found;
     }
 
     if (getRootCounter() < getEventCounter()) {
         // update stored state (sensi)
-        event_states_.at(getRootCounter()) = getSimulationState();
+        result.event_states_.at(getRootCounter()) = getSimulationState();
     } else {
         // add stored state (sensi)
-        event_states_.push_back(getSimulationState());
+        result.event_states_.push_back(getSimulationState());
     }
 
     // EVENT OUTPUT
-    for (int ie = 0; ie < model->ne; ie++) {
+    for (int ie = 0; ie < model_->ne; ie++) {
         // only look for roots of the rootfunction not discontinuities
-        if (nroots_.at(ie) >= model->nMaxEvent())
+        if (ws_->nroots.at(ie) >= model_->nMaxEvent())
             continue;
 
         // only consider transitions false -> true or event filling
-        if (roots_found_.at(ie) != 1 && !is_last_timepoint) {
+        if (ws_->roots_found.at(ie) != 1 && !is_last_timepoint) {
             continue;
         }
 
-        if (edata && solver->computingASA())
-            model->getAdjointStateEventUpdate(
-                slice(dJzdx_, nroots_.at(ie), model->nx_solver * model->nJ), ie,
-                nroots_.at(ie), t_, ws_.x, *edata
+        if (edata && solver_->computingASA())
+            model_->getAdjointStateEventUpdate(
+                slice(
+                    *dJzdx_, ws_->nroots.at(ie), model_->nx_solver * model_->nJ
+                ),
+                ie, ws_->nroots.at(ie), t_, ws_->x, *edata
             );
 
-        nroots_.at(ie)++;
+        ws_->nroots.at(ie)++;
     }
 
     if (is_last_timepoint) {
         // call from fillEvent at last timepoint
         // loop until all events are filled
-        fillEvents(model->nMaxEvent());
+        fillEvents(model_->nMaxEvent(), edata);
     }
 }
 
-void ForwardProblem::store_pre_event_state(bool seflag, bool initial_event) {
+void EventHandlingSimulator::store_pre_event_state(
+    bool seflag, bool initial_event
+) {
     // If we need to do forward sensitivities later on we need to store the old
     // x and the old xdot.
-    if (solver->getSensitivityOrder() >= SensitivityOrder::first) {
+    if (solver_->getSensitivityOrder() >= SensitivityOrder::first) {
         // store x and xdot to compute jump in sensitivities
-        ws_.x_old.copy(ws_.x);
-        model->fxdot(t_, ws_.x, ws_.dx, ws_.xdot);
-        ws_.xdot_old.copy(ws_.xdot);
+        ws_->x_old.copy(ws_->x);
+        model_->fxdot(t_, ws_->x, ws_->dx, ws_->xdot);
+        ws_->xdot_old.copy(ws_->xdot);
     }
-    if (solver->computingFSA()) {
+    if (solver_->computingFSA()) {
         // compute event-time derivative only for primary events, we get
         // into trouble with multiple simultaneously firing events here (but
         // is this really well defined then?), in that case just use the
         // last ie and hope for the best.
         if (!seflag && !initial_event) {
-            for (int ie = 0; ie < model->ne; ie++) {
+            for (int ie = 0; ie < model_->ne; ie++) {
                 // only consider transitions false -> true
-                if (roots_found_.at(ie) == 1) {
-                    model->getEventTimeSensitivity(ws_.stau, t_, ie, ws_.x, ws_.sx);
+                if (ws_->roots_found.at(ie) == 1) {
+                    model_->getEventTimeSensitivity(
+                        ws_->stau, t_, ie, ws_->x, ws_->sx
+                    );
                 }
             }
         }
         if (initial_event) {
             // t0 has no parameter dependency
-            std::ranges::fill(ws_.stau, 0.0);
+            std::ranges::fill(ws_->stau, 0.0);
         }
-    } else if (solver->computingASA()) {
-        discs_.back().xdot_pre = ws_.xdot_old;
+    } else if (solver_->computingASA()) {
+        result.discs.back().xdot_pre = ws_->xdot_old;
     }
 }
 
-int ForwardProblem::detect_secondary_events() {
+int EventHandlingSimulator::detect_secondary_events() {
     int secondevent = 0;
 
     // check whether we need to fire a secondary event
-    model->froot(t_, ws_.x, ws_.dx, rootvals_);
-    for (int ie = 0; ie < model->ne; ie++) {
+    model_->froot(t_, ws_->x, ws_->dx, ws_->rootvals);
+    for (int ie = 0; ie < model_->ne; ie++) {
         // the same event should not trigger itself
-        if (roots_found_.at(ie) == 0) {
+        if (ws_->roots_found.at(ie) == 0) {
             // check whether there was a zero-crossing
-            if (0 > rval_tmp_.at(ie) * rootvals_.at(ie)) {
-                if (rval_tmp_.at(ie) < rootvals_.at(ie)) {
-                    roots_found_.at(ie) = 1;
-                    auto const& event = model->get_event(ie);
-                    pending_events_.push(
+            if (0 > ws_->rval_tmp.at(ie) * ws_->rootvals.at(ie)) {
+                if (ws_->rval_tmp.at(ie) < ws_->rootvals.at(ie)) {
+                    ws_->roots_found.at(ie) = 1;
+                    auto const& event = model_->get_event(ie);
+                    ws_->pending_events.push(
                         {.event = event,
                          .idx = ie,
                          .state_old
@@ -468,15 +494,15 @@ int ForwardProblem::detect_secondary_events() {
                                 : std::nullopt)}
                     );
                 } else {
-                    roots_found_.at(ie) = -1;
+                    ws_->roots_found.at(ie) = -1;
                 }
                 secondevent++;
             } else {
-                roots_found_.at(ie) = 0;
+                ws_->roots_found.at(ie) = 0;
             }
         } else {
             // don't fire the same event again
-            roots_found_.at(ie) = 0;
+            ws_->roots_found.at(ie) = 0;
         }
     }
 
@@ -484,8 +510,8 @@ int ForwardProblem::detect_secondary_events() {
     if (secondevent > 0) {
         // Secondary events may result in wrong forward sensitivities,
         // if the secondary event has a bolus...
-        if (solver->computingFSA() && solver->logger)
-            solver->logger->log(
+        if (solver_->computingFSA() && solver_->logger)
+            solver_->logger->log(
                 LogSeverity::warning, "SECONDARY_EVENT",
                 "Secondary event was triggered. Depending on "
                 "the bolus of the secondary event, forward "
@@ -496,13 +522,13 @@ int ForwardProblem::detect_secondary_events() {
     return secondevent;
 }
 
-void ForwardProblem::handleDataPoint(realtype t) {
+void EventHandlingSimulator::handleDataPoint(realtype t) {
     // We only store the simulation state if it's not the initial state, as the
     // initial state is stored anyway and we want to avoid storing it twice
-    if (t != model->t0() && !timepoint_states_.contains(t))
-        timepoint_states_[t] = getSimulationState();
+    if (t != t0_ && !result.timepoint_states_.contains(t))
+        result.timepoint_states_[t] = getSimulationState();
     // store diagnosis information for debugging
-    solver->storeDiagnosis();
+    solver_->storeDiagnosis();
 }
 
 std::vector<realtype>
@@ -527,17 +553,17 @@ ForwardProblem::getAdjointUpdates(Model& model, ExpData const& edata) {
     return dJydx;
 }
 
-SimulationState ForwardProblem::getSimulationState() {
-    if (std::isfinite(solver->gett())) {
-        solver->writeSolution(&t_, ws_.x, ws_.dx, ws_.sx, ws_.dx);
+SimulationState EventHandlingSimulator::getSimulationState() {
+    if (std::isfinite(solver_->gett())) {
+        solver_->writeSolution(&t_, ws_->x, ws_->dx, ws_->sx, ws_->dx);
     }
     auto state = SimulationState();
     state.t = t_;
-    state.x = ws_.x;
-    state.dx = ws_.dx;
-    if (solver->computingFSA() || t_ == model->t0())
-        state.sx = ws_.sx;
-    state.state = model->getModelState();
+    state.x = ws_->x;
+    state.dx = ws_->dx;
+    if (solver_->computingFSA() || t_ == t0_)
+        state.sx = ws_->sx;
+    state.state = model_->getModelState();
     return state;
 }
 

--- a/src/steadystateproblem.cpp
+++ b/src/steadystateproblem.cpp
@@ -408,7 +408,7 @@ void SteadystateProblem::initializeForwardProblem(
         // The solver was not run before, set up everything.
         auto roots_found = std::vector<int>(model.ne, 0);
         model.initialize(
-            state_.x, state_.dx, state_.sx, sdx_,
+            model.t0(), state_.x, state_.dx, state_.sx, sdx_,
             solver.getSensitivityOrder() >= SensitivityOrder::first, roots_found
         );
         state_.t = model.t0();


### PR DESCRIPTION
Related to #2775.

Implement event-handling during presimulation:
* Extract event- and data-handling from from `ForwardProblem` to a new `EventHandlingSimulator`
* Extract data members from `ForwardProblem` to a new `FwdSimWorkspace`
* Use them for simulation and event handling during both presimulation and the main simulation
* Simplify initialization logic before pre- and main simulation
* Replace some uses of `Model::t0()` by explicit time parameters

