### PR TITLE
Refactor BackwardProblem for presimulation

### DIFF
--- a/include/amici/backwardproblem.h
+++ b/include/amici/backwardproblem.h
@@ -183,8 +183,6 @@ class BackwardProblem {
     realtype t_;
     /** sensitivity state vector array */
     AmiVectorArray sx0_;
-    /** array of number of found roots for a certain event type */
-    std::vector<int> nroots_;
     /** array containing the time-points of discontinuities*/
     std::vector<Discontinuity> discs_;
 

--- a/include/amici/backwardproblem.h
+++ b/include/amici/backwardproblem.h
@@ -8,12 +8,131 @@
 #include <vector>
 
 namespace amici {
-
 class ExpData;
 class Solver;
 class Model;
 class ForwardProblem;
 class SteadystateProblem;
+
+/**
+ * @brief The BwdSimWorkspace class is used to store temporary simulation
+ * state during backward simulations.
+ */
+struct BwdSimWorkspace {
+    /**
+     * @brief Constructor
+     * @param model The model for which to set up the workspace.
+     * @param solver The solver for which to set up this workspace.
+     */
+    BwdSimWorkspace(
+        gsl::not_null<Model*> model, gsl::not_null<Solver const*> solver
+    );
+
+    /** The model. */
+    Model* model_;
+
+    /** adjoint state vector */
+    AmiVector xB_;
+    /** differential adjoint state vector */
+    AmiVector dxB_;
+    /** quadrature state vector */
+    AmiVector xQB_;
+
+    /** array of number of found roots for a certain event type */
+    std::vector<int> nroots_;
+    /** array containing the time-points of discontinuities*/
+    std::vector<Discontinuity> discs_;
+    /** index of the backward problem */
+    int which = 0;
+};
+
+/**
+ * @brief The EventHandlingBwdSimulator class runs a backward simulation
+ * and processes events and measurements general.
+ */
+class EventHandlingBwdSimulator {
+  public:
+    /**
+     * @brief EventHandlingBwdSimulator constructor.
+     * @param model The model to simulate.
+     * @param solver The solver to use for the simulation.
+     * @param ws The workspace to use for the simulation.
+     * (dimension nJ x nx x nMaxEvent, ordering =?)
+     */
+    EventHandlingBwdSimulator(
+        gsl::not_null<Model*> model, gsl::not_null<Solver*> solver,
+        gsl::not_null<BwdSimWorkspace*> ws
+    )
+        : model_(model)
+        , solver_(solver)
+        , ws_(ws) {};
+
+    /**
+     * @brief Run the simulation.
+     *
+     * It will run the backward simulation from the initial time of this period
+     * to the final timepoint of this period, handling events
+     * and data points as they occur.
+     *
+     * Expects the model and the solver to be set up, and `ws` to be initialized
+     * for this period.
+     *
+     * @param t_start The initial time of this period.
+     * @param t_end The final time of this period.
+     * @param it The index of the timepoint in `timepoints` to start with.
+     * @param timepoints The output timepoints or measurement timepoints of
+     * this period. This must contain at least the final timepoint of this
+     * period.
+     * @param dJydx State-derivative of data likelihood
+     * @param dJzdx State-derivative of event likelihood
+     */
+    void
+    run(realtype t_start, realtype t_end, realtype it,
+        std::vector<realtype> const& timepoints,
+        std::vector<realtype> const* dJydx, std::vector<realtype> const* dJzdx);
+
+  private:
+    /**
+     * @brief Execute everything necessary for the handling of events
+     * for the backward problem
+     * @param disc The discontinuity to handle
+     * @param dJzdx State-derivative of event likelihood
+     */
+    void
+    handleEventB(Discontinuity const& disc, std::vector<realtype> const* dJzdx);
+
+    /**
+     * @brief Execute everything necessary for the handling of data
+     * points for the backward problems
+     *
+     * @param it index of data point
+     * @param dJydx State-derivative of data likelihood
+     */
+    void handleDataPointB(int it, std::vector<realtype> const* dJydx);
+
+    /**
+     * @brief Compute the next timepoint to integrate to.
+     *
+     * This is the maximum of tdata and troot but also takes into account if
+     * it<0 or iroot<0 where these expressions do not necessarily make sense.
+     *
+     * @param it index of next data point
+     * @return tnext next timepoint
+     */
+    realtype getTnext(int it);
+
+    /** The model to simulate. */
+    Model* model_;
+
+    /** The solver to use for the simulation. */
+    Solver* solver_;
+
+    /** The workspace to use for the simulation. */
+    gsl::not_null<BwdSimWorkspace*> ws_;
+
+    /** current time */
+    realtype t_{0};
+};
 
 //!  class to solve backwards problems.
 /*!
@@ -32,76 +151,28 @@ class BackwardProblem {
     /**
      * @brief Solve the backward problem.
      *
-     * If adjoint sensitivities are enabled this will also compute
-     * sensitivities. workForwardProblem must be called before this is
-     * function is called.
+     * If adjoint sensitivities are enabled, this will also compute
+     * sensitivities. workForwardProblem must be called before this function is
+     * called.
      */
     void workBackwardProblem();
-
-    /**
-     * @brief Accessor for current time t
-     * @return t
-     */
-    realtype gett() const { return t_; }
-
-    /**
-     * @brief Accessor for which
-     * @return which
-     */
-    int getwhich() const { return which; }
-
-    /**
-     * @brief Accessor for pointer to which
-     * @return which
-     */
-    int* getwhichptr() { return &which; }
-
-    /**
-     * @brief Accessor for dJydx
-     * @return dJydx
-     */
-    std::vector<realtype> const& getdJydx() const { return dJydx_; }
 
     /**
      * @brief Accessor for xB
      * @return xB
      */
-    AmiVector const& getAdjointState() const { return xB_; }
+    [[nodiscard]] AmiVector const& getAdjointState() const { return ws_.xB_; }
 
     /**
      * @brief Accessor for xQB
      * @return xQB
      */
-    AmiVector const& getAdjointQuadrature() const { return xQB_; }
+    [[nodiscard]] AmiVector const& getAdjointQuadrature() const {
+        return ws_.xQB_;
+    }
 
   private:
     void handlePostequilibration();
-
-    /**
-     * @brief Execute everything necessary for the handling of events
-     * for the backward problem
-     * @param disc The discontinuity to handle
-     */
-    void handleEventB(Discontinuity const& disc);
-
-    /**
-     * @brief Execute everything necessary for the handling of data
-     * points for the backward problems
-     *
-     * @param it index of data point
-     */
-    void handleDataPointB(int it);
-
-    /**
-     * @brief Compute the next timepoint to integrate to.
-     *
-     * This is the maximum of tdata and troot but also takes into account if
-     * it<0 or iroot<0 where these expressions do not necessarily make sense.
-     *
-     * @param it index of next data point
-     * @return tnext next timepoint
-     */
-    realtype getTnext(int it);
 
     Model* model_;
     Solver* solver_;
@@ -109,20 +180,12 @@ class BackwardProblem {
 
     /** current time */
     realtype t_;
-    /** adjoint state vector */
-    AmiVector xB_;
-    /** differential adjoint state vector */
-    AmiVector dxB_;
-    /** quadrature state vector */
-    AmiVector xQB_;
     /** sensitivity state vector array */
     AmiVectorArray sx0_;
     /** array of number of found roots for a certain event type */
     std::vector<int> nroots_;
     /** array containing the time-points of discontinuities*/
     std::vector<Discontinuity> discs_;
-    /** index of the backward problem */
-    int which = 0;
 
     /** state derivative of data likelihood */
     std::vector<realtype> dJydx_;
@@ -134,8 +197,12 @@ class BackwardProblem {
 
     /** The postequilibration steadystate problem from the forward problem. */
     SteadystateProblem* posteq_problem_;
+
+    BwdSimWorkspace ws_;
+
+    EventHandlingBwdSimulator simulator_;
 };
 
 } // namespace amici
 
-#endif // BACKWARDPROBLEM_H
+#endif // AMICI_BACKWARDPROBLEM_H

--- a/include/amici/backwardproblem.h
+++ b/include/amici/backwardproblem.h
@@ -57,7 +57,6 @@ class EventHandlingBwdSimulator {
      * @param model The model to simulate.
      * @param solver The solver to use for the simulation.
      * @param ws The workspace to use for the simulation.
-     * (dimension nJ x nx x nMaxEvent, ordering =?)
      */
     EventHandlingBwdSimulator(
         gsl::not_null<Model*> model, gsl::not_null<Solver*> solver,
@@ -83,8 +82,10 @@ class EventHandlingBwdSimulator {
      * @param timepoints The output timepoints or measurement timepoints of
      * this period. This must contain at least the final timepoint of this
      * period.
-     * @param dJydx State-derivative of data likelihood
-     * @param dJzdx State-derivative of event likelihood
+     * @param dJydx State-derivative of data likelihood. Must be non-null if
+     * there are any data points in this period.
+     * @param dJzdx State-derivative of event likelihood. Must be non-null if
+     * the model has any event-observables.
      */
     void
     run(realtype t_start, realtype t_end, realtype it,

--- a/include/amici/forwardproblem.h
+++ b/include/amici/forwardproblem.h
@@ -64,6 +64,16 @@ struct Discontinuity {
 };
 
 /**
+ * @brief Compute the number of roots for each root function from a vector of
+ * discontinuities.
+ * @param discs Encountered discontinuities.
+ * @param ne Number of root functions (ne).
+ * @param nmaxevents Maximum number of events to track (nmaxevents).
+ * @return The number of roots for each root function.
+ */
+std::vector<int> compute_nroots(std::vector<Discontinuity> const& discs, int ne, int nmaxevents);
+
+/**
  * @brief The ForwardProblem class groups all functions for solving the
  * forward problem.
  */
@@ -126,12 +136,6 @@ class ForwardProblem {
      * @return sx
      */
     AmiVectorArray const& getStateSensitivity() const { return sx_; }
-
-    /**
-     * @brief Accessor for nroots
-     * @return nroots
-     */
-    std::vector<int> const& getNumberOfRoots() const { return nroots_; }
 
     /**
      * @brief Get information on the discontinuities encountered so far.

--- a/src/backwardproblem.cpp
+++ b/src/backwardproblem.cpp
@@ -15,7 +15,6 @@ BackwardProblem::BackwardProblem(ForwardProblem& fwd)
     , edata_(fwd.edata)
     , t_(fwd.getTime())
     , sx0_(fwd.getStateSensitivity())
-    , nroots_(fwd.getNumberOfRoots())
     , discs_(fwd.getDiscontinuities())
     , dJydx_(fwd.getAdjointUpdates(*model_, *edata_))
     , dJzdx_(fwd.getDJzdx())
@@ -44,7 +43,7 @@ void BackwardProblem::workBackwardProblem() {
     // initialize state vectors, depending on postequilibration
     model_->initializeB(ws_.xB_, ws_.dxB_, ws_.xQB_, it < model_->nt() - 1);
     ws_.discs_ = discs_;
-    ws_.nroots_ = nroots_;
+    ws_.nroots_ = compute_nroots(discs_, model_->ne, model_->nMaxEvent());
     simulator_.run(
         t_, model_->t0(), it, model_->getTimepoints(), &dJydx_, &dJzdx_
     );

--- a/src/forwardproblem.cpp
+++ b/src/forwardproblem.cpp
@@ -548,4 +548,26 @@ SimulationState ForwardProblem::getSimulationState() {
     return state;
 }
 
+std::vector<int> compute_nroots(
+    std::vector<Discontinuity> const& discs, int ne, int nmaxevents
+    ) {
+    auto size = gsl::narrow<std::vector<int>::size_type>(ne);
+    std::vector<int> nroots(size, 0);
+    for (auto const& disc : discs) {
+        for (std::vector<int>::size_type i = 0; i < size; ++i) {
+            if (disc.root_info[i] == 1) {
+                nroots[i]++;
+            }
+        }
+    }
+
+    for (auto& n : nroots) {
+        if (n > nmaxevents) {
+            n = nmaxevents;
+        }
+    }
+    return nroots;
+}
+
+
 } // namespace amici


### PR DESCRIPTION
Refactor BackwardProblem to implement presimulation including event-handling (#2775).

Similar to #2777 for the ForwardProblem:

* Extract some state from BackwardProblem
* Extract a EventHandlingBwdSimulator that handles simulation and discontinuities
* Those will be reused for presimulation shortly
* Remove some unused getters from BackwardProblem