### PR TITLE
Fix Model::addAdjointQuadratureEventUpdate

### DIFF
--- a/include/amici/model.h
+++ b/include/amici/model.h
@@ -1332,7 +1332,7 @@ class Model : public AbstractModel, public ModelDimensions {
      * @param xdot_old Value of residual function before event
      */
     void addAdjointQuadratureEventUpdate(
-        AmiVector xQB, int const ie, realtype const t, AmiVector const& x,
+        AmiVector& xQB, int const ie, realtype const t, AmiVector const& x,
         AmiVector const& xB, AmiVector const& xdot, AmiVector const& xdot_old
     );
 

--- a/src/model.cpp
+++ b/src/model.cpp
@@ -1525,7 +1525,7 @@ void Model::addAdjointStateEventUpdate(
 }
 
 void Model::addAdjointQuadratureEventUpdate(
-    AmiVector xQB, int const ie, realtype const t, AmiVector const& x,
+    AmiVector &xQB, int const ie, realtype const t, AmiVector const& x,
     AmiVector const& xB, AmiVector const& xdot, AmiVector const& xdot_old
 ) {
     for (int ip = 0; ip < nplist(); ip++) {


### PR DESCRIPTION
It seems like `xQB` should be passed by reference to `Model::addAdjointQuadratureEventUpdate`. So far, this was passed by value, and all updates by that function were lost.