### PR TITLE
Fix redundant solver reinitialization in

### DIFF
--- a/src/steadystateproblem.cpp
+++ b/src/steadystateproblem.cpp
@@ -242,7 +242,6 @@ void SteadystateProblem::workSteadyStateBackwardProblem(
 
         // only preequilibrations needs a reInit,
         // postequilibration does not
-        solver.reInit(state_.t, state_.x, state_.dx);
         solver.updateAndReinitStatesAndSensitivities(&model);
     }
 


### PR DESCRIPTION
Fix redundant solver reinitialization in `SteadystateProblem::workSteadyStateBackwardProblem`. `Solver::reInit` is already called by `Solver::updateAndReinitStatesAndSensitivities`.