### PR TITLE
Fix event processing

### DIFF
--- a/python/sdist/amici/de_model.py
+++ b/python/sdist/amici/de_model.py
@@ -1664,8 +1664,8 @@ class DEModel:
                 for ie in range(self.num_events())
             ]
             if name == "dzdx":
+                dtaudx = self.eq("dtaudx")
                 for ie in range(self.num_events()):
-                    dtaudx = self.eq("dtaudx")
                     for iz in range(self.num_eventobs()):
                         if ie != self._z2event[iz] - 1:
                             continue
@@ -1734,7 +1734,7 @@ class DEModel:
                     )
 
                 # only add deltax part if there is a state update
-                if event._assignments is not None:
+                if event.updates_state:
                     # partial derivative for the parameters
                     tmp_eq += self.eq("ddeltaxdp")[ie]
 

--- a/python/sdist/amici/de_model_components.py
+++ b/python/sdist/amici/de_model_components.py
@@ -837,6 +837,11 @@ class Event(ModelQuantity):
         """
         return self._use_values_from_trigger_time
 
+    @property
+    def updates_state(self) -> bool:
+        """Whether the event assignment updates the model state."""
+        return bool(self._assignments)
+
 
 # defines the type of some attributes in DEModel
 symbol_to_type = {

--- a/src/backwardproblem.cpp
+++ b/src/backwardproblem.cpp
@@ -92,7 +92,7 @@ void EventHandlingBwdSimulator::handleEventB(
 ) {
     for (int ie = 0; ie < model_->ne; ie++) {
 
-        if (disc.root_info[ie] == 0) {
+        if (disc.root_info[ie] != 1) {
             continue;
         }
 
@@ -105,6 +105,7 @@ void EventHandlingBwdSimulator::handleEventB(
         );
 
         if (model_->nz > 0) {
+            Expects(ws_->nroots_[ie] >= 0);
             for (int ix = 0; ix < model_->nxtrue_solver; ++ix) {
                 for (int iJ = 0; iJ < model_->nJ; ++iJ) {
                     ws_->xB_[ix + iJ * model_->nxtrue_solver] += (*dJzdx

--- a/src/forwardproblem.cpp
+++ b/src/forwardproblem.cpp
@@ -316,6 +316,8 @@ void EventHandlingSimulator::handle_event(
         if (solver_->computingASA()) {
             // store updated x to compute jump in discontinuity
             result.discs.back().x_post = ws_->x;
+            // Update xdot after the state update
+            model_->fxdot(t_, ws_->x, ws_->dx, ws_->xdot);
             result.discs.back().xdot_post = ws_->xdot;
         }
     };

--- a/src/model.cpp
+++ b/src/model.cpp
@@ -1525,7 +1525,7 @@ void Model::addAdjointStateEventUpdate(
 }
 
 void Model::addAdjointQuadratureEventUpdate(
-    AmiVector &xQB, int const ie, realtype const t, AmiVector const& x,
+    AmiVector& xQB, int const ie, realtype const t, AmiVector const& x,
     AmiVector const& xB, AmiVector const& xdot, AmiVector const& xdot_old
 ) {
     for (int ip = 0; ip < nplist(); ip++) {


### PR DESCRIPTION
* Fix check for state updates during model import (no state update is `Event._assignment == {}` not `None`)
* EventHandlingBwdSimulator::handleEventB: Only handle events where with sign change from negative to positive
* EventHandlingSimulator::handle_event: Fix post-event xdot. Previously, the pre-event xdot was stored.