### PR TITLE
Handle ComplexInfinity during code printing

### DIFF
--- a/include/amici/defines.h
+++ b/include/amici/defines.h
@@ -6,6 +6,7 @@
 #endif
 
 #include <cmath>
+#include <limits>
 
 /* Math constants in case _USE_MATH_DEFINES is not supported */
 #if defined(_USE_MATH_DEFINES)
@@ -51,6 +52,8 @@
 #endif
 
 namespace amici {
+// verify that we have infinity, NaN, and that negative infinity is -inf
+static_assert(std::numeric_limits<double>::is_iec559, "IEEE 754 required");
 
 constexpr double pi = M_PI;
 

--- a/python/sdist/amici/cxxcodeprinter.py
+++ b/python/sdist/amici/cxxcodeprinter.py
@@ -87,6 +87,15 @@ class AmiciCxxCodePrinter(CXX11CodePrinter):
 
         return self._print_min_max(expr, "max", Max)
 
+    def _print_Infinity(self, expr):
+        return "std::numeric_limits<double>::infinity()"
+
+    def _print_NegativeInfinity(self, expr):
+        return "-std::numeric_limits<double>::infinity()"
+
+    def _print_ComplexInfinity(self, expr):
+        return "std::numeric_limits<double>::infinity()"
+
     def _get_sym_lines_array(
         self, equations: sp.Matrix, variable: str, indent_level: int
     ) -> list[str]:
@@ -290,6 +299,7 @@ def get_switch_statement(
         indent0 + "}",
     ]
 
+
 def csc_matrix(
     matrix: sp.Matrix,
     rownames: list[sp.Symbol],
@@ -369,6 +379,7 @@ def csc_matrix(
         symbol_list,
         sparse_matrix,
     )
+
 
 def get_initializer_list(values: Iterable) -> str:
     """Generate C++ initializer list for given values.

--- a/python/tests/test_cxxcodeprinter.py
+++ b/python/tests/test_cxxcodeprinter.py
@@ -14,3 +14,35 @@ def test_optimizations():
         assert "expm1" in cp.doprint(sp.sympify("exp(x) - 1"))
     finally:
         AmiciCxxCodePrinter.optimizations = old_optim
+
+
+@skip_on_valgrind
+def test_print_infinity():
+    """Check that AmiciCxxCodePrinter prints infinity correctly."""
+    from sympy.core.numbers import NegativeInfinity, Infinity, ComplexInfinity
+
+    cp = AmiciCxxCodePrinter()
+    assert cp.doprint(Infinity()) == "std::numeric_limits<double>::infinity()"
+    assert (
+        cp.doprint(NegativeInfinity())
+        == "-std::numeric_limits<double>::infinity()"
+    )
+    assert (
+        cp.doprint(-NegativeInfinity())
+        == "std::numeric_limits<double>::infinity()"
+    )
+    assert (
+        cp.doprint(-Infinity()) == "-std::numeric_limits<double>::infinity()"
+    )
+    assert cp.doprint(sp.oo) == "std::numeric_limits<double>::infinity()"
+    assert cp.doprint(-sp.oo) == "-std::numeric_limits<double>::infinity()"
+    assert (
+        cp.doprint(ComplexInfinity())
+        == "std::numeric_limits<double>::infinity()"
+    )
+    assert (
+        cp.doprint(-ComplexInfinity())
+        == "std::numeric_limits<double>::infinity()"
+    )
+    assert cp.doprint(sp.zoo) == "std::numeric_limits<double>::infinity()"
+    assert cp.doprint(-sp.zoo) == "std::numeric_limits<double>::infinity()"


### PR DESCRIPTION
Having `sympy.core.numbers.ComplexInfinity` show up inside a model is usually not a good sign, but might be harmless or even intended in rare cases. Thus, let's print it as real infinity if it occurs. If it is indeed a problem, this will surface during simulation.

Fixes #2791.