### PR TITLE
Fix indexing errors for adjoint quadratures during event updates

### DIFF
--- a/include/amici/backwardproblem.h
+++ b/include/amici/backwardproblem.h
@@ -31,11 +31,11 @@ struct BwdSimWorkspace {
     /** The model. */
     Model* model_;
 
-    /** adjoint state vector */
+    /** adjoint state vector (size: nx_solver)  */
     AmiVector xB_;
-    /** differential adjoint state vector */
+    /** differential adjoint state vector (size: nx_solver) */
     AmiVector dxB_;
-    /** quadrature state vector */
+    /** quadrature state vector (size: nJ x nplist, col-major) */
     AmiVector xQB_;
 
     /** array of number of found roots for a certain event type */

--- a/include/amici/model_state.h
+++ b/include/amici/model_state.h
@@ -336,7 +336,7 @@ struct ModelStateDerived {
     std::vector<realtype> dJzdx_;
 
     /** parameter derivative of event likelihood for current timepoint
-     * (dimension: nJ x nplist x, row-major)
+     * (dimension: nJ x nplist, col-major)
      */
     std::vector<realtype> dJzdp_;
 
@@ -433,7 +433,7 @@ struct ModelStateDerived {
     std::vector<realtype> deltaxB_;
 
     /** temporary storage for change in qB after event
-     * (dimension: nJ x nplist, row-major)
+     * (dimension: nJ)
      */
     std::vector<realtype> deltaqB_;
 

--- a/src/model.cpp
+++ b/src/model.cpp
@@ -1539,11 +1539,11 @@ void Model::addAdjointQuadratureEventUpdate(
         );
 
         for (int iJ = 0; iJ < nJ; ++iJ)
-            xQB.at(iJ) += derived_state_.deltaqB_.at(iJ);
+            xQB.at(ip * nJ + iJ) += derived_state_.deltaqB_.at(iJ);
     }
 
     if (always_check_finite_) {
-        checkFinite(derived_state_.deltaqB_, ModelQuantity::deltaqB, nplist());
+        checkFinite(derived_state_.deltaqB_, ModelQuantity::deltaqB, t);
     }
 }
 


### PR DESCRIPTION
* Fix indexing error in xQB (related to #18)
   Now this is in line with the indexing in ReturnData https://github.com/AMICI-dev/AMICI/blob/ce28017159c9172a93b3b5ad6c602ebd3c0cd9d3/src/rdata.cpp#L497
* Fix incorrect documentation of dimensions
* Fix error message for finiteness check for deltaqB