### PR TITLE
Simplify benchmark imports

### DIFF
--- a/.github/workflows/test_benchmark_collection_models.yml
+++ b/.github/workflows/test_benchmark_collection_models.yml
@@ -14,7 +14,7 @@ on:
     - cron:  '48 4 * * *'
 
 jobs:
-  build:
+  non_jax:
     name: Benchmark Collection
 
     runs-on: ubuntu-24.04
@@ -66,11 +66,11 @@ jobs:
       env:
         AMICI_PARALLEL_COMPILE: ""
       run: |
-          cd tests/benchmark-models && pytest \
-              --durations=10 \
-              --cov=amici \
-              --cov-report=xml:"coverage_py.xml" \
-              --cov-append \
+        cd tests/benchmark-models && pytest test_petab_benchmark.py \
+          --durations=10 \
+          --cov=amici \
+          --cov-report=xml:"coverage_py.xml" \
+          --cov-append \
 
     - name: Codecov Python
       if: github.event_name == 'pull_request' || github.repository_owner == 'AMICI-dev'
@@ -93,3 +93,67 @@ jobs:
         path: |
           tests/benchmark-models/computation_times.csv
           tests/benchmark-models/computation_times.png
+
+  jax:
+    name: Benchmark Collection JAX
+    runs-on: ubuntu-24.04
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version: [ "3.12" ]
+        extract_subexpressions: ["true", "false"]
+    env:
+      AMICI_EXTRACT_CSE: ${{ matrix.extract_subexpressions }}
+    steps:
+    - name: Set up Python ${{ matrix.python-version }}
+      uses: actions/setup-python@v5
+      with:
+        python-version: ${{ matrix.python-version }}
+
+    - uses: actions/checkout@v4
+      with:
+        fetch-depth: 20
+
+    - name: Install apt dependencies
+      uses: ./.github/actions/install-apt-dependencies
+
+    - run: echo "${HOME}/.local/bin/" >> $GITHUB_PATH
+
+    - name: Create AMICI sdist
+      run: pip3 install build && cd python/sdist && python3 -m build --sdist
+
+    - name: Install AMICI sdist
+      run: |
+        pip3 install --user petab[vis] && \
+        AMICI_PARALLEL_COMPILE="" pip3 install -v --user \
+            $(ls -t python/sdist/dist/amici-*.tar.gz | head -1)[petab,test,vis,jax]
+
+    - name: Install test dependencies
+      run: |
+        python3 -m pip uninstall -y petab && python3 -m pip install git+https://github.com/petab-dev/libpetab-python.git@develop \
+        &&  python3 -m pip install -U sympy \
+        &&  python3 -m pip install git+https://github.com/ICB-DCM/fiddy.git
+
+    - name: Download benchmark collection
+      run: |
+        pip install git+https://github.com/Benchmarking-Initiative/Benchmark-Models-PEtab.git@master#subdirectory=src/python
+
+    - name: Run JAX tests
+      env:
+        AMICI_PARALLEL_COMPILE: ""
+      run: |
+        cd tests/benchmark-models && pytest test_petab_benchmark_jax.py \
+          --durations=10 \
+          --cov=amici \
+          --cov-report=xml:"coverage_py.xml" \
+          --cov-append
+
+    - name: Codecov Python
+      if: github.event_name == 'pull_request' || github.repository_owner == 'AMICI-dev'
+      uses: codecov/codecov-action@v5
+      with:
+        token: ${{ secrets.CODECOV_TOKEN }}
+        files: coverage_py.xml
+        flags: python
+        fail_ci_if_error: true
+        verbose: true

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,23 @@
+# Agent Instructions
+
+To ensure all tools and dependencies are available, activate the virtual environment before running any commands:
+
+```bash
+source ./venv/bin/activate
+```
+
+This project uses `pre-commit` for linting and `pytest` for tests. Run them on changed files whenever you make modifications.
+
+When running the benchmark tests locally, change into the test directory first:
+
+```bash
+cd tests/benchmark-models
+pytest test_petab_benchmark.py
+pytest test_petab_benchmark_jax.py
+```
+
+To quickly verify the benchmark tests, you can limit execution to a small model:
+
+```bash
+pytest -k Boehm_JProteomeRes2014 test_petab_benchmark.py
+```

--- a/tests/benchmark-models/conftest.py
+++ b/tests/benchmark-models/conftest.py
@@ -1,0 +1,178 @@
+import copy
+from collections import defaultdict
+from dataclasses import dataclass, field
+from pathlib import Path
+
+import pytest
+import petab.v1 as petab
+from petab.v1.lint import measurement_table_has_timepoint_specific_mappings
+
+import benchmark_models_petab
+import amici
+from amici.petab.petab_import import import_petab_problem
+
+script_dir = Path(__file__).parent
+repo_root = script_dir.parent.parent
+benchmark_outdir = repo_root / "test_bmc"
+
+# problem IDs for which to check the gradient
+# TODO: extend
+problems_for_gradient_check = list(
+    sorted(
+        set(benchmark_models_petab.MODELS)
+        - {
+            # excluded due to excessive runtime
+            "Bachmann_MSB2011",
+            "Chen_MSB2009",
+            "Froehlich_CellSystems2018",
+            "Raimundez_PCB2020",
+            "Lucarelli_CellSystems2018",
+            "Isensee_JCB2018",
+            "Beer_MolBioSystems2014",
+            "Alkan_SciSignal2018",
+            "Lang_PLOSComputBiol2024",
+            "Smith_BMCSystBiol2013",
+            # excluded due to excessive numerical failures
+            "Crauste_CellSystems2017",
+        }
+    )
+)
+
+problems_for_llh_check = [
+    "Bachmann_MSB2011",
+    "Beer_MolBioSystems2014",
+    "Boehm_JProteomeRes2014",
+    "Borghans_BiophysChem1997",
+    "Brannmark_JBC2010",
+    "Bruno_JExpBot2016",
+    "Crauste_CellSystems2017",
+    "Elowitz_Nature2000",
+    "Fiedler_BMCSystBiol2016",
+    "Fujita_SciSignal2010",
+    "Lucarelli_CellSystems2018",
+    "Schwen_PONE2014",
+    "Smith_BMCSystBiol2013",
+    "Sneyd_PNAS2002",
+    "Weber_BMC2015",
+    "Zheng_PNAS2012",
+]
+
+problems = list(
+    sorted(set(problems_for_gradient_check + problems_for_llh_check))
+)
+
+
+@dataclass
+class GradientCheckSettings:
+    """Problem-specific settings for gradient checks."""
+
+    # Absolute and relative tolerances for simulation
+    atol_sim: float = 1e-16
+    rtol_sim: float = 1e-12
+    # Absolute and relative tolerances for finite difference gradient checks.
+    atol_check: float = 1e-3
+    rtol_check: float = 1e-2
+    # Absolute and relative tolerances for fiddy consistency check between
+    # forward/backward/central differences.
+    atol_consistency: float = 1e-5
+    rtol_consistency: float = 1e-1
+    # Step sizes for finite difference gradient checks.
+    step_sizes: list[float] = field(
+        default_factory=lambda: [
+            2e-1,
+            1e-1,
+            5e-2,
+            1e-2,
+            5e-1,
+            1e-3,
+            1e-4,
+            1e-5,
+        ]
+    )
+    rng_seed: int = 0
+    ss_sensitivity_mode: amici.SteadyStateSensitivityMode = (
+        amici.SteadyStateSensitivityMode.integrateIfNewtonFails
+    )
+    noise_level: float = 0.05
+
+
+settings = defaultdict(GradientCheckSettings)
+# NOTE: Newton method fails badly with ASA for Blasi_CellSystems2016
+settings["Blasi_CellSystems2016"] = GradientCheckSettings(
+    atol_check=1e-12,
+    rtol_check=1e-4,
+    ss_sensitivity_mode=amici.SteadyStateSensitivityMode.integrationOnly,
+)
+settings["Borghans_BiophysChem1997"] = GradientCheckSettings(
+    rng_seed=2,
+    atol_check=1e-5,
+    rtol_check=1e-3,
+)
+settings["Brannmark_JBC2010"] = GradientCheckSettings(
+    ss_sensitivity_mode=amici.SteadyStateSensitivityMode.integrationOnly,
+)
+settings["Fujita_SciSignal2010"] = GradientCheckSettings(
+    atol_check=1e-7,
+    rtol_check=5e-4,
+)
+settings["Giordano_Nature2020"] = GradientCheckSettings(
+    atol_check=1e-6, rtol_check=1e-3, rng_seed=1
+)
+settings["Okuonghae_ChaosSolitonsFractals2020"] = GradientCheckSettings(
+    atol_sim=1e-14,
+    rtol_sim=1e-14,
+    noise_level=0.01,
+    atol_consistency=1e-3,
+)
+settings["Oliveira_NatCommun2021"] = GradientCheckSettings(
+    # Avoid "root after reinitialization"
+    atol_sim=1e-12,
+    rtol_sim=1e-12,
+)
+settings["Raia_CancerResearch2011"] = GradientCheckSettings(
+    atol_check=1e-10,
+    rtol_check=1e-3,
+)
+settings["Smith_BMCSystBiol2013"] = GradientCheckSettings(
+    atol_sim=1e-10,
+    rtol_sim=1e-10,
+)
+settings["Sneyd_PNAS2002"] = GradientCheckSettings(
+    atol_sim=1e-15,
+    rtol_sim=1e-12,
+    atol_check=1e-5,
+    rtol_check=1e-4,
+    rng_seed=7,
+)
+settings["Weber_BMC2015"] = GradientCheckSettings(
+    atol_sim=1e-12,
+    rtol_sim=1e-12,
+    atol_check=1e-6,
+    rtol_check=1e-2,
+    rng_seed=1,
+)
+settings["Zheng_PNAS2012"] = GradientCheckSettings(
+    rng_seed=1,
+    rtol_sim=1e-15,
+    atol_check=5e-4,
+    rtol_check=4e-3,
+    noise_level=0.01,
+)
+
+
+@pytest.fixture(scope="session", params=problems, ids=problems)
+def benchmark_problem(request):
+    """Fixture providing model and PEtab problem for a benchmark model."""
+    problem_id = request.param
+    petab_problem = benchmark_models_petab.get_problem(problem_id)
+    flat_petab_problem = copy.deepcopy(petab_problem)
+    if measurement_table_has_timepoint_specific_mappings(
+        petab_problem.measurement_df,
+    ):
+        petab.flatten_timepoint_specific_output_overrides(flat_petab_problem)
+
+    amici_model = import_petab_problem(
+        flat_petab_problem,
+        model_output_dir=benchmark_outdir / problem_id,
+    )
+    return problem_id, flat_petab_problem, petab_problem, amici_model

--- a/tests/benchmark-models/test_petab_benchmark_jax.py
+++ b/tests/benchmark-models/test_petab_benchmark_jax.py
@@ -1,0 +1,121 @@
+import logging
+from functools import partial
+
+import numpy as np
+import pytest
+import jax
+import jax.numpy as jnp
+import equinox as eqx
+
+import amici
+from amici.jax.petab import run_simulations, JAXProblem
+from amici.petab.petab_import import import_petab_problem
+from amici.petab.simulations import simulate_petab, LLH, SLLH
+
+from conftest import (
+    settings,
+    problems_for_gradient_check,
+    benchmark_outdir,
+)
+
+
+@pytest.mark.filterwarnings(
+    "ignore:The following problem parameters were not used *",
+    "ignore: The environment variable *",
+    "ignore:Adjoint sensitivity analysis for models with discontinuous ",
+)
+def test_jax_llh(benchmark_problem):
+    jax.config.update("jax_enable_x64", True)
+    from beartype import beartype
+
+    problem_id, flat_petab_problem, petab_problem, amici_model = (
+        benchmark_problem
+    )
+
+    amici_solver = amici_model.getSolver()
+    cur_settings = settings[problem_id]
+    amici_solver.setAbsoluteTolerance(1e-8)
+    amici_solver.setRelativeTolerance(1e-8)
+    amici_solver.setMaxSteps(10_000)
+
+    simulate_amici = partial(
+        simulate_petab,
+        petab_problem=flat_petab_problem,
+        amici_model=amici_model,
+        solver=amici_solver,
+        scaled_parameters=True,
+        scaled_gradients=True,
+        log_level=logging.DEBUG,
+    )
+
+    np.random.seed(cur_settings.rng_seed)
+
+    problem_parameters = None
+    if problem_id in problems_for_gradient_check:
+        point = flat_petab_problem.x_nominal_free_scaled
+        for _ in range(20):
+            amici_solver.setSensitivityMethod(amici.SensitivityMethod.adjoint)
+            amici_solver.setSensitivityOrder(amici.SensitivityOrder.first)
+            amici_model.setSteadyStateSensitivityMode(
+                cur_settings.ss_sensitivity_mode
+            )
+            point_noise = (
+                np.random.randn(len(point)) * cur_settings.noise_level
+            )
+            point += point_noise  # avoid small gradients at nominal value
+
+            problem_parameters = dict(
+                zip(flat_petab_problem.x_free_ids, point)
+            )
+
+            r_amici = simulate_amici(
+                problem_parameters=problem_parameters,
+            )
+            if np.isfinite(r_amici[LLH]):
+                break
+        else:
+            raise RuntimeError("Could not compute expected derivative.")
+    else:
+        r_amici = simulate_amici()
+    llh_amici = r_amici[LLH]
+
+    jax_model = import_petab_problem(
+        petab_problem,
+        model_output_dir=benchmark_outdir / (problem_id + "_jax"),
+        jax=True,
+    )
+    jax_problem = JAXProblem(jax_model, petab_problem)
+    if problem_parameters:
+        jax_problem = eqx.tree_at(
+            lambda x: x.parameters,
+            jax_problem,
+            jnp.array(
+                [problem_parameters[pid] for pid in jax_problem.parameter_ids]
+            ),
+        )
+
+    if problem_id in problems_for_gradient_check:
+        beartype(run_simulations)(jax_problem)
+        (llh_jax, _), sllh_jax = eqx.filter_value_and_grad(
+            run_simulations, has_aux=True
+        )(jax_problem)
+    else:
+        llh_jax, _ = beartype(run_simulations)(jax_problem)
+
+    np.testing.assert_allclose(
+        llh_jax,
+        llh_amici,
+        rtol=1e-3,
+        atol=1e-3,
+        err_msg=f"LLH mismatch for {problem_id}",
+    )
+
+    if problem_id in problems_for_gradient_check:
+        sllh_amici = r_amici[SLLH]
+        np.testing.assert_allclose(
+            sllh_jax.parameters,
+            np.array([sllh_amici[pid] for pid in jax_problem.parameter_ids]),
+            rtol=1e-2,
+            atol=1e-2,
+            err_msg=f"SLLH mismatch for {problem_id}, {dict(zip(jax_problem.parameter_ids, sllh_jax.parameters))}",
+        )


### PR DESCRIPTION
## Summary
- remove try/except around benchmark imports
- use only `conftest` when running from `tests/benchmark-models`

## Testing
- `pre-commit run --files tests/benchmark-models/test_petab_benchmark.py tests/benchmark-models/test_petab_benchmark_jax.py`
- `pytest -k Boehm_JProteomeRes2014 test_petab_benchmark.py -vv` *(fails: KeyboardInterrupt)*
- `pytest -k Boehm_JProteomeRes2014 test_petab_benchmark_jax.py -vv` *(fails: KeyboardInterrupt)*

------
https://chatgpt.com/codex/tasks/task_b_68502acb66ac832b954e9c7e99618f9f