### PR TITLE
Store default parameters in JAX models

### DIFF
--- a/python/sdist/amici/jax/jax.template.py
+++ b/python/sdist/amici/jax/jax.template.py
@@ -11,6 +11,7 @@ class JAXModel_TPL_MODEL_NAME(JAXModel):
 
     def __init__(self):
         self.jax_py_file = Path(__file__).resolve()
+        self.parameters = TPL_P_VALUES
         super().__init__()
 
     def _xdot(self, t, x, args):

--- a/python/sdist/amici/jax/ode_export.py
+++ b/python/sdist/amici/jax/ode_export.py
@@ -248,6 +248,7 @@ class ODEExporter:
             **_jax_variable_assignments(self.model, sym_names),
             # tuple of variable names (ids as they are unique)
             **_jax_variable_ids(self.model, ("p", "k", "y", "w", "x_rdata")),
+            "P_VALUES": _jnp_array_str(self.model.val("p")),
             **{
                 "MODEL_NAME": self.model_name,
                 # keep track of the API version that the model was generated with so we


### PR DESCRIPTION
## Summary
- embed default parameters into generated JAX models
- use stored parameter values if none are provided for `simulate_condition`
- update SBML JAX tests to rely on default parameters
- run PEtab SBML test suite with stored parameters

## Testing
- `pre-commit run --files python/sdist/amici/jax/jax.template.py python/sdist/amici/jax/model.py tests/sbml/testSBMLSuiteJax.py`
- `pytest -k Boehm_JProteomeRes2014 test_petab_benchmark.py`
- `pytest test_petab_benchmark_jax.py` *(fails: AttributeError: module 'test_petab_benchmark' has no attribute 'benchmark_problem')*
- `pytest tests/petab_test_suite/test_petab_suite.py --petab-cases=1 -k "sbml and True" -q`

------
https://chatgpt.com/codex/tasks/task_b_685319a51964832bbd646c723b8c2ab0