### PR TITLE
Ignore trailing whitespace when parsing function signatures

### DIFF
--- a/python/sdist/amici/_codegen/cxx_functions.py
+++ b/python/sdist/amici/_codegen/cxx_functions.py
@@ -44,6 +44,35 @@ class _FunctionInfo:
             return self.ode_arguments
         return self.dae_arguments
 
+    def get_deps(self, ode: bool) -> list[str]:
+        """Get the variables this function depends on.
+
+        :param ode: whether to get the ODE (``True``) or DAE (``False``)
+            dependencies.
+        :return: list of variable names this function depends on
+        """
+        return re.findall(
+            r"const (?:realtype|double) \*(\w+)0?(?:,|\s*$)",
+            self.arguments(ode=ode),
+        )
+
+    def var_in_signature(self, varname: str, ode: bool = True) -> bool:
+        """Check if a variable is in the function signature.
+
+        :param varname: name of the variable to check
+        :param ode: whether to check the ODE (``True``) or DAE (``False``)
+            signature.
+        :return: ``True`` if the variable is in the function signature,
+            ``False`` otherwise
+        """
+        return (
+            re.search(
+                rf"const (?:realtype|double) \*{varname}0?(?:,|\s*$)+",
+                self.arguments(ode=ode),
+            )
+            is not None
+        )
+
 
 # Information on a model-specific generated C++ function
 # prototype for generated C++ functions, keys are the names of functions
@@ -392,7 +421,7 @@ multiobs_functions = [
 
 def var_in_function_signature(name: str, varname: str, ode: bool) -> bool:
     """
-    Checks if the values for a symbolic variable is passed in the signature
+    Checks if the values for a symbolic variable are passed in the signature
     of a function
 
     :param name:
@@ -406,7 +435,4 @@ def var_in_function_signature(name: str, varname: str, ode: bool) -> bool:
         boolean indicating whether the variable occurs in the function
         signature
     """
-    return name in functions and re.search(
-        rf"const (realtype|double) \*{varname}[0]*(,|$)+",
-        functions[name].arguments(ode=ode),
-    )
+    return name in functions and functions[name].var_in_signature(varname, ode)

--- a/python/sdist/amici/de_export.py
+++ b/python/sdist/amici/de_export.py
@@ -18,7 +18,6 @@ import re
 import shutil
 from pathlib import Path
 from typing import (
-    TYPE_CHECKING,
     Literal,
 )
 
@@ -54,16 +53,10 @@ from ._codegen.template import apply_template
 from .cxxcodeprinter import (
     AmiciCxxCodePrinter,
     get_switch_statement,
-)
-from .de_model import DEModel
-from .de_model_components import *
-from .constants import SymbolId
-from .cxxcodeprinter import (
-    AmiciCxxCodePrinter,
-    get_switch_statement,
     get_initializer_list,
 )
-from .de_model import *
+from .de_model_components import *
+from .de_model import DEModel
 from .import_utils import (
     strip_pysb,
 )
@@ -74,10 +67,6 @@ from .sympy_utils import (
     _monkeypatched,
     smart_is_zero_matrix,
 )
-
-if TYPE_CHECKING:
-    pass
-
 
 # Template for model simulation main.cpp file
 CXX_MAIN_TEMPLATE_FILE = os.path.join(amiciSrcPath, "main.template.cpp")
@@ -490,10 +479,7 @@ class DEExporter:
         # don't add includes for files that won't be generated.
         # Unfortunately we cannot check for `self.functions[sym].body`
         # here since it may not have been generated yet.
-        for sym in re.findall(
-            r"const (?:realtype|double) \*([\w]+)[0]*(?:,|$)",
-            func_info.arguments(self.model.is_ode()),
-        ):
+        for sym in func_info.get_deps(ode=self.model.is_ode()):
             if sym not in self.model.sym_names():
                 continue
 

--- a/python/sdist/amici/de_model.py
+++ b/python/sdist/amici/de_model.py
@@ -70,6 +70,10 @@ logger = get_logger(__name__, logging.ERROR)
 
 DERIVATIVE_PATTERN = re.compile(r"^d(x_rdata|xdot|\w+?)d(\w+?)(?:_explicit)?$")
 
+__all__ = [
+    "DEModel",
+]
+
 
 class DEModel:
     """


### PR DESCRIPTION
Previously, trailing whitespace in function signatures in `_FunctionInfo` would result in not so informative compilation errors. Make the pattern more tolerant and move it closer to the function definitions.