### PR TITLE
Optional random generator seed for `ExpData::ExpData(ReturnData const&, ...)`

### DIFF
--- a/include/amici/edata.h
+++ b/include/amici/edata.h
@@ -95,28 +95,35 @@ class ExpData : public SimulationParameters {
     explicit ExpData(Model const& model);
 
     /**
-     * @brief constructor that initializes with returnData, adds noise according
-     * to specified sigmas
+     * @brief Constructor that initializes with ReturnData, adds normally
+     * distributed noise according to specified sigmas.
      *
      * @param rdata return data pointer with stored simulation results
      * @param sigma_y scalar standard deviations for all observables
      * @param sigma_z scalar standard deviations for all event observables
+     * @param seed Seed for the random number generator. If a negative number
+     * is passed, a random seed is used.
      */
-    ExpData(ReturnData const& rdata, realtype sigma_y, realtype sigma_z);
+    ExpData(
+        ReturnData const& rdata, realtype sigma_y, realtype sigma_z,
+        int seed = -1
+    );
 
     /**
-     * @brief constructor that initializes with returnData, adds noise according
-     * to specified sigmas
+     * @brief Constructor that initializes with ReturnData, adds normally
+     * distributed noise according to specified sigmas.
      *
      * @param rdata return data pointer with stored simulation results
      * @param sigma_y vector of standard deviations for observables
      * (dimension: nytrue or nt x nytrue, row-major)
      * @param sigma_z vector of standard deviations for event observables
      * (dimension: nztrue or nmaxevent x nztrue, row-major)
+     * @param seed Seed for the random number generator. If a negative number
+     * is passed, a random seed is used.
      */
     ExpData(
         ReturnData const& rdata, std::vector<realtype> sigma_y,
-        std::vector<realtype> sigma_z
+        std::vector<realtype> sigma_z, int seed = -1
     );
 
     ~ExpData() = default;

--- a/src/edata.cpp
+++ b/src/edata.cpp
@@ -68,15 +68,17 @@ ExpData::ExpData(Model const& model)
     reinitialization_state_idxs_sim = model.getReinitializationStateIdxs();
 }
 
-ExpData::ExpData(ReturnData const& rdata, realtype sigma_y, realtype sigma_z)
+ExpData::ExpData(
+    ReturnData const& rdata, realtype sigma_y, realtype sigma_z, int seed
+)
     : ExpData(
           rdata, std::vector<realtype>(rdata.nytrue * rdata.nt, sigma_y),
-          std::vector<realtype>(rdata.nztrue * rdata.nmaxevent, sigma_z)
+          std::vector<realtype>(rdata.nztrue * rdata.nmaxevent, sigma_z), seed
       ) {}
 
 ExpData::ExpData(
     ReturnData const& rdata, std::vector<realtype> sigma_y,
-    std::vector<realtype> sigma_z
+    std::vector<realtype> sigma_z, int seed
 )
     : ExpData(rdata.nytrue, rdata.nztrue, rdata.nmaxevent, rdata.ts) {
     if (sigma_y.size() != (unsigned)nytrue_
@@ -93,8 +95,7 @@ ExpData::ExpData(
             nztrue_ * nmaxevent_, sigma_z.size()
         );
 
-    std::random_device rd{};
-    std::mt19937 gen{rd()};
+    std::mt19937 gen{seed < 0 ? std::random_device()() : seed};
 
     realtype sigma;
 
@@ -121,7 +122,7 @@ ExpData::ExpData(
             std::normal_distribution<> e{0, sigma};
             observed_events_.at(iz + rdata.nztrue * ie)
                 = rdata.z.at(iz + rdata.nz * ie) + e(gen);
-            observed_data_std_dev_.at(iz + rdata.nztrue * ie) = sigma;
+            observed_events_std_dev_.at(iz + rdata.nztrue * ie) = sigma;
         }
     }
 

--- a/tests/cpp/unittests/testExpData.cpp
+++ b/tests/cpp/unittests/testExpData.cpp
@@ -3,6 +3,7 @@
 #include <amici/amici.h>
 #include <amici/model_ode.h>
 #include <amici/symbolic_functions.h>
+#include <amici/solver_cvodes.h>
 
 #include <exception>
 #include <vector>
@@ -337,6 +338,27 @@ TEST_F(ExpDataTest, SettersGetters)
                     TEST_ATOL,
                     TEST_RTOL,
                     "ObservedEventsStdDev");
+}
+
+TEST_F(ExpDataTest, RngSeed)
+{
+    ReturnData rdata(CVodeSolver(), testModel);
+    rdata.y.assign(testModel.ny * testModel.nt(), 1.0);
+    rdata.z.assign(testModel.nz * testModel.nMaxEvent(), 1.0);
+
+    // random RNG seed
+    ExpData edata1(rdata, 1, 1, -1);
+
+    ASSERT_TRUE(edata1.getObservedData() != rdata.y);
+
+    // fixed RNG seed
+    ExpData edata2(rdata, 1, 1, 1);
+
+    ASSERT_TRUE(edata2.getObservedData() != rdata.y);
+    ASSERT_TRUE(edata2.getObservedData() != edata1.getObservedData());
+
+    ExpData edata3(rdata, 1, 1, 1);
+    ASSERT_TRUE(edata3.getObservedData() == edata2.getObservedData());
 }
 
 } // namespace


### PR DESCRIPTION

* Allow passing a random number generator seed for generation of artificial measurements in `ExpData::ExpData(ReturnData const&, ...)`. The default remains a random seed. Closes #2599.
* Fixes incorrect results and a potential crash (attempted out-of-bound write) due to incorrect writing to `ExpData::observed_data_std_dev_` instead of `ExpData::observed_events_std_dev_`.