### PR TITLE
Fix deltaxB dimensions

### DIFF
--- a/include/amici/backwardproblem.h
+++ b/include/amici/backwardproblem.h
@@ -186,9 +186,15 @@ class BackwardProblem {
     /** array containing the time-points of discontinuities*/
     std::vector<Discontinuity> discs_;
 
-    /** state derivative of data likelihood */
+    /**
+     * state derivative of data likelihood
+     * dimensions: nt * nJ * nx_solver
+     */
     std::vector<realtype> dJydx_;
-    /** state derivative of event likelihood */
+    /**
+     * state derivative of event likelihood
+     * dimensions: nJ * nx_solver * nmaxevent
+     */
     std::vector<realtype> const dJzdx_;
 
     /** The preequilibration steadystate problem from the forward problem. */

--- a/include/amici/model_state.h
+++ b/include/amici/model_state.h
@@ -428,7 +428,8 @@ struct ModelStateDerived {
      */
     std::vector<realtype> deltasx_;
 
-    /** temporary storage for change in xB after event (dimension: `nx_solver`)
+    /** temporary storage for change in xB after event
+     * (dimension: `nxtrue_solver` * `nJ`, row-major)
      */
     std::vector<realtype> deltaxB_;
 

--- a/src/model.cpp
+++ b/src/model.cpp
@@ -1510,7 +1510,7 @@ void Model::addAdjointStateEventUpdate(
     AmiVector const& xdot, AmiVector const& xdot_old
 ) {
 
-    derived_state_.deltaxB_.assign(nx_solver, 0.0);
+    derived_state_.deltaxB_.assign(nxtrue_solver * nJ, 0.0);
 
     // compute update
     fdeltaxB(


### PR DESCRIPTION
Prevent out-of-bounds access in `Model::addAdjointStateEventUpdate` at 
https://github.com/dweindl/AMICI/blob/60b6ae1ca91858154147791f66587825fcbb773b/src/model.cpp#L1530

Only relevant for 2nd order adjoint sensitivities.