### PR TITLE
Add warning if model expressions contains complex infinity

### DIFF
--- a/python/sdist/amici/cxxcodeprinter.py
+++ b/python/sdist/amici/cxxcodeprinter.py
@@ -3,6 +3,7 @@
 import itertools
 import os
 import re
+import warnings
 from collections.abc import Sequence
 from collections.abc import Iterable
 
@@ -94,6 +95,19 @@ class AmiciCxxCodePrinter(CXX11CodePrinter):
         return "-std::numeric_limits<double>::infinity()"
 
     def _print_ComplexInfinity(self, expr):
+        # Since -zoo==+zoo, expressions containing ComplexInfinity may yield
+        # unexpected results as compared to IEEE 754.
+
+        warnings.warn(
+            "Expression contains ComplexInfinity. "
+            "This may point to a bug in the model and may result in "
+            "incorrect simulation results. "
+            "A possible cause is a division by zero in the model equations, "
+            "which is supported by IEEE 754, but not by sympy."
+            "Please check your model equations for potential issues.",
+            stacklevel=1,
+        )
+
         return "std::numeric_limits<double>::infinity()"
 
     def _get_sym_lines_array(

--- a/python/tests/test_cxxcodeprinter.py
+++ b/python/tests/test_cxxcodeprinter.py
@@ -2,6 +2,7 @@ import sympy as sp
 from amici.cxxcodeprinter import AmiciCxxCodePrinter
 from sympy.codegen.rewriting import optims_c99
 from amici.testing import skip_on_valgrind
+import pytest
 
 
 @skip_on_valgrind
@@ -36,13 +37,15 @@ def test_print_infinity():
     )
     assert cp.doprint(sp.oo) == "std::numeric_limits<double>::infinity()"
     assert cp.doprint(-sp.oo) == "-std::numeric_limits<double>::infinity()"
-    assert (
-        cp.doprint(ComplexInfinity())
-        == "std::numeric_limits<double>::infinity()"
-    )
-    assert (
-        cp.doprint(-ComplexInfinity())
-        == "std::numeric_limits<double>::infinity()"
-    )
-    assert cp.doprint(sp.zoo) == "std::numeric_limits<double>::infinity()"
-    assert cp.doprint(-sp.zoo) == "std::numeric_limits<double>::infinity()"
+
+    with pytest.warns(UserWarning, match="contains ComplexInfinity"):
+        assert (
+            cp.doprint(ComplexInfinity())
+            == "std::numeric_limits<double>::infinity()"
+        )
+        assert (
+            cp.doprint(-ComplexInfinity())
+            == "std::numeric_limits<double>::infinity()"
+        )
+        assert cp.doprint(sp.zoo) == "std::numeric_limits<double>::infinity()"
+        assert cp.doprint(-sp.zoo) == "std::numeric_limits<double>::infinity()"


### PR DESCRIPTION
See the discussion at #2791.

Ideally, this would be checked earlier, but this would require checks in too many places. Thus, let's check it when printing the model equations.