### PR TITLE
Fix SBML test suite tests

### DIFF
--- a/tests/sbml/conftest.py
+++ b/tests/sbml/conftest.py
@@ -66,18 +66,18 @@ def pytest_generate_tests(metafunc):
     """Parameterize tests"""
 
     # Run for all SBML semantic test suite cases
-    if "test_number" in metafunc.fixturenames:
+    if "test_id" in metafunc.fixturenames:
         # Get CLI option
         cases = metafunc.config.getoption("cases")
         if cases:
             # Run selected tests
             last_id = int(list(get_all_semantic_case_ids())[-1])
             test_numbers = sorted(set(parse_selection(cases, last_id)))
+            test_ids = map(format_test_id, test_numbers)
         else:
             # Run all tests
-            test_numbers = get_all_semantic_case_ids()
-        test_numbers = map(format_test_id, test_numbers)
-        metafunc.parametrize("test_number", test_numbers)
+            test_ids = get_all_semantic_case_ids()
+        metafunc.parametrize("test_id", test_ids)
 
 
 def pytest_sessionfinish(session, exitstatus):

--- a/tests/sbml/testSBMLSuite.py
+++ b/tests/sbml/testSBMLSuite.py
@@ -24,7 +24,6 @@ import pytest
 from amici.constants import SymbolId
 from amici.gradient_check import check_derivatives
 from numpy.testing import assert_allclose
-from tests.sbml.conftest import format_test_id
 
 
 @pytest.fixture(scope="session")
@@ -45,10 +44,7 @@ def sbml_test_dir():
     sys.path = old_path
 
 
-def test_sbml_testsuite_case(
-    test_number, result_path, sbml_semantic_cases_dir
-):
-    test_id = format_test_id(test_number)
+def test_sbml_testsuite_case(test_id, result_path, sbml_semantic_cases_dir):
     model_dir = None
 
     # test cases for which sensitivities are to be checked

--- a/tests/sbml/testSBMLSuiteJax.py
+++ b/tests/sbml/testSBMLSuiteJax.py
@@ -23,7 +23,6 @@ from tests.sbml.testSBMLSuite import (
     find_model_file,
     read_settings_file,
 )
-from tests.sbml.conftest import format_test_id
 
 jax.config.update("jax_enable_x64", True)
 
@@ -127,9 +126,8 @@ def run_jax_simulation(model, importer, ts, atol, rtol, tol_factor=1e2):
 
 
 def test_sbml_testsuite_case_jax(
-    test_number, result_path_jax, sbml_semantic_cases_dir
+    test_id, result_path_jax, sbml_semantic_cases_dir
 ):
-    test_id = format_test_id(test_number)
     model_dir = Path(__file__).parent / "SBMLTestModelsJax" / test_id
     try:
         current_test_path = sbml_semantic_cases_dir / test_id


### PR DESCRIPTION
Don't import from conftest (only use fixtures from there). The imported function is not necessary, though. The IDs already are in the correct format. This was some leftover from earlier days, I think.