### PR TITLE
Refactor: Avoid xQ dummy arguments

### DIFF
--- a/include/amici/solver.h
+++ b/include/amici/solver.h
@@ -657,6 +657,17 @@ class Solver {
     ) const;
 
     /**
+     * @brief write solution from forward simulation
+     * @param t time
+     * @param x state
+     * @param dx derivative state
+     * @param sx state sensitivity
+     */
+    void writeSolution(
+        realtype* t, AmiVector& x, AmiVector& dx, AmiVectorArray& sx
+    ) const;
+
+    /**
      * @brief write solution from backward simulation
      * @param t time
      * @param xB adjoint state

--- a/src/forwardproblem.cpp
+++ b/src/forwardproblem.cpp
@@ -112,7 +112,7 @@ void EventHandlingSimulator::run(
                 int const status = solver_->run(next_t_stop);
                 // sx will be copied from solver on demand if sensitivities
                 // are computed
-                solver_->writeSolution(&t_, ws_->x, ws_->dx, ws_->sx, ws_->dx);
+                solver_->writeSolution(&t_, ws_->x, ws_->dx, ws_->sx);
 
                 if (status == AMICI_ILL_INPUT) {
                     // clustering of roots => turn off root-finding
@@ -210,7 +210,7 @@ void ForwardProblem::handlePresimulation() {
 
     std::vector<realtype> const timepoints{model->t0()};
     pre_simulator_.run(t_, edata, timepoints);
-    solver->writeSolution(&t_, ws_.x, ws_.dx, ws_.sx, ws_.dx);
+    solver->writeSolution(&t_, ws_.x, ws_.dx, ws_.sx);
 }
 
 void ForwardProblem::handleMainSimulation() {
@@ -562,7 +562,7 @@ ForwardProblem::getAdjointUpdates(Model& model, ExpData const& edata) {
 
 SimulationState EventHandlingSimulator::get_simulation_state() {
     if (std::isfinite(solver_->gett())) {
-        solver_->writeSolution(&t_, ws_->x, ws_->dx, ws_->sx, ws_->dx);
+        solver_->writeSolution(&t_, ws_->x, ws_->dx, ws_->sx);
     }
     auto state = SimulationState();
     state.t = t_;

--- a/src/solver.cpp
+++ b/src/solver.cpp
@@ -1318,6 +1318,16 @@ void Solver::writeSolution(
     dx.copy(getDerivativeState(*t));
 }
 
+void Solver::writeSolution(
+    realtype* t, AmiVector& x, AmiVector& dx, AmiVectorArray& sx
+) const {
+    *t = gett();
+    if (sens_initialized_)
+        sx.copy(getStateSensitivity(*t));
+    x.copy(getState(*t));
+    dx.copy(getDerivativeState(*t));
+}
+
 void Solver::writeSolutionB(
     realtype* t, AmiVector& xB, AmiVector& dxB, AmiVector& xQB, int const which
 ) const {

--- a/src/steadystateproblem.cpp
+++ b/src/steadystateproblem.cpp
@@ -415,7 +415,7 @@ void SteadystateProblem::initializeForwardProblem(
         solver.setup(t0, &model, state_.x, state_.dx, state_.sx, sdx_);
     } else {
         // The solver was run before, extract current state from solver.
-        solver.writeSolution(&state_.t, state_.x, state_.dx, state_.sx, xQ_);
+        solver.writeSolution(&state_.t, state_.x, state_.dx, state_.sx);
     }
 
     state_.t = t0;
@@ -710,7 +710,7 @@ void SteadystateProblem::runSteadystateSimulationFwd(
         // direction w.r.t. current t.
         solver.step(std::max(state_.t, 1.0) * 10);
 
-        solver.writeSolution(&state_.t, state_.x, state_.dx, state_.sx, xQ_);
+        solver.writeSolution(&state_.t, state_.x, state_.dx, state_.sx);
         flagUpdatedState();
     }
 


### PR DESCRIPTION
Overload `Solver::writeSolution` to avoid confusing dummy arguments for `xQ`. This also saves some unnecessary copying.