### PR TITLE
GHA: Fix libsbml crashes

### DIFF
--- a/.github/workflows/test_python_ver_matrix.yml
+++ b/.github/workflows/test_python_ver_matrix.yml
@@ -70,6 +70,11 @@ jobs:
         path: ${{ env.pooch-cache }}
         key: ${{ runner.os }}-py${{ matrix.python-version }}-${{ github.job }}
 
+    # https://github.com/sbmlteam/python-libsbml/issues/40
+    - name: No -Werror
+      if: matrix.python-version == '3.11'
+      run: sed -ri "s/    error//" pytest.ini
+
     - name: Python tests
       run: |
         source venv/bin/activate \


### PR DESCRIPTION
On Python3.11, to prevent crashes, don't use `-Werror`.