### PR TITLE
GHA: develop -> main

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,4 +8,4 @@ updates:
     ignore:
       - dependency-name: "*"
         update-types: ["version-update:semver-patch", "version-update:semver-minor"]
-    target-branch: "develop"
+    target-branch: "main"

--- a/.github/workflows/test_valgrind.yml
+++ b/.github/workflows/test_valgrind.yml
@@ -36,7 +36,7 @@ jobs:
       if: github.event_name == 'schedule'
       uses: actions/checkout@v4
       with:
-        ref: develop
+        ref: main
 
     - name: Checkout code (manual, push, pull request)
       if: github.event_name != 'schedule'


### PR DESCRIPTION
Fix some missed references to the discontinued `develop` branch.