### PR TITLE
Add JAX gradient checks for SBML testsuite

### DIFF
--- a/.github/actions/install-apt-dependencies/action.yml
+++ b/.github/actions/install-apt-dependencies/action.yml
@@ -11,5 +11,7 @@ runs:
               libboost-chrono-dev \
               libboost-math-dev \
               libboost-serialization-dev \
-              libhdf5-serial-dev
+              libhdf5-serial-dev \
+              libxml2-dev \
+              libxslt-dev
       shell: bash

--- a/.github/workflows/test_sbml_semantic_test_suite_jax.yml
+++ b/.github/workflows/test_sbml_semantic_test_suite_jax.yml
@@ -39,6 +39,9 @@ jobs:
     - name: Install apt dependencies
       uses: ./.github/actions/install-apt-dependencies
 
+    - name: Install Cython
+      run: pip install Cython
+
     - run: AMICI_PARALLEL_COMPILE="" ./scripts/installAmiciSource.sh
     - run: source ./venv/bin/activate && pip uninstall -y diffrax && pip install git+https://github.com/patrick-kidger/diffrax # TODO FIXME https://github.com/patrick-kidger/diffrax/issues/654
     - run: ./scripts/run-SBMLTestsuite.sh --jax ${{ matrix.cases }}

--- a/scripts/installAmiciSource.sh
+++ b/scripts/installAmiciSource.sh
@@ -36,7 +36,7 @@ python -m pip install --upgrade pip wheel
 # we need to install all build-system.requires manually, because of
 #  --no-build-isolation below.
 #  The latter is necessary for code coverage to work.
-python -m pip install --upgrade pip setuptools cmake_build_extension==0.6.0 numpy petab swig
+python -m pip install --upgrade pip setuptools cmake_build_extension==0.6.0 numpy petab swig Cython
 python -m pip install git+https://github.com/pysb/pysb@master # for SPM with compartments
 AMICI_BUILD_TEMP="${AMICI_PATH}/python/sdist/build/temp" \
   python -m pip install --verbose -e "${AMICI_PATH}/python/sdist[petab,test,vis,jax]" --no-build-isolation

--- a/tests/sbml/testSBMLSuite.py
+++ b/tests/sbml/testSBMLSuite.py
@@ -17,6 +17,11 @@ import amici
 import pandas as pd
 import pytest
 from amici.gradient_check import check_derivatives
+import jax
+import jax.numpy as jnp
+import numpy as np
+import diffrax
+from amici.jax.petab import DEFAULT_CONTROLLER_SETTINGS
 
 from utils import (
     verify_results,
@@ -88,6 +93,14 @@ def test_sbml_testsuite_case(test_id, result_path, sbml_semantic_cases_dir):
             solver.setSensitivityOrder(amici.SensitivityOrder.first)
             solver.setSensitivityMethod(amici.SensitivityMethod.forward)
             check_derivatives(model, solver, epsilon=epsilon)
+            jax_sensitivity_check(
+                current_test_path,
+                test_id,
+                model,
+                rdata,
+                atol,
+                rtol,
+            )
 
     except amici.sbml_import.SBMLException as err:
         pytest.skip(str(err))
@@ -122,3 +135,74 @@ def compile_model(
     solver = model.getSolver()
 
     return model, solver, sbml_importer
+
+
+def compile_model_jax(sbml_dir: Path, test_id: str, model_dir: Path):
+    """Import the given test model as JAX model"""
+    model_dir.mkdir(parents=True, exist_ok=True)
+    sbml_file = find_model_file(sbml_dir, test_id)
+    sbml_importer = amici.SbmlImporter(sbml_file)
+    model_name = f"SBMLTest{test_id}_jax"
+    sbml_importer.sbml2jax(model_name, output_dir=model_dir)
+    model_module = amici.import_model_module(model_dir.name, model_dir.parent)
+    jax_model = model_module.Model()
+    return jax_model, sbml_importer
+
+
+def jax_sensitivity_check(
+    sbml_dir: Path,
+    test_id: str,
+    amici_model: "amici.Model",
+    rdata: dict,
+    atol: float,
+    rtol: float,
+):
+    """Compare AMICI forward sensitivities against JAX autodiff"""
+    model_dir = Path(__file__).parent / "SBMLTestModelsJaxGrad" / test_id
+    jax_model, _ = compile_model_jax(sbml_dir, test_id, model_dir)
+
+    try:
+        ts = rdata["ts"]
+        p = jax_model.parameters
+        ts_jnp = jnp.asarray(ts, dtype=float)
+        zeros = jnp.zeros_like(ts_jnp)
+        solver = diffrax.Kvaerno5()
+        controller = diffrax.PIDController(
+            rtol=rtol,
+            atol=atol,
+            pcoeff=DEFAULT_CONTROLLER_SETTINGS["pcoeff"],
+            icoeff=DEFAULT_CONTROLLER_SETTINGS["icoeff"],
+            dcoeff=DEFAULT_CONTROLLER_SETTINGS["dcoeff"],
+        )
+
+        def simulate(pars):
+            x, _ = jax_model.simulate_condition(
+                pars,
+                ts_jnp,
+                jnp.array([]),
+                zeros,
+                jnp.zeros_like(ts_jnp, dtype=int),
+                jnp.zeros_like(ts_jnp, dtype=int),
+                jnp.zeros((ts_jnp.shape[0], 0)),
+                jnp.zeros((ts_jnp.shape[0], 0)),
+                solver,
+                controller,
+                diffrax.DirectAdjoint(),
+                diffrax.SteadyStateEvent(),
+                2**10,
+                ret=amici.jax.ReturnValue.x,
+            )
+            return x
+
+        x = simulate(p)
+        sx = jax.jacfwd(simulate)(p)
+        par_idx = [
+            jax_model.parameter_ids.index(pid)
+            for pid in amici_model.getParameterIds()
+        ]
+        sx = jnp.transpose(sx[:, :, par_idx], (0, 2, 1))
+
+        np.testing.assert_allclose(x, rdata["x"], rtol=1e-5, atol=1e-7)
+        np.testing.assert_allclose(sx, rdata["sx"], rtol=1e-5, atol=1e-7)
+    finally:
+        shutil.rmtree(model_dir, ignore_errors=True)


### PR DESCRIPTION
## Summary
- extend SBML semantic tests with JAX gradient checks
- compile SBML models for JAX and compare sensitivities

## Testing
- `pre-commit run --files tests/sbml/testSBMLSuite.py`
- `pytest tests/benchmark_models/test_petab_benchmark.py`
- `pytest tests/benchmark_models/test_petab_benchmark_jax.py -k Boehm_JProteomeRes2014`


------
https://chatgpt.com/codex/tasks/task_b_685d259297a4832bb74795ffd6214f34