### PR TITLE
Improve sigma<=0 error reporting

### DIFF
--- a/src/model.cpp
+++ b/src/model.cpp
@@ -7,6 +7,7 @@
 
 #include <algorithm>
 #include <cassert>
+#include <sstream>
 #include <cmath>
 #include <cstring>
 #include <numeric>
@@ -2164,10 +2165,17 @@ void Model::fsigmay(int const it, ExpData const* edata) {
             for (int iJ = 1; iJ < nJ; iJ++)
                 derived_state_.sigmay_.at(iytrue + iJ * nytrue) = 0;
 
-            if (edata->isSetObservedData(it, iytrue))
+            if (edata->isSetObservedData(it, iytrue)) {
+                std::string obs_id = hasObservableIds()
+                                         ? getObservableIds().at(iytrue)
+                                         : std::to_string(iytrue);
+                std::stringstream ss;
+                ss << "sigmay (" << obs_id << ", ExpData::id=" << edata->id
+                   << ", t=" << getTimepoint(it) << ")";
                 checkSigmaPositivity(
-                    derived_state_.sigmay_.at(iytrue), "sigmay"
+                    derived_state_.sigmay_.at(iytrue), ss.str().c_str()
                 );
+            }
         }
     }
 }


### PR DESCRIPTION
## Summary
- enhance `sigmay` sigma positivity check to include observable id, ExpData id and timepoint in error message
- include `<sstream>` for string formatting

## Testing
- `pre-commit run --files src/model.cpp src/model.cpp src/model.cpp`
- `pytest tests/benchmark_models/test_petab_benchmark.py -k Boehm_JProteomeRes2014`
- `pytest tests/benchmark_models/test_petab_benchmark_jax.py -k Boehm_JProteomeRes2014`


------
https://chatgpt.com/codex/tasks/task_b_685d26ba5dc8832bb224b16c390a4806