### PR TITLE
Refactor Newton's method / DEStateView

### DIFF
--- a/include/amici/newton_solver.h
+++ b/include/amici/newton_solver.h
@@ -10,7 +10,43 @@ namespace amici {
 class Model;
 class Solver;
 class AmiVector;
-struct SimulationState;
+
+/**
+ * @brief A non-owning container that groups references to the dynamical state
+ * of differential equation system.
+ *
+ * It's intended to passing around the current state of a system while
+ * avoiding repetetive argument passing in function signatures.
+ */
+struct DEStateView {
+    /**
+     * @brief Reference to the current simulation time \( t \).
+     */
+    realtype& t;
+
+    /**
+     * @brief Reference to the state vector \( x(t) \).
+     */
+    AmiVector& x;
+
+    /**
+     * @brief Reference to the time derivative of the state vector (DAE)
+     */
+    AmiVector& dx;
+
+    /**
+     * @brief Construct a DEStateView from references to state, derivative, and
+     * time.
+     *
+     * @param t_ Reference to the simulation time.
+     * @param x_ Reference to the state vector.
+     * @param dx_ Reference to the state derivative.
+     */
+    DEStateView(realtype& t_, AmiVector& x_, AmiVector& dx_)
+        : t(t_)
+        , x(x_)
+        , dx(dx_) {}
+};
 
 /**
  * @brief The NewtonSolver class sets up the linear solver for the Newton
@@ -44,7 +80,7 @@ class NewtonSolver {
      * @param model the model instance
      * @param state current simulation state
      */
-    void getStep(AmiVector& delta, Model& model, SimulationState const& state);
+    void getStep(AmiVector& delta, Model& model, DEStateView const& state);
 
     /**
      * @brief Computes steady state sensitivities
@@ -54,7 +90,7 @@ class NewtonSolver {
      * @param state current simulation state
      */
     void computeNewtonSensis(
-        AmiVectorArray& sx, Model& model, SimulationState const& state
+        AmiVectorArray& sx, Model& model, DEStateView const& state
     );
 
     /**
@@ -64,7 +100,7 @@ class NewtonSolver {
      * @param model the model instance
      * @param state current simulation state
      */
-    void prepareLinearSystem(Model& model, SimulationState const& state);
+    void prepareLinearSystem(Model& model, DEStateView const& state);
 
     /**
      * Writes the Jacobian (JB) for the Newton iteration and passes it to the
@@ -73,7 +109,7 @@ class NewtonSolver {
      * @param model the model instance
      * @param state current simulation state
      */
-    void prepareLinearSystemB(Model& model, SimulationState const& state);
+    void prepareLinearSystemB(Model& model, DEStateView const& state);
 
     /**
      * @brief Solves the linear system for the Newton step
@@ -97,7 +133,7 @@ class NewtonSolver {
      * @return boolean indicating whether the linear system is singular
      * (condition number < 1/machine precision)
      */
-    bool is_singular(Model& model, SimulationState const& state) const;
+    bool is_singular(Model& model, DEStateView const& state) const;
 
   private:
     /** dummy rhs, used as dummy argument when computing J and JB */

--- a/include/amici/steadystateproblem.h
+++ b/include/amici/steadystateproblem.h
@@ -97,7 +97,7 @@ class NewtonsMethod {
      * @param wrms_computer WRMSComputer instance to compute the WRMS norm.
      */
     void
-    run(AmiVector& xdot, SimulationState& state, WRMSComputer& wrms_computer);
+    run(AmiVector& xdot, DEStateView const& state, WRMSComputer& wrms_computer);
 
     /**
      * @brief Compute the Newton step for the current state_.x and xdot and
@@ -105,7 +105,7 @@ class NewtonsMethod {
      * @param xdot Time derivative of the state vector `state.x`.
      * @param state SimulationState instance containing the current state.
      */
-    void compute_step(AmiVector const& xdot, SimulationState const& state);
+    void compute_step(AmiVector const& xdot, DEStateView const& state);
 
     /**
      * @brief Get the last Newton step.
@@ -147,7 +147,7 @@ class NewtonsMethod {
      * @return WRMS norm.
      */
     realtype compute_wrms(
-        AmiVector const& xdot, SimulationState const& state,
+        AmiVector const& xdot, DEStateView const& state,
         WRMSComputer& wrms_computer
     );
 
@@ -164,7 +164,7 @@ class NewtonsMethod {
      * @return Whether convergence has been reached.
      */
     bool has_converged(
-        AmiVector& xdot, SimulationState& state, WRMSComputer& wrms_computer
+        AmiVector& xdot, DEStateView const& state, WRMSComputer& wrms_computer
     );
 
     static constexpr realtype conv_thresh = 1.0;

--- a/src/newton_solver.cpp
+++ b/src/newton_solver.cpp
@@ -42,7 +42,7 @@ NewtonSolver::NewtonSolver(
 }
 
 void NewtonSolver::getStep(
-    AmiVector& delta, Model& model, SimulationState const& state
+    AmiVector& delta, Model& model, DEStateView const& state
 ) {
     prepareLinearSystem(model, state);
 
@@ -51,7 +51,7 @@ void NewtonSolver::getStep(
 }
 
 void NewtonSolver::computeNewtonSensis(
-    AmiVectorArray& sx, Model& model, SimulationState const& state
+    AmiVectorArray& sx, Model& model, DEStateView const& state
 ) {
     prepareLinearSystem(model, state);
     model.fdxdotdp(state.t, state.x, state.dx);
@@ -84,9 +84,7 @@ void NewtonSolver::computeNewtonSensis(
     }
 }
 
-void NewtonSolver::prepareLinearSystem(
-    Model& model, SimulationState const& state
-) {
+void NewtonSolver::prepareLinearSystem(Model& model, DEStateView const& state) {
     auto& J = linsol_->getMatrix();
     if (J.matrix_id() == SUNMATRIX_SPARSE) {
         model.fJSparse(state.t, 0.0, state.x, state.dx, xdot_, J);
@@ -102,7 +100,7 @@ void NewtonSolver::prepareLinearSystem(
 }
 
 void NewtonSolver::prepareLinearSystemB(
-    Model& model, SimulationState const& state
+    Model& model, DEStateView const& state
 ) {
     auto& J = linsol_->getMatrix();
     if (J.matrix_id() == SUNMATRIX_SPARSE) {
@@ -145,9 +143,7 @@ void NewtonSolver::reinitialize() {
     );
 }
 
-bool NewtonSolver::is_singular(
-    Model& model, SimulationState const& state
-) const {
+bool NewtonSolver::is_singular(Model& model, DEStateView const& state) const {
     if (auto s = dynamic_cast<SUNLinSolKLU const*>(linsol_.get())) {
         return s->is_singular();
     }


### PR DESCRIPTION
Introduce new struct `DEStateView` to simplify passing around {t, x, dx}. Don't require a full `SimulationState` if only a small subset is required. Will simplify further refactoring.