### PR TITLE
Add Python nogil workflow

### DIFF
--- a/.github/workflows/test_python_nogil.yml
+++ b/.github/workflows/test_python_nogil.yml
@@ -1,0 +1,45 @@
+name: Python nogil Tests
+on:
+  push:
+  pull_request:
+    branches:
+      - main
+  merge_group:
+  workflow_dispatch:
+
+jobs:
+  nogil-tests:
+    name: Python nogil
+    runs-on: ubuntu-24.04
+    env:
+      AMICI_SKIP_CMAKE_TESTS: "TRUE"
+      AMICI_PARALLEL_COMPILE: ""
+    steps:
+    - uses: actions/checkout@v4
+      with:
+        fetch-depth: 20
+    - run: git fetch --prune --unshallow
+    - run: echo "AMICI_DIR=$(pwd)" >> $GITHUB_ENV
+    - name: Set up Python 3.13 free-threaded
+      uses: actions/setup-python@v5
+      with:
+        python-version: '3.13'
+        freethreaded: true
+    - name: Install apt dependencies
+      uses: ./.github/actions/install-apt-dependencies
+    - name: Install python package
+      run: scripts/installAmiciSource.sh
+    - run: source venv/bin/activate && pip3 install "sympy>1.12"
+    - name: Get Pooch Cache Directory
+      id: get-pooch-cache
+      run: |
+        echo "pooch-cache=$(source venv/bin/activate && python -c 'import pooch; print(pooch.os_cache("pooch"))')" >> $GITHUB_ENV
+    - name: Cache Pooch Directory
+      uses: actions/cache@v4
+      with:
+        path: ${{ env.pooch-cache }}
+        key: ${{ runner.os }}-nogil-${{ github.job }}
+    - name: Python tests
+      run: |
+        source venv/bin/activate && \
+        pytest python/tests/test_sbml_import.py::test_sbml2amici_no_observables -vv


### PR DESCRIPTION
## Summary
- add GitHub workflow to run tests using Python built without the GIL
- use actions/setup-python `freethreaded` option (PEP 703)
- remove BNGL and PySB dependencies
- limit nogil workflow to one simple test

## Testing
- `pre-commit run --files .github/workflows/test_python_nogil.yml`
- `pytest python/tests/test_sbml_import.py::test_sbml2amici_no_observables -vv`


------
https://chatgpt.com/codex/tasks/task_b_685d2711b7bc832b8a5754593d40d112