### PR TITLE
Refactor SteadyStateProblem / FwdSimWorkspace

### DIFF
--- a/include/amici/forwardproblem.h
+++ b/include/amici/forwardproblem.h
@@ -127,6 +127,8 @@ struct FwdSimWorkspace {
         , rootvals(gsl::narrow<decltype(rootvals)::size_type>(model->ne), 0.0)
 
     {}
+    /** current simulation time */
+    realtype t{NAN};
 
     /** state vector (dimension: nx_solver) */
     AmiVector x;

--- a/src/forwardproblem.cpp
+++ b/src/forwardproblem.cpp
@@ -173,7 +173,7 @@ void ForwardProblem::handlePreequilibration() {
 
     ConditionContext cc2(model, edata, FixedParameterContext::preequilibration);
 
-    preeq_problem_.emplace(*solver, *model);
+    preeq_problem_.emplace(&ws_, *solver, *model);
     auto t0 = std::isnan(model->t0Preeq()) ? model->t0() : model->t0Preeq();
     preeq_problem_->workSteadyStateProblem(*solver, *model, -1, t0);
 
@@ -267,7 +267,7 @@ void ForwardProblem::handleMainSimulation() {
 
 void ForwardProblem::handlePostequilibration() {
     if (getCurrentTimeIteration() < model->nt()) {
-        posteq_problem_.emplace(*solver, *model);
+        posteq_problem_.emplace(&ws_, *solver, *model);
         auto it = getCurrentTimeIteration();
         auto t0 = it < 1 ? model->t0() : model->getTimepoint(it - 1);
         posteq_problem_->workSteadyStateProblem(*solver, *model, it, t0);


### PR DESCRIPTION
Use `FwdSimWorkspace` in `SteadyStateProblem` instead of its own `SimulationParameters`.
Required to implement event-handling during pre-equilibration (https://github.com/AMICI-dev/AMICI/issues/2775) later on.