### PR TITLE
Improve presimulation test

### DIFF
--- a/python/tests/test_sbml_import.py
+++ b/python/tests/test_sbml_import.py
@@ -236,15 +236,20 @@ def test_presimulation(sbml_example_presimulation_module):
     )
     solver.setSensitivityOrder(amici.SensitivityOrder.first)
     model.setReinitializeFixedParameterInitialStates(True)
+    model.requireSensitivitiesForAllParameters()
 
-    rdata = amici.runAmiciSimulation(model, solver)
-    edata = amici.ExpData(rdata, 0.1, 0.0)
+    rdata_ref = amici.runAmiciSimulation(model, solver)
+    edata = amici.ExpData(rdata_ref, 0.1, 0.0)
+    edata.t_presim = 1
     edata.fixedParameters = [10, 2]
-    edata.fixedParametersPresimulation = [10, 2]
+    edata.fixedParametersPresimulation = [10, 0]
     edata.fixedParametersPreequilibration = [3, 0]
-    assert isinstance(
-        amici.runAmiciSimulation(model, solver, edata), amici.ReturnDataView
-    )
+    rdata = amici.runAmiciSimulation(model, solver, edata)
+    assert isinstance(rdata, amici.ReturnDataView)
+    assert not np.allclose(rdata_ref["x0"], rdata["x0"])
+    assert np.any(rdata["sx"])
+    assert np.any(rdata["sy"])
+    assert np.any(rdata["sllh"])
 
     solver.setRelativeTolerance(1e-12)
     solver.setAbsoluteTolerance(1e-12)


### PR DESCRIPTION
## Summary
- ensure `test_presimulation` actually runs presimulation
- verify gradients are nonzero
- add more observables to presimulation fixture

## Testing
- `pre-commit run --files python/tests/test_sbml_import.py python/tests/conftest.py`
- `pytest python/tests/test_sbml_import.py::test_presimulation -q`

------
https://chatgpt.com/codex/tasks/task_b_685d25fb7768832b840af6f1e4437acb