### PR TITLE
Add conda installation workflow

### DIFF
--- a/.github/workflows/test_conda_install.yml
+++ b/.github/workflows/test_conda_install.yml
@@ -1,0 +1,34 @@
+name: Conda installation
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: '48 4 * * *'
+  pull_request:
+    branches:
+      - main
+
+jobs:
+  conda:
+    name: Conda installation
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-24.04, macos-latest]
+        python-version: ['3.11']
+    runs-on: ${{ matrix.os }}
+    steps:
+      - uses: actions/checkout@v4
+      - name: Set up Miniconda
+        uses: conda-incubator/setup-miniconda@v3
+        with:
+          python-version: ${{ matrix.python-version }}
+          auto-update-conda: true
+          activate-environment: amici
+      - name: Install AMICI
+        shell: bash -l {0}
+        run: conda install -y -c conda-forge amici
+      - name: Test import
+        shell: bash -l {0}
+        run: |
+          python -c "from amici import _amici; print(_amici)"
+          python -m amici


### PR DESCRIPTION
## Summary
- add a cron-based GitHub Actions workflow to verify conda installations on Linux and macOS
- ensure the workflow also runs on pull requests

## Testing
- `pre-commit run --files .github/workflows/test_conda_install.yml`
- `pytest tests/benchmark_models/test_petab_benchmark.py -k Boehm_JProteomeRes2014`
- `pytest tests/benchmark_models/test_petab_benchmark_jax.py -k Boehm_JProteomeRes2014`


------
https://chatgpt.com/codex/tasks/task_b_685d2741a818832ba131032a356886d8