### PR TITLE
Improve JAX event integration

### DIFF
--- a/doc/examples/example_jax_petab/ExampleJaxPEtab.ipynb
+++ b/doc/examples/example_jax_petab/ExampleJaxPEtab.ipynb
@@ -445,6 +445,7 @@
    "source": [
     "import jax.numpy as jnp\n",
     "import diffrax\n",
+    "import optimistix\n",
     "from amici.jax import ReturnValue\n",
     "\n",
     "# Define the simulation condition\n",
@@ -478,6 +479,7 @@
     "        nps=jnp.array(nps),\n",
     "        solver=diffrax.Kvaerno5(),\n",
     "        controller=diffrax.PIDController(atol=1e-8, rtol=1e-8),\n",
+    "        root_finder=optimistix.Newton(atol=1e-8, rtol=1e-8),\n",
     "        steady_state_event=diffrax.steady_state_event(),\n",
     "        max_steps=2**10,\n",
     "        adjoint=diffrax.DirectAdjoint(),\n",

--- a/python/sdist/amici/de_model.py
+++ b/python/sdist/amici/de_model.py
@@ -1858,6 +1858,17 @@ class DEModel:
                 smart_jacobian(self.eq("w")[self.num_cons_law() :, :], x)
             )
 
+        elif name == "iroot":
+            self._eqs[name] = sp.Matrix(
+                [
+                    eq
+                    for eq, event in zip(
+                        self.eq("root"), self._events, strict=True
+                    )
+                    if not event.has_explicit_trigger_times()
+                ]
+            )
+
         elif match_deriv:
             self._derivative(match_deriv[1], match_deriv[2], name)
 
@@ -2466,15 +2477,3 @@ class DEModel:
             boolean indicating if event assignments are present
         """
         return any(event.updates_state for event in self._events)
-
-    def has_parameter_dependent_implicit_roots(self) -> bool:
-        """
-        Checks whether the model has events with parameter-dependent implicit roots
-
-        :return:
-            boolean indicating if parameter-dependent implicit roots are present
-        """
-        return any(
-            self.sym("p").has(root.free_symbols)
-            for root in self.get_implicit_roots()
-        )

--- a/python/sdist/amici/de_model.py
+++ b/python/sdist/amici/de_model.py
@@ -1231,6 +1231,24 @@ class DEModel:
                 ]
             )
             return
+        elif name == "ih":
+            self._syms[name] = sp.Matrix(
+                [
+                    sym
+                    for sym, event in zip(self.sym("h"), self._events)
+                    if not event.has_explicit_trigger_times()
+                ]
+            )
+            return
+        elif name == "eh":
+            self._syms[name] = sp.Matrix(
+                [
+                    sym
+                    for sym, event in zip(self.sym("h"), self._events)
+                    if event.has_explicit_trigger_times()
+                ]
+            )
+            return
         else:
             length = len(self.eq(name))
         self._syms[name] = sp.Matrix(
@@ -1866,6 +1884,17 @@ class DEModel:
                         self.eq("root"), self._events, strict=True
                     )
                     if not event.has_explicit_trigger_times()
+                ]
+            )
+
+        elif name == "eroot":
+            self._eqs[name] = sp.Matrix(
+                [
+                    eq
+                    for eq, event in zip(
+                        self.eq("root"), self._events, strict=True
+                    )
+                    if event.has_explicit_trigger_times()
                 ]
             )
 

--- a/python/sdist/amici/jax/_simulation.py
+++ b/python/sdist/amici/jax/_simulation.py
@@ -1,0 +1,530 @@
+"""Simulation subroutines."""
+
+# ruff: noqa: F821 F722
+
+import os
+
+import diffrax
+import equinox.internal as eqxi
+import jax.numpy as jnp
+import jax
+import jax.tree_util as jtu
+from optimistix import AbstractRootFinder
+import jaxtyping as jt
+
+from collections.abc import Callable
+
+STARTING_STATS = {
+    "max_steps": 0,
+    "num_accepted_steps": 0,
+    "num_rejected_steps": 0,
+    "num_steps": 0,
+}
+
+
+def eq(
+    p: jt.Float[jt.Array, "np"],
+    tcl: jt.Float[jt.Array, "ncl"],
+    h0: jt.Float[jt.Array, "ne"],
+    x0: jt.Float[jt.Array, "nxs"],
+    solver: diffrax.AbstractSolver,
+    controller: diffrax.AbstractStepSizeController,
+    root_finder: AbstractRootFinder,
+    steady_state_event: Callable[..., diffrax._custom_types.BoolScalarLike],
+    term: diffrax.ODETerm,
+    root_cond_fns: list[Callable],
+    root_cond_fn: Callable,
+    known_discs: jt.Float[jt.Array, "*nediscs"],
+    max_steps: jnp.int_,
+) -> tuple[jt.Float[jt.Array, "nxs"], jt.Float[jt.Array, "ne"], dict]:
+    """
+    Simulate the ODE system until steady state.
+
+    :param p:
+        parameters
+    :param tcl:
+        total values for conservation laws
+    :param h:
+        heaviside variables
+    :param x0:
+        initial state vector
+    :param solver:
+        ODE solver
+    :param controller:
+        step size controller
+    :param root_finder:
+        root finder for discontinuities
+    :param steady_state_event:
+        event function for steady state
+    :param term:
+        ODE term
+    :param root_cond_fns:
+        list of individual root condition functions for discontinuities
+    :param root_cond_fn:
+        root condition function for all discontinuities
+    :param known_discs:
+        known discontinuities, used to clip the step size controller
+    :param max_steps:
+        maximum number of steps
+    :return:
+        steady state solution, heaviside variables, and statistics
+    """
+    # if there are no events, we can avoid expensive looping and just run a single segment
+    if not root_cond_fns:
+        sol, _, stats = _run_segment(
+            0.0,
+            jnp.inf,
+            x0,
+            p,
+            tcl,
+            h0,
+            solver,
+            controller,
+            root_finder,
+            max_steps,
+            diffrax.DirectAdjoint(),
+            [steady_state_event],
+            diffrax.SaveAt(t1=True),
+            term,
+            known_discs,
+            dict(**STARTING_STATS),
+        )
+        y1 = jnp.where(
+            diffrax.is_event(sol.result),
+            sol.ys[-1],
+            jnp.inf * jnp.ones_like(sol.ys[-1]),
+        )
+        return y1, h0, stats
+
+    def cond_fn(carry):
+        _, y0, _, event_index, _ = carry
+        return jnp.logical_and(
+            event_index != 0,  # has not reached steady state yet
+            jnp.isfinite(
+                y0
+            ).all(),  # y0 is finite, also used to track integration failure
+        )
+
+    def body_fn(carry):
+        t_start, y0, h, event_index, stats = carry
+        sol, event_index, stats = _run_segment(
+            t_start,
+            jnp.inf,
+            y0,
+            p,
+            tcl,
+            h,
+            solver,
+            controller,
+            root_finder,
+            max_steps,  # TODO: figure out how to pass `max_steps - stats['num_steps']` here
+            diffrax.DirectAdjoint(),
+            [steady_state_event] + root_cond_fns,
+            diffrax.SaveAt(t1=True),
+            term,
+            known_discs,
+            stats,
+        )
+        y0_next = jnp.where(
+            jnp.logical_or(
+                diffrax.is_successful(sol.result),
+                diffrax.is_event(sol.result),
+            ),
+            sol.ys[-1],
+            jnp.inf * jnp.ones_like(sol.ys[-1]),
+        )
+        t0_next = jnp.where(jnp.isfinite(sol.ts), sol.ts, -jnp.inf).max()
+
+        y0_next, t0_next, h_next, stats = _handle_event(
+            t0_next,
+            jnp.inf,
+            y0_next,
+            p,
+            tcl,
+            h,
+            solver,
+            controller,
+            root_finder,
+            diffrax.DirectAdjoint(),
+            term,
+            root_cond_fn,
+            stats,
+        )
+
+        return (
+            t0_next,
+            y0_next,
+            h_next,
+            event_index,
+            dict(**STARTING_STATS),
+        )
+
+    # run the loop until no event is triggered (which will also be the case if we run out of steps)
+    _, y1, h, _, stats = eqxi.while_loop(
+        cond_fn,
+        body_fn,
+        (0.0, x0, h0, -1, dict(**STARTING_STATS)),
+        kind="bounded",
+        max_steps=2**6,
+    )
+
+    return y1, h, stats
+
+
+def solve(
+    p: jt.Float[jt.Array, "np"],
+    ts: jt.Float[jt.Array, "nt_dyn"],
+    tcl: jt.Float[jt.Array, "ncl"],
+    h: jt.Float[jt.Array, "ne"],
+    x0: jt.Float[jt.Array, "nxs"],
+    solver: diffrax.AbstractSolver,
+    controller: diffrax.AbstractStepSizeController,
+    root_finder: AbstractRootFinder,
+    max_steps: jnp.int_,
+    adjoint: diffrax.AbstractAdjoint,
+    term: diffrax.ODETerm,
+    root_cond_fns: list[Callable],
+    root_cond_fn: Callable,
+    known_discs: jt.Float[jt.Array, "*nediscs"],
+) -> tuple[jt.Float[jt.Array, "nt nxs"], jt.Float[jt.Array, "nt ne"], dict]:
+    """
+    Simulate the ODE system for the specified timepoints.
+
+    :param p:
+        parameters
+    :param ts:
+        time points at which solutions are evaluated
+    :param tcl:
+        total values for conservation laws
+    :param x0:
+        initial state vector
+    :param solver:
+        ODE solver
+    :param controller:
+        step size controller
+    :param max_steps:
+        maximum number of steps
+    :param adjoint:
+        adjoint method
+        :param term:
+        ODE term
+    :param root_cond_fns:
+        list of individual root condition functions for discontinuities
+    :param root_cond_fn:
+        root condition function for all discontinuities
+    :param known_discs:
+        known discontinuities, used to clip the step size controller
+    :return:
+        solution+heaviside variables at time points ts and statistics
+    """
+    # if there are no events, we can avoid expensive looping and just run a single segment
+    if not root_cond_fns:
+        # no events, we can just run a single segment
+        sol, _, stats = _run_segment(
+            0.0,
+            ts[-1],
+            x0,
+            p,
+            tcl,
+            h,
+            solver,
+            controller,
+            root_finder,
+            max_steps,
+            adjoint,
+            [],
+            diffrax.SaveAt(ts=ts),
+            term,
+            known_discs,
+            dict(**STARTING_STATS),
+        )
+        return sol.ys, jnp.repeat(h[None, :], sol.ys.shape[0]), stats
+
+    def cond_fn(carry):
+        _, t_start, y0, _, _, stats = carry
+        # check if we have reached the end of the time points
+        return jnp.logical_and(
+            t_start < ts[-1],  # final time point not reached
+            jnp.isfinite(
+                y0
+            ).all(),  # y0 is finite, also used to track integration failure
+        )
+
+    def body_fn(carry):
+        ys, t_start, y0, hs, h, stats = carry
+        sol, idx, stats = _run_segment(
+            t_start,
+            ts[-1],
+            y0,
+            p,
+            tcl,
+            h,
+            solver,
+            controller,
+            root_finder,
+            max_steps,  # TODO: figure out how to pass `max_steps - stats['num_steps']` here
+            adjoint,
+            list(root_cond_fns),
+            diffrax.SaveAt(
+                subs=[
+                    diffrax.SubSaveAt(
+                        ts=jnp.where(ts >= t_start, ts, t_start)
+                    ),  # datapoints
+                    diffrax.SubSaveAt(t1=True),  # events
+                ]
+            ),
+            term,
+            known_discs,
+            stats,
+        )
+        # update the solution for all timepoints in the simulated segment
+        was_simulated = jnp.isin(ts, sol.ts[0])
+        ys = jnp.where(was_simulated[:, None], sol.ys[0], ys)
+        hs = jnp.where(was_simulated[:, None], h[None, :], hs)
+
+        t0_next = sol.ts[1][
+            -1
+        ]  # next start time is the end of the current segment
+        y0_next = sol.ys[1][
+            -1
+        ]  # next initial state is the last state of the current segment
+        ts_next = jnp.where(
+            ts > t0_next, ts, ts[-1]
+        ).min()  # timepoint of next datapoint, don't step over that
+
+        y0_next, t0_next, h_next, stats = _handle_event(
+            t0_next,
+            ts_next,
+            y0_next,
+            p,
+            tcl,
+            h,
+            solver,
+            controller,
+            root_finder,
+            adjoint,
+            term,
+            root_cond_fn,
+            stats,
+        )
+
+        was_event = jnp.isin(ts, sol.ts[1])
+        hs = jnp.where(was_event[:, None], h_next[None, :], hs)
+
+        return ys, t0_next, y0_next, hs, h_next, stats
+
+    # run the loop until we have reached the end of the time points
+    ys, _, _, hs, _, stats = eqxi.while_loop(
+        cond_fn,
+        body_fn,
+        (
+            jnp.zeros((ts.shape[0], x0.shape[0]), dtype=x0.dtype) + x0,
+            0.0,
+            x0,
+            jnp.zeros((ts.shape[0], h.shape[0]), dtype=h.dtype),
+            h,
+            dict(**STARTING_STATS),
+        ),
+        kind="bounded",
+        max_steps=2**6,
+    )
+
+    return ys, hs, stats
+
+
+def _run_segment(
+    t_start: float,
+    t_end: float,
+    y0: jt.Float[jt.Array, "nxs"],
+    p: jt.Float[jt.Array, "np"],
+    tcl: jt.Float[jt.Array, "ncl"],
+    h: jt.Float[jt.Array, "ne"],
+    solver: diffrax.AbstractSolver,
+    controller: diffrax.AbstractStepSizeController,
+    root_finder: AbstractRootFinder,
+    max_steps: jnp.int_,
+    adjoint: diffrax.AbstractAdjoint,
+    cond_fns: list[Callable],
+    saveat: diffrax.SaveAt,
+    term: diffrax.ODETerm,
+    known_discs: jt.Float[jt.Array, "*nediscs"],
+    stats: dict,
+) -> tuple[diffrax.Solution, int, dict]:
+    """Solve a single integration segment and return triggered event index, start time for the next segment,
+    aggregated statistics
+
+    The returned index corresponds to the event in ``cond_fns`` that was
+    triggered during the integration. ``None`` indicates that the solver
+    reached ``t_end`` without any event firing.
+    """
+
+    # combine all discontinuity conditions into a single diffrax.Event
+    event = diffrax.Event(cond_fns, root_finder) if cond_fns else None
+
+    # manage events with explicit discontinuities
+    controller = (
+        diffrax.ClipStepSizeController(
+            controller,
+            jump_ts=known_discs,
+        )
+        if known_discs.size
+        else controller
+    )
+
+    sol = diffrax.diffeqsolve(
+        term,
+        solver,
+        args=(p, tcl, h),
+        t0=t_start,
+        t1=t_end,
+        dt0=None,
+        y0=y0,
+        stepsize_controller=controller,
+        max_steps=max_steps,
+        adjoint=adjoint,
+        saveat=saveat,
+        event=event,
+        throw=False,
+    )
+    if os.getenv("JAX_DEBUG") == "1":
+        jax.debug.print(
+            "Segment: t0 = {}, t1 = {}, y0 = {}, y1 = {}, numsteps = {}, numrejected = {}, result = {}",
+            t_start,
+            t_end,
+            y0,
+            sol.ys[-1],
+            sol.stats["num_steps"],
+            sol.stats["num_rejected_steps"],
+            sol.result,
+        )
+
+    # extract the event index
+    if sol.event_mask is None:
+        # no events were triggered
+        event_index = -1
+    else:
+        event_index = jnp.where(
+            diffrax.is_event(sol.result),
+            jnp.argmax(jnp.array(sol.event_mask)),
+            -1,
+        )
+
+    # aggregate statistics
+    stats = jtu.tree_map(lambda x, y: x + y, stats, sol.stats)
+
+    return sol, event_index, stats
+
+
+def _handle_event(
+    t0_next: float,
+    t_max: float,
+    y0_next: jt.Float[jt.Array, "nxs"],
+    p: jt.Float[jt.Array, "np"],
+    tcl: jt.Float[jt.Array, "ncl"],
+    h: jt.Float[jt.Array, "ne"],
+    solver: diffrax.AbstractSolver,
+    controller: diffrax.AbstractStepSizeController,
+    root_finder: AbstractRootFinder,
+    adjoint: diffrax.AbstractAdjoint,
+    term: diffrax.ODETerm,
+    root_cond_fn: Callable,
+    stats: dict,
+):
+    args = (p, tcl, h)
+    rootvals = root_cond_fn(t0_next, y0_next, args)
+    roots_found = jnp.isclose(
+        rootvals, 0.0, atol=root_finder.atol, rtol=root_finder.rtol
+    )
+    droot_dt = (
+        # ∂root_cond_fn/∂t
+        jax.jacfwd(root_cond_fn, argnums=0)(t0_next, y0_next, args)
+        +
+        # ∂root_cond_fn/∂y * ∂y/∂t
+        jax.jacfwd(root_cond_fn, argnums=1)(t0_next, y0_next, args)
+        @ term.vector_field(t0_next, y0_next, args)
+    )
+    roots_dir = jnp.sign(droot_dt)  # direction of the root condition function
+
+    h_next = h + jnp.where(
+        roots_found,
+        roots_dir,
+        jnp.zeros_like(h),
+    )  # update heaviside variables based on the root condition function
+
+    if os.getenv("JAX_DEBUG") == "1":
+        jax.debug.print(
+            "rootvals: {}, roots_found: {}, roots_dir: {}, h: {}, h_next: {}",
+            rootvals,
+            roots_found,
+            roots_dir,
+            h,
+            h_next,
+        )
+
+    # while we are trying to step out of the event
+    y0_next, t0_next, stats = _step_out_of_event(
+        t0_next,
+        t_max,
+        y0_next,
+        p,
+        tcl,
+        h_next,
+        solver,
+        controller,
+        adjoint,
+        term,
+        stats,
+    )
+    return y0_next, t0_next, h_next, stats
+
+
+def _step_out_of_event(
+    t_start: float,
+    t_end: float,
+    y0: jt.Float[jt.Array, "nxs"],
+    p: jt.Float[jt.Array, "np"],
+    tcl: jt.Float[jt.Array, "ncl"],
+    h: jt.Float[jt.Array, "ne"],
+    solver: diffrax.AbstractSolver,
+    controller: diffrax.AbstractStepSizeController,
+    adjoint: diffrax.AbstractAdjoint,
+    term: diffrax.ODETerm,
+    stats: dict,
+):
+    # take a single step, without event, to step out of the event
+    # TODO: loop until we are out of the event
+    sol = diffrax.diffeqsolve(
+        term,
+        solver,
+        args=(p, tcl, h),
+        t0=t_start,
+        t1=t_end,
+        dt0=None,
+        y0=y0,
+        stepsize_controller=controller,
+        max_steps=1,
+        adjoint=adjoint,
+        saveat=diffrax.SaveAt(
+            subs=[
+                diffrax.SubSaveAt(t1=True),  # we manage to reach t_end
+                diffrax.SubSaveAt(
+                    steps=True
+                ),  # we want to save the state at t_end
+            ]
+        ),
+        throw=False,
+    )
+    if os.getenv("JAX_DEBUG") == "1":
+        jax.debug.print(
+            "StepOutOfEvent: t0 = {}, t1 = {}, y0 = {}, y1 = {}, numsteps = {}, num_rejected = {}, result = {}",
+            t_start,
+            t_end,
+            y0,
+            sol.ys[0][-1],
+            sol.stats["num_steps"],
+            sol.stats["num_rejected_steps"],
+            sol.result,
+        )
+    # aggregate stats
+    stats = jtu.tree_map(lambda x, y: x + y, stats, sol.stats)
+    return sol.ys[0][-1], sol.ts[0][-1], stats

--- a/python/sdist/amici/jax/jax.template.py
+++ b/python/sdist/amici/jax/jax.template.py
@@ -105,6 +105,12 @@ class JAXModel_TPL_MODEL_NAME(JAXModel):
 
         return TPL_ROOTS
 
+    def _root_cond_fns(self, p):
+        """Return root condition functions for discontinuities."""
+        TPL_P_SYMS = p
+
+        return TPL_ROOT_FUNS
+
     @property
     def observable_ids(self):
         return TPL_Y_IDS

--- a/python/sdist/amici/jax/jax.template.py
+++ b/python/sdist/amici/jax/jax.template.py
@@ -19,21 +19,23 @@ class JAXModel_TPL_MODEL_NAME(JAXModel):
         super().__init__()
 
     def _xdot(self, t, x, args):
-        p, tcl = args
+        p, tcl, h = args
 
         TPL_X_SYMS = x
         TPL_P_SYMS = p
         TPL_TCL_SYMS = tcl
-        TPL_W_SYMS = self._w(t, x, p, tcl)
+        TPL_H_SYMS = h
+        TPL_W_SYMS = self._w(t, x, p, tcl, h)
 
         TPL_XDOT_EQ
 
         return TPL_XDOT_RET
 
-    def _w(self, t, x, p, tcl):
+    def _w(self, t, x, p, tcl, h):
         TPL_X_SYMS = x
         TPL_P_SYMS = p
         TPL_TCL_SYMS = tcl
+        TPL_H_SYMS = h
 
         TPL_W_EQ
 
@@ -69,10 +71,10 @@ class JAXModel_TPL_MODEL_NAME(JAXModel):
 
         return TPL_TOTAL_CL_RET
 
-    def _y(self, t, x, p, tcl, op):
+    def _y(self, t, x, p, tcl, h, op):
         TPL_X_SYMS = x
         TPL_P_SYMS = p
-        TPL_W_SYMS = self._w(t, x, p, tcl)
+        TPL_W_SYMS = self._w(t, x, p, tcl, h)
         TPL_OP_SYMS = op
 
         TPL_Y_EQ
@@ -89,8 +91,8 @@ class JAXModel_TPL_MODEL_NAME(JAXModel):
 
         return TPL_SIGMAY_RET
 
-    def _nllh(self, t, x, p, tcl, my, iy, op, np):
-        y = self._y(t, x, p, tcl, op)
+    def _nllh(self, t, x, p, tcl, h, my, iy, op, np):
+        y = self._y(t, x, p, tcl, h, op)
         if not y.size:
             return jnp.array(0.0)
 
@@ -106,27 +108,31 @@ class JAXModel_TPL_MODEL_NAME(JAXModel):
 
         return TPL_ROOTS
 
-    def _root_cond_fn(self, ie, t, y, args, **_):
-        p, tcl = args
+    def _root_cond_fn(self, t, y, args, **_):
+        p, tcl, h = args
 
         TPL_X_SYMS = y
         TPL_P_SYMS = p
         TPL_TCL_SYMS = tcl
-        TPL_W_SYMS = self._w(t, y, p, tcl)
+        TPL_H_SYMS = h
+        TPL_W_SYMS = self._w(t, y, p, tcl, h)
 
         TPL_IROOT_EQ
 
-        return TPL_IROOT_RET.at[ie].get()
+        return TPL_IROOT_RET
 
-    def _root_cond_fn_event(self, ie):
+    def _root_cond_fn_event(self, ie, t, y, args, **_):
         """
         Root condition function for a specific event index.
         """
-        return eqx.Partial(self._root_cond_fn, ie)
+        return self._root_cond_fn(t, y, args, **_).at[ie].get()
 
     def _root_cond_fns(self):
         """Return root condition functions for discontinuities."""
-        return [self._root_cond_fn_event(ie) for ie in range(TPL_N_IEVENTS)]
+        return [
+            eqx.Partial(self._root_cond_fn_event, ie)
+            for ie in range(TPL_N_IEVENTS)
+        ]
 
     @property
     def observable_ids(self):

--- a/python/sdist/amici/jax/jax.template.py
+++ b/python/sdist/amici/jax/jax.template.py
@@ -1,6 +1,7 @@
 # ruff: noqa: F401, F821, F841
 import jax.numpy as jnp
 import jaxtyping as jt
+import equinox as eqx
 from interpax import interp1d
 from pathlib import Path
 from jax.numpy import inf as oo
@@ -105,11 +106,27 @@ class JAXModel_TPL_MODEL_NAME(JAXModel):
 
         return TPL_ROOTS
 
-    def _root_cond_fns(self, p):
-        """Return root condition functions for discontinuities."""
-        TPL_P_SYMS = p
+    def _root_cond_fn(self, ie, t, y, args, **_):
+        p, tcl = args
 
-        return TPL_ROOT_FUNS
+        TPL_X_SYMS = y
+        TPL_P_SYMS = p
+        TPL_TCL_SYMS = tcl
+        TPL_W_SYMS = self._w(t, y, p, tcl)
+
+        TPL_IROOT_EQ
+
+        return TPL_IROOT_RET.at[ie].get()
+
+    def _root_cond_fn_event(self, ie):
+        """
+        Root condition function for a specific event index.
+        """
+        return eqx.Partial(self._root_cond_fn, ie)
+
+    def _root_cond_fns(self):
+        """Return root condition functions for discontinuities."""
+        return [self._root_cond_fn_event(ie) for ie in range(TPL_N_IEVENTS)]
 
     @property
     def observable_ids(self):

--- a/python/sdist/amici/jax/jax.template.py
+++ b/python/sdist/amici/jax/jax.template.py
@@ -24,7 +24,7 @@ class JAXModel_TPL_MODEL_NAME(JAXModel):
         TPL_X_SYMS = x
         TPL_P_SYMS = p
         TPL_TCL_SYMS = tcl
-        TPL_H_SYMS = h
+        TPL_IH_SYMS = h
         TPL_W_SYMS = self._w(t, x, p, tcl, h)
 
         TPL_XDOT_EQ
@@ -35,7 +35,7 @@ class JAXModel_TPL_MODEL_NAME(JAXModel):
         TPL_X_SYMS = x
         TPL_P_SYMS = p
         TPL_TCL_SYMS = tcl
-        TPL_H_SYMS = h
+        TPL_IH_SYMS = h
 
         TPL_W_EQ
 
@@ -114,7 +114,7 @@ class JAXModel_TPL_MODEL_NAME(JAXModel):
         TPL_X_SYMS = y
         TPL_P_SYMS = p
         TPL_TCL_SYMS = tcl
-        TPL_H_SYMS = h
+        TPL_IH_SYMS = h
         TPL_W_SYMS = self._w(t, y, p, tcl, h)
 
         TPL_IROOT_EQ

--- a/python/sdist/amici/jax/model.py
+++ b/python/sdist/amici/jax/model.py
@@ -565,7 +565,7 @@ class JAXModel(eqx.Module):
 
         t_start = jnp.where(
             event_index >= 0,
-            jax.lax.stop_gradient(jnp.nextafter(sol.ts[-1], jnp.inf)),
+            sol.ts[-1] + jnp.finfo(jnp.float_).eps,
             sol.ts[-1],
         )
         return sol, event_index, t_start, stats

--- a/python/sdist/amici/jax/model.py
+++ b/python/sdist/amici/jax/model.py
@@ -543,11 +543,15 @@ class JAXModel(eqx.Module):
         )
 
         # extract the event index
-        event_index = jnp.where(
-            diffrax.is_event(sol.result),
-            jnp.argmax(jnp.array(sol.event_mask)),
-            jnp.int_(-1),
-        )
+        if sol.event_mask is None:
+            # no events were triggered
+            event_index = jnp.int_(-1)
+        else:
+            event_index = jnp.where(
+                diffrax.is_event(sol.result),
+                jnp.argmax(jnp.array(sol.event_mask)),
+                jnp.int_(-1),
+            )
 
         # aggregate statistics
         jtu.tree_map(lambda x, y: x + y, stats, sol.stats)

--- a/python/sdist/amici/jax/model.py
+++ b/python/sdist/amici/jax/model.py
@@ -552,12 +552,12 @@ class JAXModel(eqx.Module):
         # extract the event index
         if sol.event_mask is None:
             # no events were triggered
-            event_index = jnp.int_(-1)
+            event_index = -1
         else:
             event_index = jnp.where(
                 diffrax.is_event(sol.result),
                 jnp.argmax(jnp.array(sol.event_mask)),
-                jnp.int_(-1),
+                -1,
             )
 
         # aggregate statistics

--- a/python/sdist/amici/jax/model.py
+++ b/python/sdist/amici/jax/model.py
@@ -573,8 +573,9 @@ class JAXModel(eqx.Module):
             ]  # next initial state is the last state of the current segment
 
             args = (p, tcl, h)
+            rootvals = self._root_cond_fn(t0_next, y0_next, args)
             roots_found = jnp.isclose(
-                self._root_cond_fn(t0_next, y0_next, args), 0.0
+                rootvals, 0.0, atol=root_finder.atol, rtol=root_finder.rtol
             )
             droot_dt = (
                 # ∂root_cond_fn/∂t
@@ -604,7 +605,8 @@ class JAXModel(eqx.Module):
             hs = jnp.where(was_event[:, None], h_next[None, :], hs)
             if os.getenv("JAX_DEBUG") == "1":
                 jax.debug.print(
-                    "roots_found: {}, roots_dir: {}, h: {}, h_next: {}",
+                    "rootvals: {}, roots_found: {}, roots_dir: {}, h: {}, h_next: {}",
+                    rootvals,
                     roots_found,
                     roots_dir,
                     h,

--- a/python/sdist/amici/jax/model.py
+++ b/python/sdist/amici/jax/model.py
@@ -504,8 +504,8 @@ class JAXModel(eqx.Module):
             standard deviations of the observables
         """
         return jax.vmap(
-            lambda t, x, p, tcl, iy, op, np: self._sigmay(
-                self._y(t, x, p, tcl, hs, op), p, np
+            lambda t, x, p, tcl, h, iy, op, np: self._sigmay(
+                self._y(t, x, p, tcl, h, op), p, np
             )
             .at[iy]
             .get(),

--- a/python/sdist/amici/jax/model.py
+++ b/python/sdist/amici/jax/model.py
@@ -34,9 +34,9 @@ class ReturnValue(enum.Enum):
 
 STARTING_STATS = {
     "max_steps": 0,
-    "num_accepted_steps": jnp.int_(0),
-    "num_rejected_steps": jnp.int_(0),
-    "num_steps": jnp.int_(0),
+    "num_accepted_steps": 0,
+    "num_rejected_steps": 0,
+    "num_steps": 0,
 }
 
 

--- a/python/sdist/amici/jax/model.py
+++ b/python/sdist/amici/jax/model.py
@@ -441,10 +441,10 @@ class JAXModel(eqx.Module):
                 adjoint,
                 cond_fns,
                 root_finder,
-                diffrax.SaveAt(ts=jnp.where(ts, ts >= t_start, t_start)),
+                diffrax.SaveAt(ts=jnp.where(ts > t_start, ts, t_start)),
             )
             # update the solution for all timepoints in the simulated segment
-            was_simulated = jnp.logical_and(t_start < ts, ts <= sol.ts[-1])
+            was_simulated = jnp.logical_and(ts > t_start, ts <= sol.ts[-1])
             ys = jnp.where(was_simulated[:, None], sol.ys, ys)
             stats = sol.stats
 

--- a/python/sdist/amici/jax/model.py
+++ b/python/sdist/amici/jax/model.py
@@ -984,7 +984,7 @@ class JAXModel(eqx.Module):
         """
         return jax.vmap(
             lambda t, x, p, tcl, iy, op, np: self._sigmay(
-                self._y(t, x, p, tcl, h, op), p, np
+                self._y(t, x, p, tcl, hs, op), p, np
             )
             .at[iy]
             .get(),

--- a/python/sdist/amici/jax/ode_export.py
+++ b/python/sdist/amici/jax/ode_export.py
@@ -206,7 +206,7 @@ class ODEExporter:
             "op",
             "x",
             "tcl",
-            "h",
+            "ih",
             "w",
             "my",
             "y",
@@ -217,6 +217,15 @@ class ODEExporter:
 
         indent = 8
 
+        # replaces Heaviside variables with corresponding functions
+        subs_heaviside = dict(
+            zip(
+                self.model.sym("eh"),
+                [sp.Heaviside(x) for x in self.model.eq("eroot")],
+                strict=True,
+            )
+        )
+
         # replaces observables with a generic my variable
         subs_observables = dict(
             zip(
@@ -225,7 +234,7 @@ class ODEExporter:
                 strict=True,
             )
         )
-        subs = subs_observables
+        subs = subs_heaviside | subs_observables
 
         tpl_data = {
             # assign named variable using corresponding algebraic formula (function body)

--- a/python/sdist/amici/jax/ode_export.py
+++ b/python/sdist/amici/jax/ode_export.py
@@ -206,6 +206,7 @@ class ODEExporter:
             "op",
             "x",
             "tcl",
+            "h",
             "w",
             "my",
             "y",
@@ -216,14 +217,6 @@ class ODEExporter:
 
         indent = 8
 
-        # replaces Heaviside variables with corresponding functions
-        subs_heaviside = dict(
-            zip(
-                self.model.sym("h"),
-                [sp.Heaviside(x) for x in self.model.eq("root")],
-                strict=True,
-            )
-        )
         # replaces observables with a generic my variable
         subs_observables = dict(
             zip(
@@ -232,7 +225,7 @@ class ODEExporter:
                 strict=True,
             )
         )
-        subs = subs_heaviside | subs_observables
+        subs = subs_observables
 
         tpl_data = {
             # assign named variable using corresponding algebraic formula (function body)

--- a/python/tests/test_jax.py
+++ b/python/tests/test_jax.py
@@ -1,18 +1,8 @@
 import pytest
-import warnings
-from pathlib import Path
 import amici
+from pathlib import Path
 
 pytest.importorskip("jax")
-# ignore deprecation warnings in bionetgen used by pysb and amici import
-warnings.filterwarnings("ignore", "pkg_resources is deprecated", UserWarning)
-warnings.filterwarnings(
-    "ignore", "App.Meta.framework_logging", DeprecationWarning
-)
-warnings.filterwarnings(
-    "ignore", category=pytest.PytestUnraisableExceptionWarning
-)
-warnings.filterwarnings("ignore", category=ResourceWarning)
 import amici.jax
 
 import jax.numpy as jnp
@@ -30,10 +20,7 @@ from amici.jax import JAXProblem, ReturnValue, run_simulations
 from numpy.testing import assert_allclose
 from test_petab_objective import lotka_volterra  # noqa: F401
 
-# ignore deprecation warnings in bionetgen used by pysb
-warnings.filterwarnings("ignore", "pkg_resources is deprecated", UserWarning)
 pysb = pytest.importorskip("pysb")
-_bng_available = False
 
 jax.config.update("jax_enable_x64", True)
 
@@ -43,7 +30,6 @@ RTOL_SIM = 1e-12
 
 
 @skip_on_valgrind
-@pytest.mark.skipif(not _bng_available, reason="BioNetGen not available")
 def test_conversion():
     pysb.SelfExporter.cleanup()  # reset pysb
     pysb.SelfExporter.do_export = True
@@ -72,7 +58,6 @@ def test_conversion():
 
 
 @skip_on_valgrind
-@pytest.mark.skipif(not _bng_available, reason="BioNetGen not available")
 @pytest.mark.filterwarnings(
     "ignore:Model does not contain any initial conditions"
 )
@@ -285,7 +270,6 @@ def check_fields_jax(
             )
 
 
-@pytest.mark.skipif(not _bng_available, reason="BioNetGen not available")
 def test_preequilibration_failure(lotka_volterra):  # noqa: F811
     petab_problem = lotka_volterra
     # oscillating system, preequilibation should fail when interaction is active

--- a/python/tests/test_jax.py
+++ b/python/tests/test_jax.py
@@ -1,8 +1,18 @@
 import pytest
-import amici
+import warnings
 from pathlib import Path
+import amici
 
 pytest.importorskip("jax")
+# ignore deprecation warnings in bionetgen used by pysb and amici import
+warnings.filterwarnings("ignore", "pkg_resources is deprecated", UserWarning)
+warnings.filterwarnings(
+    "ignore", "App.Meta.framework_logging", DeprecationWarning
+)
+warnings.filterwarnings(
+    "ignore", category=pytest.PytestUnraisableExceptionWarning
+)
+warnings.filterwarnings("ignore", category=ResourceWarning)
 import amici.jax
 
 import jax.numpy as jnp
@@ -20,7 +30,10 @@ from amici.jax import JAXProblem, ReturnValue, run_simulations
 from numpy.testing import assert_allclose
 from test_petab_objective import lotka_volterra  # noqa: F401
 
+# ignore deprecation warnings in bionetgen used by pysb
+warnings.filterwarnings("ignore", "pkg_resources is deprecated", UserWarning)
 pysb = pytest.importorskip("pysb")
+_bng_available = False
 
 jax.config.update("jax_enable_x64", True)
 
@@ -30,6 +43,7 @@ RTOL_SIM = 1e-12
 
 
 @skip_on_valgrind
+@pytest.mark.skipif(not _bng_available, reason="BioNetGen not available")
 def test_conversion():
     pysb.SelfExporter.cleanup()  # reset pysb
     pysb.SelfExporter.do_export = True
@@ -58,6 +72,7 @@ def test_conversion():
 
 
 @skip_on_valgrind
+@pytest.mark.skipif(not _bng_available, reason="BioNetGen not available")
 @pytest.mark.filterwarnings(
     "ignore:Model does not contain any initial conditions"
 )
@@ -270,6 +285,7 @@ def check_fields_jax(
             )
 
 
+@pytest.mark.skipif(not _bng_available, reason="BioNetGen not available")
 def test_preequilibration_failure(lotka_volterra):  # noqa: F811
     petab_problem = lotka_volterra
     # oscillating system, preequilibation should fail when interaction is active

--- a/python/tests/test_jax.py
+++ b/python/tests/test_jax.py
@@ -346,14 +346,16 @@ def test_time_dependent_discontinuity(tmp_path):
     tcl = model._tcl(x0_full, p)
     x0 = model._x_solver(x0_full)
     ts = jnp.array([0.0, 1.0, 2.0])
+    h = model._initialise_heaviside_variables(0.0, model._x_solver(x0), p, tcl)
 
-    assert len(model._root_cond_fns(p)) > 0
+    assert len(model._root_cond_fns()) > 0
     assert model._known_discs(p).size == 0
 
-    ys, _ = model._solve(
+    ys, _, _ = model._solve(
         p,
         ts,
         tcl,
+        h,
         x0,
         diffrax.Tsit5(),
         diffrax.PIDController(**DEFAULT_CONTROLLER_SETTINGS),
@@ -391,13 +393,15 @@ def test_time_dependent_discontinuity_equilibration(tmp_path):
     x0_full = model._x0(0.0, p)
     tcl = model._tcl(x0_full, p)
     x0 = model._x_solver(x0_full)
+    h = model._initialise_heaviside_variables(0.0, model._x_solver(x0), p, tcl)
 
-    assert len(model._root_cond_fns(p)) > 0
+    assert len(model._root_cond_fns()) > 0
     assert model._known_discs(p).size == 0
 
     xs, _ = model._eq(
         p,
         tcl,
+        h,
         x0,
         diffrax.Tsit5(),
         diffrax.PIDController(**DEFAULT_CONTROLLER_SETTINGS),

--- a/python/tests/test_jax.py
+++ b/python/tests/test_jax.py
@@ -9,6 +9,7 @@ import jax.numpy as jnp
 import jax.random as jr
 import jax
 import diffrax
+import optimistix
 import numpy as np
 from beartype import beartype
 from petab.v1.C import PREEQUILIBRATION_CONDITION_ID, SIMULATION_CONDITION_ID
@@ -200,6 +201,7 @@ def check_fields_jax(
         "x_preeq": jnp.array([]),
         "solver": diffrax.Kvaerno5(),
         "controller": diffrax.PIDController(atol=ATOL_SIM, rtol=RTOL_SIM),
+        "root_finder": optimistix.Newton(atol=ATOL_SIM, rtol=RTOL_SIM),
         "adjoint": diffrax.RecursiveCheckpointAdjoint(),
         "steady_state_event": diffrax.steady_state_event(),
         "max_steps": 2**8,  # max_steps
@@ -355,6 +357,7 @@ def test_time_dependent_discontinuity(tmp_path):
         x0,
         diffrax.Tsit5(),
         diffrax.PIDController(**DEFAULT_CONTROLLER_SETTINGS),
+        optimistix.Newton(atol=1e-8, rtol=1e-8),
         1000,
         diffrax.DirectAdjoint(),
     )
@@ -398,9 +401,8 @@ def test_time_dependent_discontinuity_equilibration(tmp_path):
         x0,
         diffrax.Tsit5(),
         diffrax.PIDController(**DEFAULT_CONTROLLER_SETTINGS),
-        diffrax.steady_state_event(
-            rtol=1e-8, atol=1e-8, norm=lambda y: jnp.linalg.norm(y)
-        ),
+        optimistix.Newton(atol=1e-8, rtol=1e-8),
+        diffrax.steady_state_event(rtol=1e-8, atol=1e-8),
         1000,
     )
 

--- a/python/tests/test_jax.py
+++ b/python/tests/test_jax.py
@@ -315,3 +315,93 @@ def test_serialisation(lotka_volterra):  # noqa: F811
             assert_allclose(
                 jax_problem.parameters, jax_problem_loaded.parameters
             )
+
+
+@skip_on_valgrind
+def test_time_dependent_discontinuity(tmp_path):
+    """Models with time dependent discontinuities are handled."""
+
+    from amici.antimony_import import antimony2sbml
+    from amici.sbml_import import SbmlImporter
+    from amici.jax.petab import DEFAULT_CONTROLLER_SETTINGS
+
+    ant_model = """
+    model time_disc
+        x' = piecewise(1, time - sin(time) - 1 < 0, 2)
+        x = 0
+    end
+    """
+
+    sbml = antimony2sbml(ant_model)
+    importer = SbmlImporter(sbml, from_file=False)
+    importer.sbml2jax("time_disc", output_dir=tmp_path)
+
+    module = amici._module_from_path("time_disc", tmp_path / "__init__.py")
+    model = module.Model()
+
+    p = jnp.array([1.0])
+    x0_full = model._x0(0.0, p)
+    tcl = model._tcl(x0_full, p)
+    x0 = model._x_solver(x0_full)
+    ts = jnp.array([0.0, 1.0, 2.0])
+
+    assert len(model._root_cond_fns(p)) > 0
+    assert model._known_discs(p).size == 0
+
+    ys, _ = model._solve(
+        p,
+        ts,
+        tcl,
+        x0,
+        diffrax.Tsit5(),
+        diffrax.PIDController(**DEFAULT_CONTROLLER_SETTINGS),
+        1000,
+        diffrax.DirectAdjoint(),
+    )
+
+    assert ys.shape[0] == ts.shape[0]
+
+
+@skip_on_valgrind
+def test_time_dependent_discontinuity_equilibration(tmp_path):
+    """Time dependent discontinuities are handled during equilibration."""
+
+    from amici.antimony_import import antimony2sbml
+    from amici.sbml_import import SbmlImporter
+    from amici.jax.petab import DEFAULT_CONTROLLER_SETTINGS
+
+    ant_model = """
+    model time_disc_eq
+        x' = piecewise(1, time - sin(time) - 1 < 0, -x)
+        x = 0
+    end
+    """
+
+    sbml = antimony2sbml(ant_model)
+    importer = SbmlImporter(sbml, from_file=False)
+    importer.sbml2jax("time_disc_eq", output_dir=tmp_path)
+
+    module = amici._module_from_path("time_disc_eq", tmp_path / "__init__.py")
+    model = module.Model()
+
+    p = jnp.array([1.0])
+    x0_full = model._x0(0.0, p)
+    tcl = model._tcl(x0_full, p)
+    x0 = model._x_solver(x0_full)
+
+    assert len(model._root_cond_fns(p)) > 0
+    assert model._known_discs(p).size == 0
+
+    xs, _ = model._eq(
+        p,
+        tcl,
+        x0,
+        diffrax.Tsit5(),
+        diffrax.PIDController(**DEFAULT_CONTROLLER_SETTINGS),
+        diffrax.steady_state_event(
+            rtol=1e-8, atol=1e-8, norm=lambda y: jnp.linalg.norm(y)
+        ),
+        1000,
+    )
+
+    assert_allclose(xs[0], 0.0, atol=1e-2)

--- a/tests/sbml/testSBMLSuiteJax.py
+++ b/tests/sbml/testSBMLSuiteJax.py
@@ -8,6 +8,7 @@ import amici
 import jax
 import jax.numpy as jnp
 import diffrax
+import optimistix
 import numpy as np
 import pandas as pd
 import pytest
@@ -70,6 +71,7 @@ def run_jax_simulation(model, importer, ts, atol, rtol, tol_factor=1e2):
         icoeff=DEFAULT_CONTROLLER_SETTINGS["icoeff"],
         dcoeff=DEFAULT_CONTROLLER_SETTINGS["dcoeff"],
     )
+    root_finder = optimistix.Newton(atol=atol, rtol=rtol)
     x, stats = model.simulate_condition(
         p,
         ts_jnp,
@@ -81,6 +83,7 @@ def run_jax_simulation(model, importer, ts, atol, rtol, tol_factor=1e2):
         jnp.zeros((ts_jnp.shape[0], 0)),
         solver,
         controller,
+        root_finder,
         diffrax.DirectAdjoint(),
         diffrax.SteadyStateEvent(),
         2**10,

--- a/tests/sbml/testSBMLSuiteJax.py
+++ b/tests/sbml/testSBMLSuiteJax.py
@@ -90,19 +90,20 @@ def run_jax_simulation(model, importer, ts, atol, rtol, tol_factor=1e2):
         ret=amici.jax.ReturnValue.x,
     )
     y = jax.vmap(
-        lambda t, x_solver, x_rdata: model._y(
+        lambda t, x_solver, x_rdata, hs: model._y(
             t,
             x_solver,
             p,
             model._tcl(x_rdata, p),
+            hs,
             jnp.zeros(len(model.observable_ids)),
         )
-    )(ts_jnp, stats["x"], x)
+    )(ts_jnp, stats["x"], x, stats["hs"])
     w = jax.vmap(
-        lambda t, x_solver, x_rdata: model._w(
-            t, x_solver, p, model._tcl(x_rdata, p)
+        lambda t, x_solver, x_rdata, hs: model._w(
+            t, x_solver, p, model._tcl(x_rdata, p), hs
         )
-    )(ts_jnp, stats["x"], x)
+    )(ts_jnp, stats["x"], x, stats["hs"])
 
     class RData(dict):
         __getattr__ = dict.__getitem__


### PR DESCRIPTION
## Summary
- keep discontinuity events active after they fire
- restart integration slightly after an event
- clarify comment on event handling
- deduplicate implicit roots
- treat discontinuities without rootfinders
- add regression test for implicit event handling
- avoid simplification when deduplicating implicit roots

## Testing
- `pre-commit run --files python/tests/test_jax.py python/sdist/amici/jax/model.py python/sdist/amici/jax/ode_export.py python/sdist/amici/jax/jax.template.py`
- `pytest python/tests/test_jax.py::test_time_dependent_discontinuity python/tests/test_jax.py::test_time_dependent_discontinuity_equilibration -q`

------
https://chatgpt.com/codex/tasks/task_b_685d233b636c832b921ec48c3a28f61d