### PR TITLE
Refactor Solver::writeSolution

### DIFF
--- a/include/amici/solver.h
+++ b/include/amici/solver.h
@@ -663,7 +663,7 @@ class Solver {
      * @param sx state sensitivity
      */
     void writeSolution(
-        realtype* t, AmiVector& x, AmiVector& dx, AmiVectorArray& sx
+        realtype& t, AmiVector& x, AmiVector& dx, AmiVectorArray& sx
     ) const;
 
     /**
@@ -675,7 +675,7 @@ class Solver {
      * @param which index of adjoint problem
      */
     void writeSolutionB(
-        realtype* t, AmiVector& xB, AmiVector& dxB, AmiVector& xQB, int which
+        realtype& t, AmiVector& xB, AmiVector& dxB, AmiVector& xQB, int which
     ) const;
 
     /**

--- a/src/backwardproblem.cpp
+++ b/src/backwardproblem.cpp
@@ -219,7 +219,7 @@ void EventHandlingBwdSimulator::run(
         if (tnext < t_) {
             solver_->runB(tnext);
             solver_->writeSolutionB(
-                &t_, ws_->xB_, ws_->dxB_, ws_->xQB_, ws_->which
+                t_, ws_->xB_, ws_->dxB_, ws_->xQB_, ws_->which
             );
         }
 
@@ -243,9 +243,7 @@ void EventHandlingBwdSimulator::run(
     // we still need to integrate from first datapoint to t_start
     if (t_ > t_end) {
         solver_->runB(t_end);
-        solver_->writeSolutionB(
-            &t_, ws_->xB_, ws_->dxB_, ws_->xQB_, ws_->which
-        );
+        solver_->writeSolutionB(t_, ws_->xB_, ws_->dxB_, ws_->xQB_, ws_->which);
     }
 }
 

--- a/src/forwardproblem.cpp
+++ b/src/forwardproblem.cpp
@@ -112,7 +112,7 @@ void EventHandlingSimulator::run(
                 int const status = solver_->run(next_t_stop);
                 // sx will be copied from solver on demand if sensitivities
                 // are computed
-                solver_->writeSolution(&t_, ws_->x, ws_->dx, ws_->sx);
+                solver_->writeSolution(t_, ws_->x, ws_->dx, ws_->sx);
 
                 if (status == AMICI_ILL_INPUT) {
                     // clustering of roots => turn off root-finding
@@ -214,7 +214,7 @@ void ForwardProblem::handlePresimulation() {
 
     std::vector<realtype> const timepoints{model->t0()};
     pre_simulator_.run(t_, edata, timepoints, false);
-    solver->writeSolution(&t_, ws_.x, ws_.dx, ws_.sx);
+    solver->writeSolution(t_, ws_.x, ws_.dx, ws_.sx);
 }
 
 void ForwardProblem::handleMainSimulation() {
@@ -573,7 +573,7 @@ ForwardProblem::getAdjointUpdates(Model& model, ExpData const& edata) {
 
 SimulationState EventHandlingSimulator::get_simulation_state() {
     if (std::isfinite(solver_->gett())) {
-        solver_->writeSolution(&t_, ws_->x, ws_->dx, ws_->sx);
+        solver_->writeSolution(t_, ws_->x, ws_->dx, ws_->sx);
     }
     auto state = SimulationState();
     state.t = t_;

--- a/src/solver.cpp
+++ b/src/solver.cpp
@@ -1319,22 +1319,22 @@ void Solver::writeSolution(
 }
 
 void Solver::writeSolution(
-    realtype* t, AmiVector& x, AmiVector& dx, AmiVectorArray& sx
+    realtype& t, AmiVector& x, AmiVector& dx, AmiVectorArray& sx
 ) const {
-    *t = gett();
+    t = gett();
     if (sens_initialized_)
-        sx.copy(getStateSensitivity(*t));
-    x.copy(getState(*t));
-    dx.copy(getDerivativeState(*t));
+        sx.copy(getStateSensitivity(t));
+    x.copy(getState(t));
+    dx.copy(getDerivativeState(t));
 }
 
 void Solver::writeSolutionB(
-    realtype* t, AmiVector& xB, AmiVector& dxB, AmiVector& xQB, int const which
+    realtype& t, AmiVector& xB, AmiVector& dxB, AmiVector& xQB, int const which
 ) const {
-    *t = gett();
-    xB.copy(getAdjointState(which, *t));
-    dxB.copy(getAdjointDerivativeState(which, *t));
-    xQB.copy(getAdjointQuadrature(which, *t));
+    t = gett();
+    xB.copy(getAdjointState(which, t));
+    dxB.copy(getAdjointDerivativeState(which, t));
+    xQB.copy(getAdjointQuadrature(which, t));
 }
 
 AmiVector const& Solver::getState(realtype const t) const {

--- a/src/steadystateproblem.cpp
+++ b/src/steadystateproblem.cpp
@@ -413,7 +413,7 @@ void SteadystateProblem::initializeForwardProblem(
         solver.setup(t0, &model, state_.x, state_.dx, state_.sx, sdx_);
     } else {
         // The solver was run before, extract current state from solver.
-        solver.writeSolution(&state_.t, state_.x, state_.dx, state_.sx);
+        solver.writeSolution(state_.t, state_.x, state_.dx, state_.sx);
     }
 
     state_.t = t0;
@@ -730,7 +730,7 @@ void SteadystateProblem::runSteadystateSimulationFwd(
         // direction w.r.t. current t.
         solver.step(std::max(state_.t, 1.0) * 10);
 
-        solver.writeSolution(&state_.t, state_.x, state_.dx, state_.sx);
+        solver.writeSolution(state_.t, state_.x, state_.dx, state_.sx);
         flagUpdatedState();
     }
 


### PR DESCRIPTION
For consistency, use `realtype& t` instead of `realtype* t` for consistency in `Solver::{writeSolution,writeSolutionB}`. All other arguments are references and `t` is not optional.