### PR TITLE
Add Python nogil workflow

### DIFF
--- a/.github/workflows/test_python_nogil.yml
+++ b/.github/workflows/test_python_nogil.yml
@@ -1,0 +1,53 @@
+name: Python nogil Tests
+on:
+  push:
+  pull_request:
+    branches:
+      - main
+  merge_group:
+  workflow_dispatch:
+
+jobs:
+  nogil-tests:
+    name: Python nogil
+    runs-on: ubuntu-24.04
+    env:
+      AMICI_SKIP_CMAKE_TESTS: "TRUE"
+      AMICI_PARALLEL_COMPILE: ""
+    steps:
+    - uses: actions/checkout@v4
+      with:
+        fetch-depth: 20
+    - run: git fetch --prune --unshallow
+    - run: echo "AMICI_DIR=$(pwd)" >> $GITHUB_ENV
+    - name: Set up Python 3.13 free-threaded
+      uses: actions/setup-python@v5
+      with:
+        python-version: '3.13'
+        freethreaded: true
+    - name: Install apt dependencies
+      uses: ./.github/actions/install-apt-dependencies
+    - name: Install python package
+      run: |
+        python3 -m venv venv --clear
+        source venv/bin/activate
+        pip install --upgrade pip wheel
+        pip install numpy sympy cmake-build-extension==0.6.0 swig
+        AMICI_BUILD_TEMP="python/sdist/build/temp" \
+          pip install --verbose -e python/sdist[test] --no-build-isolation
+    - run: source venv/bin/activate && pip3 install "sympy>1.12"
+    - name: Get Pooch Cache Directory
+      id: get-pooch-cache
+      run: |
+        echo "pooch-cache=$(source venv/bin/activate && python -c 'import pooch; print(pooch.os_cache("pooch"))')" >> $GITHUB_ENV
+    - name: Cache Pooch Directory
+      uses: actions/cache@v4
+      with:
+        path: ${{ env.pooch-cache }}
+        key: ${{ runner.os }}-nogil-${{ github.job }}
+    - name: Python tests
+      env:
+        AMICI_NOGIL: "1"
+      run: |
+        source venv/bin/activate && \
+        pytest python/tests/test_nogil_parallel.py -vv

--- a/python/tests/test_nogil_parallel.py
+++ b/python/tests/test_nogil_parallel.py
@@ -1,0 +1,47 @@
+import os
+import functools
+from concurrent.futures import ThreadPoolExecutor
+from pathlib import Path
+
+import numpy as np
+import amici
+from amici.sbml_import import SbmlImporter
+from amici.testing import TemporaryDirectoryWinSafe as TemporaryDirectory
+import pytest
+
+pytestmark = pytest.mark.skipif(
+    not os.environ.get("AMICI_NOGIL"),
+    reason="only run in nogil workflow",
+)
+
+
+SBML_EXAMPLE = (
+    Path(__file__).parents[2]
+    / "doc"
+    / "examples"
+    / "getting_started"
+    / "model_steadystate_scaled.xml"
+)
+
+
+def _simulate(_: int, model_dir: str) -> int:
+    model_module = amici.import_model_module("nogil_model", model_dir)
+    model = model_module.getModel()
+    model.setTimepoints(np.linspace(0, 2e5, 200001))
+    solver = model.getSolver()
+    rdata = amici.runAmiciSimulation(model, solver)
+    return int(rdata.status)
+
+
+def test_parallel_simulation_threading():
+    assert os.cpu_count() >= 2, "requires at least two CPU cores"
+
+    with TemporaryDirectory() as outdir:
+        sbml_importer = SbmlImporter(SBML_EXAMPLE)
+        sbml_importer.sbml2amici(model_name="nogil_model", output_dir=outdir)
+
+        with ThreadPoolExecutor(max_workers=2) as pool:
+            simulate = functools.partial(_simulate, model_dir=outdir)
+            statuses = list(pool.map(simulate, range(100)))
+
+    assert statuses == [amici.AMICI_SUCCESS] * 100


### PR DESCRIPTION
## Summary
- add GitHub workflow to run tests using Python built without the GIL
- limit nogil workflow to the parallel multiprocessing test
- run many simulations in parallel with a long runtime
- make the parallel test use a real model and assert multi-core availability
- avoid installing PySB in the workflow
- use threads instead of multiprocessing

## Testing
- `pre-commit run --files python/tests/test_nogil_parallel.py .github/workflows/test_python_nogil.yml`
- `pytest python/tests/test_nogil_parallel.py::test_parallel_simulation_threading -vv` *(skipped without `AMICI_NOGIL`)*
- `AMICI_NOGIL=1 pytest python/tests/test_nogil_parallel.py::test_parallel_simulation_threading -vv` *(interrupted due to long runtime)*

------
https://chatgpt.com/codex/tasks/task_b_685d2711b7bc832b8a5754593d40d112