### PR TITLE
Improve presimulation test

### DIFF
--- a/python/tests/conftest.py
+++ b/python/tests/conftest.py
@@ -35,7 +35,8 @@ def sbml_example_presimulation_module():
 
     observables = amici.assignmentRules2observables(
         sbml_importer.sbml,  # the libsbml model object
-        filter_function=lambda variable: variable.getName() == "pPROT_obs",
+        filter_function=lambda variable: variable.getName()
+        in {"pPROT_obs", "pPROT", "tPROT"},
     )
     module_name = "test_model_presimulation"
 

--- a/python/tests/test_sbml_import.py
+++ b/python/tests/test_sbml_import.py
@@ -236,18 +236,23 @@ def test_presimulation(sbml_example_presimulation_module):
     )
     solver.setSensitivityOrder(amici.SensitivityOrder.first)
     model.setReinitializeFixedParameterInitialStates(True)
+    model.requireSensitivitiesForAllParameters()
 
-    rdata = amici.runAmiciSimulation(model, solver)
-    edata = amici.ExpData(rdata, 0.1, 0.0)
+    rdata_ref = amici.runAmiciSimulation(model, solver)
+    edata = amici.ExpData(rdata_ref, 0.1, 0.0)
+    edata.t_presim = 10
     edata.fixedParameters = [10, 2]
-    edata.fixedParametersPresimulation = [10, 2]
+    edata.fixedParametersPresimulation = [10, 0]
     edata.fixedParametersPreequilibration = [3, 0]
-    assert isinstance(
-        amici.runAmiciSimulation(model, solver, edata), amici.ReturnDataView
-    )
+    rdata = amici.runAmiciSimulation(model, solver, edata)
+    assert isinstance(rdata, amici.ReturnDataView)
+    assert not np.allclose(rdata_ref["x0"], rdata["x0"])
+    assert np.any(rdata["sx"])
+    assert np.any(rdata["sy"])
+    assert np.any(rdata["sllh"])
 
-    solver.setRelativeTolerance(1e-12)
-    solver.setAbsoluteTolerance(1e-12)
+    solver.setRelativeTolerance(1e-14)
+    solver.setAbsoluteTolerance(1e-14)
     check_derivatives(model, solver, edata, epsilon=1e-4)
 
 


### PR DESCRIPTION
## Summary
- ensure `test_presimulation` actually runs presimulation
- verify gradients are nonzero
- add more observables to presimulation fixture
- tighten solver tolerances

## Testing
- `pre-commit run --files python/tests/test_sbml_import.py`
- `pytest python/tests/test_sbml_import.py::test_presimulation -q`


------
https://chatgpt.com/codex/tasks/task_b_685d25fb7768832b840af6f1e4437acb