### PR TITLE
Handle reserved symbol names during code generation

### DIFF
--- a/python/sdist/amici/cxxcodeprinter.py
+++ b/python/sdist/amici/cxxcodeprinter.py
@@ -10,6 +10,8 @@ from collections.abc import Iterable
 import sympy as sp
 from sympy.codegen.rewriting import Optimization, optimize
 from sympy.printing.cxx import CXX11CodePrinter
+
+from .import_utils import RESERVED_SYMBOLS
 from sympy.utilities.iterables import numbered_symbols
 from toposort import toposort
 
@@ -49,6 +51,12 @@ class AmiciCxxCodePrinter(CXX11CodePrinter):
             self._fpoptimizer = lambda x: optimize(x, self.optimizations)
         else:
             self._fpoptimizer = None
+
+    def _print_Symbol(self, expr: sp.Symbol) -> str:
+        name = super()._print_Symbol(expr)
+        if name in RESERVED_SYMBOLS and name != "t":
+            return f"amici_{name}"
+        return name
 
     def doprint(self, expr: sp.Expr, assign_to: str | None = None) -> str:
         if self._fpoptimizer:

--- a/python/sdist/amici/de_export.py
+++ b/python/sdist/amici/de_export.py
@@ -58,6 +58,7 @@ from .cxxcodeprinter import (
 from .de_model_components import *
 from .de_model import DEModel
 from .import_utils import (
+    RESERVED_SYMBOLS,
     strip_pysb,
 )
 from .logging import get_logger, log_execution_time, set_log_level
@@ -404,7 +405,12 @@ class DEExporter:
                 continue
             if str(symbol_name) == "":
                 raise ValueError(f'{name} contains a symbol called ""')
-            lines.append(f"#define {symbol_name} {name}[{index}]")
+            sanitized_name = (
+                f"amici_{symbol_name}"
+                if str(symbol_name) in RESERVED_SYMBOLS
+                else str(symbol_name)
+            )
+            lines.append(f"#define {sanitized_name} {name}[{index}]")
             if name == "stau":
                 # we only need a single macro, as all entries have the same symbol
                 break
@@ -1243,7 +1249,7 @@ class DEExporter:
             Template initializer list of ids
         """
         return "\n".join(
-            f'"{self._code_printer.doprint(symbol)}", // {name}[{idx}]'
+            f'"{strip_pysb(symbol)}", // {name}[{idx}]'
             for idx, symbol in enumerate(self.model.sym(name))
         )
 

--- a/python/sdist/amici/de_model_components.py
+++ b/python/sdist/amici/de_model_components.py
@@ -7,7 +7,6 @@ from typing import SupportsFloat
 import sympy as sp
 
 from .import_utils import (
-    RESERVED_SYMBOLS,
     ObservableTransformation,
     amici_time_symbol,
     cast_to_sym,
@@ -66,12 +65,6 @@ class ModelQuantity:
                 f"identifier must be sympy.Symbol, was {type(identifier)}"
             )
 
-        if str(identifier) in RESERVED_SYMBOLS or (
-            hasattr(identifier, "name") and identifier.name in RESERVED_SYMBOLS
-        ):
-            raise ValueError(
-                f'Cannot add model quantity with name "{name}", please rename.'
-            )
         self._identifier: sp.Symbol = identifier
 
         if not isinstance(name, str):

--- a/python/sdist/amici/jax/jaxcodeprinter.py
+++ b/python/sdist/amici/jax/jaxcodeprinter.py
@@ -4,6 +4,8 @@ import re
 from collections.abc import Iterable
 from logging import warning
 
+from ..import_utils import RESERVED_SYMBOLS
+
 import sympy as sp
 from sympy.printing.numpy import NumPyPrinter
 
@@ -16,6 +18,12 @@ def _jnp_array_str(array) -> str:
 
 class AmiciJaxCodePrinter(NumPyPrinter):
     """JAX code printer"""
+
+    def _print_Symbol(self, expr: sp.Symbol) -> str:
+        name = super()._print_Symbol(expr)
+        if name in RESERVED_SYMBOLS and name != "t":
+            return f"amici_{name}"
+        return name
 
     def doprint(self, expr: sp.Expr, assign_to: str | None = None) -> str:
         try:

--- a/python/sdist/amici/sbml_import.py
+++ b/python/sdist/amici/sbml_import.py
@@ -691,7 +691,6 @@ class SbmlImporter:
         )
         self._replace_compartments_with_volumes()
 
-        self._clean_reserved_symbols()
         self._process_time()
 
         ode_model = DEModel(

--- a/python/tests/test_bngl.py
+++ b/python/tests/test_bngl.py
@@ -77,12 +77,7 @@ def test_compare_to_pysb_simulation(example):
             with pytest.raises(ValueError, match="Conservation laws"):
                 bngl2amici(model_file, outdir, compute_conservation_laws=True)
 
-        if example in ["empty_compartments_block", "motor"]:
-            with pytest.raises(ValueError, match="Cannot add"):
-                bngl2amici(model_file, outdir, **kwargs)
-            return
-        else:
-            bngl2amici(model_file, outdir, **kwargs)
+        bngl2amici(model_file, outdir, **kwargs)
 
         amici_model_module = amici.import_model_module(pysb_model.name, outdir)
 

--- a/scripts/run-SBMLTestsuite.sh
+++ b/scripts/run-SBMLTestsuite.sh
@@ -26,7 +26,7 @@ else
 fi
 
 if [[ "$BACKEND" == "jax" ]]; then
-  RESULT_DIR=tests/sbml/amici-semantic-results-jax
+  RESULT_DIR=tests/sbml/semantic-results-jax
   TEST_SCRIPT=./tests/sbml/testSBMLSuiteJax.py
   COVERAGE_FILE=coverage_SBMLSuite_jax.xml
 else

--- a/tests/sbml/testSBMLSuiteJax.py
+++ b/tests/sbml/testSBMLSuiteJax.py
@@ -25,7 +25,7 @@ jax.config.update("jax_enable_x64", True)
 
 @pytest.fixture(scope="session")
 def result_path_jax() -> Path:
-    return Path(__file__).parent / "amici-semantic-results-jax"
+    return Path(__file__).parent / "semantic-results-jax"
 
 
 class DummyModel:

--- a/tests/sbml/utils.py
+++ b/tests/sbml/utils.py
@@ -34,7 +34,7 @@ def verify_results(settings, rdata, expected, wrapper, model, atol, rtol):
             new_key = expr_id.removeprefix("flux_")
         else:
             new_key = expr_id
-            if expr_id.removeprefix("amici_") in simulated.columns:
+            if expr_id in simulated.columns:
                 continue  # skip if already present
         expression_data[new_key] = rdata.w[:, expr_idx]
 
@@ -46,12 +46,6 @@ def verify_results(settings, rdata, expected, wrapper, model, atol, rtol):
             pd.DataFrame(parameter_data),
         ],
         axis=1,
-    )
-
-    # handle renamed reserved symbols
-    simulated.rename(
-        columns={c: c.replace("amici_", "") for c in simulated.columns},
-        inplace=True,
     )
 
     # SBML test suite case 01308 defines species with initialAmount and
@@ -150,9 +144,9 @@ def concentrations_to_amounts(
         ) or comp is None:
             continue
 
-        simulated.loc[:, species] *= simulated.loc[
-            :, comp if comp in simulated.columns else f"amici_{comp}"
-        ]
+        if comp not in simulated.columns:
+            continue
+        simulated.loc[:, species] *= simulated.loc[:, comp]
 
 
 def write_result_file(


### PR DESCRIPTION
## Summary
- avoid reserved name renaming during SBML import
- drop reserved name check in `ModelQuantity`
- sanitize symbols when printing C++ and JAX code
- adjust sbml tests for new behavior
- fix reserved symbol handling during code generation
- allow BNGL conversion for empty-compartment tests
- fix JAX SBML test module import
- revert SBMLSuiteJax import path
- use `semantic-results-jax` directory for JAX SBML suite results
- fix parameter ID names
- fix parameter ID handling
- fix JAX sanitization of variable names

## Testing
- `pre-commit run --files python/sdist/amici/jax/ode_export.py`
- `pytest python/tests/test_sbml_import.py::test_import_same_model_name -vv -s`
- `pytest python/tests/test_events.py::test_handling_of_fixed_time_point_event_triggers -q`
- `pytest tests/benchmark_models/test_petab_benchmark.py -k Boehm_JProteomeRes2014 -q`
- `pytest tests/benchmark_models/test_petab_benchmark_jax.py -k Boehm_JProteomeRes2014 -q`
- `pytest tests/sbml/testSBMLSuiteJax.py::test_sbml_testsuite_case_jax[00525] -q`


------
https://chatgpt.com/codex/tasks/task_b_685d2802e714832b968ced9c529d9411