### PR TITLE
Refactor steady-state simulation

### DIFF
--- a/include/amici/forwardproblem.h
+++ b/include/amici/forwardproblem.h
@@ -222,8 +222,7 @@ class EventHandlingSimulator {
      */
     EventHandlingSimulator(
         gsl::not_null<Model*> model, gsl::not_null<Solver*> solver,
-        gsl::not_null<FwdSimWorkspace*> ws,
-        gsl::not_null<std::vector<realtype>*> dJzdx
+        gsl::not_null<FwdSimWorkspace*> ws, std::vector<realtype>* dJzdx
     )
         : model_(model)
         , solver_(solver)

--- a/include/amici/solver.h
+++ b/include/amici/solver.h
@@ -651,7 +651,7 @@ class Solver {
      * @param xQ quadrature
      */
     void writeSolution(
-        realtype* t, AmiVector& x, AmiVector& dx, AmiVectorArray& sx,
+        realtype& t, AmiVector& x, AmiVector& dx, AmiVectorArray& sx,
         AmiVector& xQ
     ) const;
 

--- a/include/amici/steadystateproblem.h
+++ b/include/amici/steadystateproblem.h
@@ -239,9 +239,8 @@ class SteadystateProblem {
      * @param it Index of the current output time point.
      * @param t0 Initial time for the steady state simulation.
      */
-    void workSteadyStateProblem(
-        Solver const& solver, Model& model, int it, realtype t0
-    );
+    void
+    workSteadyStateProblem(Solver& solver, Model& model, int it, realtype t0);
 
     /**
      * @brief Compute the gradient via adjoint steady state sensitivities.
@@ -375,8 +374,7 @@ class SteadystateProblem {
      * @param it Index of the current output time point.
      * @param t0 Initial time for the steady state simulation.
      */
-    void
-    findSteadyState(Solver const& solver, Model& model, int it, realtype t0);
+    void findSteadyState(Solver& solver, Model& model, int it, realtype t0);
 
     /**
      * @brief Try to determine the steady state by using Newton's method.
@@ -396,7 +394,7 @@ class SteadystateProblem {
      * successfully, or if it failed.
      */
     SteadyStateStatus findSteadyStateBySimulation(
-        Solver const& solver, Model& model, int it, realtype t0
+        Solver& solver, Model& model, int it, realtype t0
     );
 
     /**
@@ -439,13 +437,6 @@ class SteadystateProblem {
     ) const;
 
     /**
-     * @brief Checks steady-state convergence for state variables
-     * @param model Model instance
-     * @return weighted root mean squared residuals of the RHS
-     */
-    realtype getWrmsState(Model& model);
-
-    /**
      * @brief Checks convergence for state sensitivities
      * @param model Model instance
      * @param wrms_computer_sx WRMSComputer instance for state sensitivities
@@ -460,7 +451,7 @@ class SteadystateProblem {
      * @param model Model instance.
      * simulation.
      */
-    void runSteadystateSimulationFwd(Solver const& solver, Model& model);
+    void runSteadystateSimulationFwd(Solver& solver, Model& model);
 
     /**
      * @brief Launch backward simulation if Newton solver or linear system solve

--- a/src/forwardproblem.cpp
+++ b/src/forwardproblem.cpp
@@ -450,14 +450,15 @@ void EventHandlingSimulator::store_event(ExpData const* edata) {
             continue;
         }
 
-        if (edata && solver_->computingASA())
+        if (edata && solver_->computingASA()) {
+            Expects(dJzdx_ != nullptr);
             model_->getAdjointStateEventUpdate(
                 slice(
                     *dJzdx_, ws_->nroots.at(ie), model_->nx_solver * model_->nJ
                 ),
                 ie, ws_->nroots.at(ie), t_, ws_->x, *edata
             );
-
+        }
         ws_->nroots.at(ie)++;
     }
 

--- a/src/model.cpp
+++ b/src/model.cpp
@@ -7,11 +7,11 @@
 
 #include <algorithm>
 #include <cassert>
-#include <sstream>
 #include <cmath>
 #include <cstring>
 #include <numeric>
 #include <regex>
+#include <sstream>
 #include <utility>
 
 namespace amici {

--- a/src/solver.cpp
+++ b/src/solver.cpp
@@ -1307,15 +1307,15 @@ void Solver::resetMutableMemory(
 }
 
 void Solver::writeSolution(
-    realtype* t, AmiVector& x, AmiVector& dx, AmiVectorArray& sx, AmiVector& xQ
+    realtype& t, AmiVector& x, AmiVector& dx, AmiVectorArray& sx, AmiVector& xQ
 ) const {
-    *t = gett();
+    t = gett();
     if (quad_initialized_)
-        xQ.copy(getQuadrature(*t));
+        xQ.copy(getQuadrature(t));
     if (sens_initialized_)
-        sx.copy(getStateSensitivity(*t));
-    x.copy(getState(*t));
-    dx.copy(getDerivativeState(*t));
+        sx.copy(getStateSensitivity(t));
+    x.copy(getState(t));
+    dx.copy(getDerivativeState(t));
 }
 
 void Solver::writeSolution(


### PR DESCRIPTION
Some changes to make it easier to implement event handling during pre-equilibration later on.

* Move getWrmsState to lambda
* Change `t` in `writeSolution` from pointer to reference (missed one overload previously)
* non-const Solver