### PR TITLE
Extract SteadyStateBackwardProblem from SteadystateProblem

### DIFF
--- a/include/amici/backwardproblem.h
+++ b/include/amici/backwardproblem.h
@@ -5,6 +5,7 @@
 #include "amici/forwardproblem.h"
 #include "amici/vector.h"
 
+#include <optional>
 #include <vector>
 
 namespace amici {
@@ -172,6 +173,28 @@ class BackwardProblem {
         return ws_.xQB_;
     }
 
+    /**
+     * @brief Return the postequilibration SteadyStateBwdProblem.
+     * @return The postequilibration SteadyStateBackwardProblem, if any.
+     */
+    [[nodiscard]] SteadyStateBackwardProblem const*
+    getPostequilibrationBwdProblem() const {
+        if (posteq_problem_bwd_.has_value())
+            return &*posteq_problem_bwd_;
+        return nullptr;
+    }
+
+    /**
+     * @brief Return the preequilibration SteadyStateBackwardProblem.
+     * @return The preequilibration SteadyStateBackwardProblem, if any.
+     */
+    [[nodiscard]] SteadyStateBackwardProblem const*
+    getPreequilibrationBwdProblem() const {
+        if (preeq_problem_bwd_.has_value())
+            return &*preeq_problem_bwd_;
+        return nullptr;
+    }
+
   private:
     void handlePostequilibration();
 
@@ -209,6 +232,12 @@ class BackwardProblem {
     BwdSimWorkspace ws_;
 
     EventHandlingBwdSimulator simulator_;
+
+    /** The preequilibration steady-state backward problem, if any. */
+    std::optional<SteadyStateBackwardProblem> preeq_problem_bwd_;
+
+    /** The postequilibration steady-state backward problem, if any. */
+    std::optional<SteadyStateBackwardProblem> posteq_problem_bwd_;
 };
 
 } // namespace amici

--- a/include/amici/rdata.h
+++ b/include/amici/rdata.h
@@ -17,6 +17,7 @@ class ExpData;
 class ForwardProblem;
 class BackwardProblem;
 class SteadystateProblem;
+class SteadyStateBackwardProblem;
 } // namespace amici
 
 namespace boost::serialization {
@@ -498,18 +499,25 @@ class ReturnData : public ModelDimensions {
     /**
      * @brief extracts data from a preequilibration SteadystateProblem
      * @param preeq SteadystateProblem for preequilibration
+     * @param preeq_bwd SteadyStateBackwardProblem from preequilibration
      * @param model Model instance to compute return values
      */
-    void processPreEquilibration(SteadystateProblem const& preeq, Model& model);
+    void processPreEquilibration(
+        SteadystateProblem const& preeq,
+        SteadyStateBackwardProblem const* preeq_bwd, Model& model
+    );
 
     /**
      * @brief extracts data from a preequilibration SteadystateProblem
      * @param posteq SteadystateProblem for postequilibration
+     * @param posteq_bwd SteadyStateBackwardProblem from postequilibration
      * @param model Model instance to compute return values
      * @param edata ExpData instance containing observable data
      */
     void processPostEquilibration(
-        SteadystateProblem const& posteq, Model& model, ExpData const* edata
+        SteadystateProblem const& posteq,
+        SteadyStateBackwardProblem const* posteq_bwd, Model& model,
+        ExpData const* edata
     );
 
     /**
@@ -526,12 +534,14 @@ class ReturnData : public ModelDimensions {
      * @brief extracts results from backward problem
      * @param fwd forward problem
      * @param bwd backward problem
-     * @param preeq SteadystateProblem for preequilibration
+     * @param preeq SteadyStateProblem for preequilibration
+     * @param preeq_bwd SteadyStateBackwardProblem for preequilibration
      * @param model model that was used for forward/backward simulation
      */
     void processBackwardProblem(
         ForwardProblem const& fwd, BackwardProblem const& bwd,
-        SteadystateProblem const* preeq, Model& model
+        SteadystateProblem const* preeq,
+        SteadyStateBackwardProblem const* preeq_bwd, Model& model
     );
 
     /**
@@ -716,13 +726,15 @@ class ReturnData : public ModelDimensions {
      * @brief Updates contribution to likelihood from quadratures (xQB),
      * if preequilibration was run in adjoint mode
      * @param model model that was used for forward/backward simulation
-     * @param preeq SteadystateProblem for preequilibration
+     * @param preeq SteadyStateProblem for preequilibration
+     * @param preeq_bwd SteadyStateBackwardProblem for preequilibration
      * @param llhS0 contribution to likelihood for initial state sensitivities
      * of preequilibration
      * @param xQB vector with quadratures from adjoint computation
      */
     void handleSx0Backward(
         Model const& model, SteadystateProblem const& preeq,
+        SteadyStateBackwardProblem const* preeq_bwd,
         std::vector<realtype>& llhS0, AmiVector& xQB
     ) const;
 

--- a/src/backwardproblem.cpp
+++ b/src/backwardproblem.cpp
@@ -72,9 +72,9 @@ void BackwardProblem::workBackwardProblem() {
         );
         auto const t0
             = std::isnan(model_->t0Preeq()) ? model_->t0() : model_->t0Preeq();
-        preeq_problem_->workSteadyStateBackwardProblem(
-            *solver_, *model_, ws_.xB_, true, t0
-        );
+        auto final_state = preeq_problem_->getFinalSimulationState();
+        preeq_problem_bwd_.emplace(*solver_, *model_, final_state);
+        preeq_problem_bwd_->run(*solver_, *model_, ws_.xB_, true, t0);
     }
 }
 
@@ -91,10 +91,10 @@ void BackwardProblem::handlePostequilibration() {
         }
     }
 
-    posteq_problem_->workSteadyStateBackwardProblem(
-        *solver_, *model_, ws_.xB_, false, model_->t0()
-    );
-    ws_.xQB_ = posteq_problem_->getEquilibrationQuadratures();
+    auto final_state = posteq_problem_->getFinalSimulationState();
+    posteq_problem_bwd_.emplace(*solver_, *model_, final_state);
+    posteq_problem_bwd_->run(*solver_, *model_, ws_.xB_, false, model_->t0());
+    ws_.xQB_ = posteq_problem_bwd_->getEquilibrationQuadratures();
 }
 
 void EventHandlingBwdSimulator::handleEventB(

--- a/src/rdata.cpp
+++ b/src/rdata.cpp
@@ -186,13 +186,19 @@ void ReturnData::processSimulationObjects(
 
     SteadystateProblem const* preeq = nullptr;
     SteadystateProblem const* posteq = nullptr;
+    SteadyStateBackwardProblem const* preeq_bwd = nullptr;
+    SteadyStateBackwardProblem const* posteq_bwd = nullptr;
     if (fwd) {
         preeq = fwd->getPreequilibrationProblem();
         posteq = fwd->getPostequilibrationProblem();
+        if (bwd) {
+            preeq_bwd = bwd->getPreequilibrationBwdProblem();
+            posteq_bwd = bwd->getPostequilibrationBwdProblem();
+        }
     }
 
     if (preeq)
-        processPreEquilibration(*preeq, model);
+        processPreEquilibration(*preeq, preeq_bwd, model);
 
     if (fwd)
         processForwardProblem(*fwd, model, edata);
@@ -200,7 +206,7 @@ void ReturnData::processSimulationObjects(
         invalidate(0);
 
     if (posteq)
-        processPostEquilibration(*posteq, model, edata);
+        processPostEquilibration(*posteq, posteq_bwd, model, edata);
 
     if (fwd && !posteq)
         storeJacobianAndDerivativeInReturnData(*fwd, model);
@@ -208,7 +214,7 @@ void ReturnData::processSimulationObjects(
         storeJacobianAndDerivativeInReturnData(*posteq, model);
 
     if (fwd && bwd)
-        processBackwardProblem(*fwd, *bwd, preeq, model);
+        processBackwardProblem(*fwd, *bwd, preeq, preeq_bwd, model);
     else if (solver.computingASA())
         invalidateSLLH();
 
@@ -216,7 +222,8 @@ void ReturnData::processSimulationObjects(
 }
 
 void ReturnData::processPreEquilibration(
-    SteadystateProblem const& preeq, Model& model
+    SteadystateProblem const& preeq,
+    SteadyStateBackwardProblem const* preeq_bwd, Model& model
 ) {
     auto const simulation_state = preeq.getFinalSimulationState();
     model.setModelState(simulation_state.state);
@@ -229,8 +236,10 @@ void ReturnData::processPreEquilibration(
     }
     /* Get cpu time for pre-equilibration in milliseconds */
     preeq_cpu_time = preeq.getCPUTime();
-    preeq_cpu_timeB = preeq.getCPUTimeB();
-    preeq_numstepsB = preeq.getNumStepsB();
+    if (preeq_bwd) {
+        preeq_cpu_timeB = preeq_bwd->getCPUTimeB();
+        preeq_numstepsB = preeq_bwd->getNumStepsB();
+    }
     preeq_wrms = preeq.getResidualNorm();
     preeq_status = preeq.getSteadyStateStatus();
     if (preeq_status[1] == SteadyStateStatus::success)
@@ -240,7 +249,9 @@ void ReturnData::processPreEquilibration(
 }
 
 void ReturnData::processPostEquilibration(
-    SteadystateProblem const& posteq, Model& model, ExpData const* edata
+    SteadystateProblem const& posteq,
+    SteadyStateBackwardProblem const* posteq_bwd, Model& model,
+    ExpData const* edata
 ) {
     for (int it = 0; it < nt; it++) {
         auto t = model.getTimepoint(it);
@@ -252,8 +263,10 @@ void ReturnData::processPostEquilibration(
     }
     /* Get cpu time for Newton solve in milliseconds */
     posteq_cpu_time = posteq.getCPUTime();
-    posteq_cpu_timeB = posteq.getCPUTimeB();
-    posteq_numstepsB = posteq.getNumStepsB();
+    if (posteq_bwd) {
+        posteq_cpu_timeB = posteq_bwd->getCPUTimeB();
+        posteq_numstepsB = posteq_bwd->getNumStepsB();
+    }
     posteq_wrms = posteq.getResidualNorm();
     posteq_status = posteq.getSteadyStateStatus();
     if (posteq_status[1] == SteadyStateStatus::success)
@@ -469,7 +482,8 @@ void ReturnData::getEventSensisFSA(
 
 void ReturnData::processBackwardProblem(
     ForwardProblem const& fwd, BackwardProblem const& bwd,
-    SteadystateProblem const* preeq, Model& model
+    SteadystateProblem const* preeq,
+    SteadyStateBackwardProblem const* preeq_bwd, Model& model
 ) {
     if (sllh.empty())
         return;
@@ -481,8 +495,8 @@ void ReturnData::processBackwardProblem(
     auto xB = bwd.getAdjointState();
     auto xQB = bwd.getAdjointQuadrature();
 
-    if (preeq && preeq->hasQuadrature()) {
-        handleSx0Backward(model, *preeq, llhS0, xQB);
+    if (preeq_bwd && preeq_bwd->hasQuadrature()) {
+        handleSx0Backward(model, *preeq, preeq_bwd, llhS0, xQB);
     } else {
         handleSx0Forward(model, simulation_state, llhS0, xB);
     }
@@ -502,7 +516,8 @@ void ReturnData::processBackwardProblem(
 
 void ReturnData::handleSx0Backward(
     Model const& model, SteadystateProblem const& preeq,
-    std::vector<realtype>& llhS0, AmiVector& xQB
+    SteadyStateBackwardProblem const* preeq_bwd, std::vector<realtype>& llhS0,
+    AmiVector& xQB
 ) const {
     /* If preequilibration is run in adjoint mode, the scalar product of sx0
        with its adjoint counterpart (see handleSx0Forward()) is not necessary:
@@ -511,13 +526,13 @@ void ReturnData::handleSx0Backward(
        and so is the scalar product. Instead of the scalar product, the
        quadratures xQB from preequilibration contribute to the gradient
        (see example notebook on equilibration for further documentation). */
-    auto const& xQBpreeq = preeq.getAdjointQuadrature();
+    auto const& xQBpreeq = preeq_bwd->getAdjointQuadrature();
     for (int ip = 0; ip < model.nplist(); ++ip)
         xQB[ip] += xQBpreeq.at(ip);
 
     /* We really need references here, as sx0 can be large... */
     auto const& sx0preeq = preeq.getStateSensitivity();
-    auto const& xBpreeq = preeq.getAdjointState();
+    auto const& xBpreeq = preeq_bwd->getAdjointState();
 
     /* Add the contribution for sx0 from preequilibration. If backward
      * preequilibration was done by simulation due to a singular Jacobian,


### PR DESCRIPTION
Related to #2776.

Reduce coupling between steady-state forward and backward problems.

This also saves some memory and allocations in case of FSA, but adds a copy of the NewtonSolver in case of ASA. (Can be avoided if really necessary.)