### PR TITLE
doc: Simplify building docs without notebook execution

### DIFF
--- a/doc/conf.py
+++ b/doc/conf.py
@@ -227,6 +227,8 @@ nbsphinx_prolog = (
     """
 )
 
+nbsphinx_execute = "never" if os.environ.get("AMICI_NO_NB_EXEC") else "auto"
+
 # Add any paths that contain templates here, relative to this directory.
 templates_path = ["_templates"]
 

--- a/tox.ini
+++ b/tox.ini
@@ -6,7 +6,7 @@ envlist =
     doc
 
 [testenv]
-passenv = AMICI_PARALLEL_COMPILE,CC,CXX,GITHUB_ACTIONS
+passenv = AMICI_PARALLEL_COMPILE,CC,CXX,GITHUB_ACTIONS,AMICI_NO_NB_EXEC
 
 [testenv:doc]
 description =


### PR DESCRIPTION
For testing documentation builds it's annoying to wait for notebook execution to complete or modifying the configuration file. With this change, setting an environment variable `AMICI_NO_NB_EXEC` to any value will skip notebook execution when building the documentation.