### PR TITLE
Event handling during pre-equilibration with FSA before ASA simulation

### DIFF
--- a/include/amici/backwardproblem.h
+++ b/include/amici/backwardproblem.h
@@ -335,8 +335,8 @@ class BackwardProblem {
     /** current time */
     realtype t_;
 
-    /** array containing the time-points of discontinuities*/
-    std::vector<Discontinuity> discs_;
+    /** The discontinuities encountered during the main simulation. */
+    std::vector<Discontinuity> discs_main_;
 
     /**
      * state derivative of data likelihood

--- a/src/backwardproblem.cpp
+++ b/src/backwardproblem.cpp
@@ -15,7 +15,7 @@ BackwardProblem::BackwardProblem(ForwardProblem& fwd)
     , solver_(fwd.solver)
     , edata_(fwd.edata)
     , t_(fwd.getTime())
-    , discs_(fwd.getDiscontinuities())
+    , discs_main_(fwd.getDiscontinuities())
     , dJydx_(fwd.getAdjointUpdates(*model_, *edata_))
     , dJzdx_(fwd.getDJzdx())
     , preeq_problem_(fwd.getPreequilibrationProblem())
@@ -45,8 +45,8 @@ void BackwardProblem::workBackwardProblem() {
 
     // initialize state vectors, depending on postequilibration
     model_->initializeB(ws_.xB_, ws_.dxB_, ws_.xQB_, it < model_->nt() - 1);
-    ws_.discs_ = discs_;
-    ws_.nroots_ = compute_nroots(discs_, model_->ne, model_->nMaxEvent());
+    ws_.discs_ = discs_main_;
+    ws_.nroots_ = compute_nroots(discs_main_, model_->ne, model_->nMaxEvent());
     simulator_.run(
         t_, model_->t0(), it, model_->getTimepoints(), &dJydx_, &dJzdx_
     );

--- a/src/solver_cvodes.cpp
+++ b/src/solver_cvodes.cpp
@@ -592,6 +592,10 @@ void CVodeSolver::reInit(
 void CVodeSolver::sensReInit(
     AmiVectorArray const& yyS0, AmiVectorArray const& /*ypS0*/
 ) const {
+    if (!sens_initialized_) {
+        return;
+    }
+
     auto cv_mem = static_cast<CVodeMem>(solver_memory_.get());
     /* Initialize znS[0] in the history array */
     for (int is = 0; is < nplist(); is++)


### PR DESCRIPTION
Implement event handling during pre-equilibration if steady-state sensitivities are computed with FSA, and ASA is used afterwards. (No ASA preeq + ASA main sim yet.)

* Store discontinuities during pre-equilibration (store `PeriodResult` instead of only `SimulationState`)
* Make sure to use the same `EventHandlingSimulator` for initial events and later events, with the correct sensitivity method

Storing the results is not so pretty yet. To be cleaned up once all methods work.

Related to https://github.com/AMICI-dev/AMICI/issues/2775.