### PR TITLE
CI: no error on longdouble warning

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -5,6 +5,8 @@ addopts = -vv --strict-markers
 filterwarnings =
     # warnings are errors
     error
+    # Known issue with numpy under valgrind - don't error on this
+    once:Signature .* for <class 'numpy.longdouble'> does not match any known type. falling back to type probe function:UserWarning
     # petab
     ignore:Using petab.v1.Problem with PEtab2.0 is deprecated:DeprecationWarning
     # amici


### PR DESCRIPTION
Don't error on stray numpy longdouble warnings that occur specifically when running under valgrind.