### PR TITLE
Fix storing final state upon preequilibration failures

### DIFF
--- a/include/amici/forwardproblem.h
+++ b/include/amici/forwardproblem.h
@@ -794,6 +794,12 @@ class ForwardProblem {
         return pre_simulator_.result;
     }
 
+    /**
+     * @brief Whether pre-equilibration was performed successfully.
+     * @return
+     */
+    bool was_preequilibrated() const { return preequilibrated_; }
+
     /** pointer to model instance */
     Model* model;
 

--- a/src/rdata.cpp
+++ b/src/rdata.cpp
@@ -198,7 +198,6 @@ void ReturnData::processSimulationObjects(
             posteq_bwd = bwd->getPostequilibrationBwdProblem();
         }
     }
-
     if (preeq)
         processPreEquilibration(*preeq, preeq_bwd, model);
 
@@ -210,7 +209,11 @@ void ReturnData::processSimulationObjects(
     if (posteq)
         processPostEquilibration(*posteq, posteq_bwd, model, edata);
 
-    if (fwd && !posteq)
+    if (edata && !edata->fixedParametersPreequilibration.empty() && fwd
+        && !fwd->was_preequilibrated() && preeq) {
+        // failure during preequilibration
+        storeJacobianAndDerivativeInReturnData(*preeq, model);
+    } else if (fwd && !posteq)
         storeJacobianAndDerivativeInReturnData(*fwd, model);
     else if (posteq)
         storeJacobianAndDerivativeInReturnData(*posteq, model);


### PR DESCRIPTION
If preequlibration fails, don't try to use the final state of the main simulation.

Fixes https://github.com/AMICI-dev/AMICI/issues/2857