### PR TITLE
Event-handling during pre-equilibration ASA / ASA

### DIFF
--- a/include/amici/backwardproblem.h
+++ b/include/amici/backwardproblem.h
@@ -308,6 +308,20 @@ class BackwardProblem {
     }
 
     /**
+     * @brief The final adjoint state vector
+     * @return xB
+     */
+    [[nodiscard]] AmiVector const& getAdjointState() const { return ws_.xB_; }
+
+    /**
+     * @brief The final quadrature state vector.
+     * @return xQB
+     */
+    [[nodiscard]] AmiVector const& getAdjointQuadrature() const {
+        return ws_.xQB_;
+    }
+
+    /**
      * @brief Return the postequilibration SteadyStateBwdProblem.
      * @return The postequilibration SteadyStateBackwardProblem, if any.
      */

--- a/include/amici/forwardproblem.h
+++ b/include/amici/forwardproblem.h
@@ -476,6 +476,14 @@ class SteadystateProblem {
      */
     [[nodiscard]] Solver const* get_solver() const { return solver_; }
 
+    /**
+     * @brief Get the preequilibration result.
+     * @return
+     */
+    [[nodiscard]] PeriodResult const& get_result() const {
+        return period_result_;
+    }
+
   private:
     /**
      * @brief Handle the computation of the steady state.

--- a/include/amici/rdata.h
+++ b/include/amici/rdata.h
@@ -792,16 +792,14 @@ class ReturnData : public ModelDimensions {
      * @brief Updates contribution to likelihood from quadratures (xQB),
      * if preequilibration was run in adjoint mode
      * @param model model that was used for forward/backward simulation
-     * @param preeq SteadyStateProblem for preequilibration
-     * @param preeq_bwd SteadyStateBackwardProblem for preequilibration
+     * @param sx0 State sensitivities at pre-equilibration steady state
+     * @param xB Adjoint state from pre-equilibration.
      * @param llhS0 contribution to likelihood for initial state sensitivities
      * of preequilibration
-     * @param xQB vector with quadratures from adjoint computation
      */
     void handleSx0Backward(
-        Model const& model, SteadystateProblem const& preeq,
-        SteadyStateBackwardProblem const* preeq_bwd,
-        std::vector<realtype>& llhS0, AmiVector& xQB
+        Model const& model, AmiVectorArray const& sx0, AmiVector const& xB,
+        std::vector<realtype>& llhS0
     ) const;
 
     /**

--- a/python/tests/test_preequilibration.py
+++ b/python/tests/test_preequilibration.py
@@ -829,8 +829,7 @@ def test_preequilibration_events(tempdir):
     for sensi_meth, sensi_meth_preeq in (
         (SensitivityMethod.forward, SensitivityMethod.forward),
         (SensitivityMethod.adjoint, SensitivityMethod.forward),
-        # TODO https://github.com/AMICI-dev/AMICI/issues/2775
-        #  (SensitivityMethod.adjoint, SensitivityMethod.adjoint),
+        (SensitivityMethod.adjoint, SensitivityMethod.adjoint),
     ):
         amici_solver.setSensitivityMethod(sensi_meth)
         amici_solver.setSensitivityMethodPreequilibration(sensi_meth_preeq)


### PR DESCRIPTION
Handle events during pre-equilibration when sensitivities for both pre-equilibration and main simulation are computed via adjoint sensitivity analysis.

If there were any discontinuities encountered during forward simulation, perform regular backward simulation with event-handling instead of using the steady-state shortcuts.

Related to #2775.