### PR TITLE
doc: ignore simulation failures in spline example (again)

### DIFF
--- a/doc/examples/example_splines_swameye/ExampleSplinesSwameye2003.ipynb
+++ b/doc/examples/example_splines_swameye/ExampleSplinesSwameye2003.ipynb
@@ -72,7 +72,7 @@
    "outputs": [],
    "source": [
     "# Number of multi-starts for MAP estimation\n",
-    "n_starts = 150\n",
+    "n_starts = 50\n",
     "# n_starts = 0 # when loading results"
    ]
   },
@@ -372,7 +372,10 @@
     "# Import PEtab problem into pyPESTO\n",
     "pypesto_problem = pypesto.petab.PetabImporter(\n",
     "    petab_problem, model_name=name\n",
-    ").create_problem()\n",
+    ").create_problem(\n",
+    "    # re-sample optimization startpoints in case of simulation errors\n",
+    "    startpoint_kwargs={\"check_fval\": True, \"check_grad\": True}\n",
+    ")\n",
     "\n",
     "# Increase maximum number of steps for AMICI\n",
     "pypesto_problem.objective.amici_solver.setMaxSteps(10**5)"
@@ -1743,7 +1746,10 @@
     "# Import PEtab problem into pyPESTO\n",
     "pypesto_problem = pypesto.petab.PetabImporter(\n",
     "    petab_problem, model_name=name\n",
-    ").create_problem()"
+    ").create_problem(\n",
+    "    # re-sample optimization startpoints in case of simulation errors\n",
+    "    startpoint_kwargs={\"check_fval\": True, \"check_grad\": True}\n",
+    ")"
    ]
   },
   {


### PR DESCRIPTION
Missed two places in #2876.

Also reduce the number of starts, since we don't need to account for the high failure rate anymore.