### PR TITLE
Fix `dx`-dependency of `fstau`

### DIFF
--- a/include/amici/abstract_model.h
+++ b/include/amici/abstract_model.h
@@ -288,7 +288,7 @@ class AbstractModel {
     virtual void fdx0(AmiVector& x0, AmiVector& dx0);
 
     /**
-     * @brief Model-specific implementation of fstau
+     * @brief Model-specific implementation of fstau (MATLAB-only, DEPRECATED)
      * @param stau total derivative of event timepoint
      * @param t current time
      * @param x current state
@@ -304,6 +304,26 @@ class AbstractModel {
         realtype* stau, realtype t, realtype const* x, realtype const* p,
         realtype const* k, realtype const* h, realtype const* tcl,
         realtype const* sx, int ip, int ie
+    );
+
+    /**
+     * @brief Model-specific implementation of fstau
+     * @param stau total derivative of event timepoint
+     * @param t current time
+     * @param x current state
+     * @param p parameter vector
+     * @param k constant vector
+     * @param h Heaviside vector
+     * @param dx time derivative of state (DAE only)
+     * @param tcl total abundances for conservation laws
+     * @param sx current state sensitivity
+     * @param ip sensitivity index
+     * @param ie event index
+     */
+    virtual void fstau(
+        realtype* stau, realtype t, realtype const* x, realtype const* p,
+        realtype const* k, realtype const* h, realtype const* dx,
+        realtype const* tcl, realtype const* sx, int ip, int ie
     );
 
     /**

--- a/include/amici/model.h
+++ b/include/amici/model.h
@@ -1276,10 +1276,11 @@ class Model : public AbstractModel, public ModelDimensions {
      * @param ie Event index
      * @param x State variables
      * @param sx State sensitivities
+     * @param dx Current derivative of state (DAE only)
      */
     void getEventTimeSensitivity(
         std::vector<realtype>& stau, realtype t, int ie, AmiVector const& x,
-        AmiVectorArray const& sx
+        AmiVectorArray const& sx, AmiVector const& dx
     );
 
     /**

--- a/python/sdist/amici/_codegen/cxx_functions.py
+++ b/python/sdist/amici/_codegen/cxx_functions.py
@@ -262,6 +262,7 @@ functions = {
     "stau": _FunctionInfo(
         "realtype *stau, const realtype t, const realtype *x, "
         "const realtype *p, const realtype *k, const realtype *h, "
+        "const realtype *dx, "
         "const realtype *tcl, const realtype *sx, const int ip, "
         "const int ie"
     ),

--- a/src/abstract_model.cpp
+++ b/src/abstract_model.cpp
@@ -67,6 +67,19 @@ void AbstractModel::fstau(
     );
 }
 
+void AbstractModel::fstau(
+    realtype* /*stau*/, realtype const /*t*/, realtype const* /*x*/,
+    realtype const* /*p*/, realtype const* /*k*/, realtype const* /*h*/,
+    realtype const* /*dx*/, realtype const* /*tcl*/, realtype const* /*sx*/,
+    int const /*ip*/, int const /*ie*/
+) {
+    throw AmiException(
+        "Requested functionality is not supported as %s is "
+        "not implemented for this model!",
+        __func__
+    );
+}
+
 void AbstractModel::
     fy(realtype* /*y*/, realtype const /*t*/, realtype const* /*x*/,
        realtype const* /*p*/, realtype const* /*k*/, realtype const* /*h*/,

--- a/src/forwardproblem.cpp
+++ b/src/forwardproblem.cpp
@@ -572,7 +572,8 @@ void EventHandlingSimulator::store_pre_event_state(
                 // only consider transitions false -> true
                 if (ws_->roots_found.at(ie) == 1) {
                     model_->getEventTimeSensitivity(
-                        ws_->stau, ws_->sol.t, ie, ws_->sol.x, ws_->sol.sx
+                        ws_->stau, ws_->sol.t, ie, ws_->sol.x, ws_->sol.sx,
+                        ws_->sol.dx
                     );
                 }
             }

--- a/src/model.cpp
+++ b/src/model.cpp
@@ -1421,17 +1421,29 @@ void Model::addPartialEventObjectiveSensitivity(
 
 void Model::getEventTimeSensitivity(
     std::vector<realtype>& stau, realtype const t, int const ie,
-    AmiVector const& x, AmiVectorArray const& sx
+    AmiVector const& x, AmiVectorArray const& sx, AmiVector const& dx
 ) {
 
     std::ranges::fill(stau, 0.0);
 
-    for (int ip = 0; ip < nplist(); ip++) {
-        fstau(
-            &stau.at(ip), t, computeX_pos(x), state_.unscaledParameters.data(),
-            state_.fixedParameters.data(), state_.h.data(),
-            state_.total_cl.data(), sx.data(ip), plist(ip), ie
-        );
+    if (pythonGenerated) {
+        for (int ip = 0; ip < nplist(); ip++) {
+            fstau(
+                &stau.at(ip), t, computeX_pos(x),
+                state_.unscaledParameters.data(), state_.fixedParameters.data(),
+                state_.h.data(), dx.data(), state_.total_cl.data(), sx.data(ip),
+                plist(ip), ie
+            );
+        }
+    } else {
+        for (int ip = 0; ip < nplist(); ip++) {
+            fstau(
+                &stau.at(ip), t, computeX_pos(x),
+                state_.unscaledParameters.data(), state_.fixedParameters.data(),
+                state_.h.data(), state_.total_cl.data(), sx.data(ip), plist(ip),
+                ie
+            );
+        }
     }
 }
 


### PR DESCRIPTION
Fixes import of some SBML test cases with algebraic rules (e.g. `00661`). Related to #2101.