### PR TITLE
Output formatter for `SUNMatrixWrapper`

### DIFF
--- a/include/amici/sundials_matrix_wrapper.h
+++ b/include/amici/sundials_matrix_wrapper.h
@@ -8,9 +8,10 @@
 #include <gsl/gsl-lite.hpp>
 
 #include <algorithm>
+#include <ostream>
 #include <vector>
 
-#include <assert.h>
+#include <cassert>
 
 #include "amici/vector.h"
 
@@ -589,6 +590,37 @@ class SUNMatrixWrapper {
      */
     bool ownmat = true;
 };
+
+
+/**
+ * @brief Output formatter for SUNMatrixWrapper.
+ * @param os output stream
+ * @param mat SUNMatrixWrapper to output
+ * @return os
+ */
+inline std::ostream& operator<<(std::ostream& os, SUNMatrixWrapper const& mat) {
+    // convert sparse to dense for easy printing
+    if (mat.matrix_id() == SUNMATRIX_SPARSE) {
+        SUNMatrixWrapper dense_mat(mat.rows(), mat.columns(), mat.get_ctx());
+        mat.to_dense(dense_mat);
+        return os << dense_mat;
+    }
+
+    os << "[";
+    for (sunindextype i = 0; i < mat.rows(); ++i) {
+        if (i > 0)
+            os << ", ";
+        os << "[";
+        for (sunindextype j = 0; j < mat.columns(); ++j) {
+            if (j > 0)
+                os << ", ";
+            os << mat.get_data(i, j);
+        }
+        os << "]";
+    }
+    os << "]";
+    return os;
+}
 
 /**
  * @brief Convert a flat index to a pair of row/column indices.

--- a/tests/cpp/unittests/testMisc.cpp
+++ b/tests/cpp/unittests/testMisc.cpp
@@ -672,6 +672,16 @@ TEST_F(SunMatrixWrapperTest, BlockTranspose)
                   SM_INDEXPTRS_S(B_sparse.get())[icol]);
 }
 
+TEST_F(SunMatrixWrapperTest, TestPrint)
+{
+    std::stringstream ss;
+        ss << A;
+    EXPECT_EQ(ss.str() , "[[0.69, 0.03], [0.32, 0.44], [0.95, 0.38]]");
+        ss.str("");
+    ss<< B;
+        EXPECT_EQ(ss.str(), "[[0, 3, 1, 0], [3, 0, 0, 2], [0, 7, 0, 0], [1, 0, 0, 9]]");
+}
+
 TEST(UnravelIndex, UnravelIndex)
 {
     EXPECT_EQ(unravel_index(0, 2), std::make_pair((size_t) 0, (size_t) 0));


### PR DESCRIPTION
Add `std::ostream& operator<<(std::ostream&, SUNMatrixWrapper const&)` for debugging purposes.