### PR TITLE
Fix `Event.get_trigger_times` for periodic functions

### DIFF
--- a/python/sdist/amici/import_utils.py
+++ b/python/sdist/amici/import_utils.py
@@ -816,3 +816,18 @@ def _default_simplify(x):
     # We need this as a free function instead of a lambda to have it picklable
     #  for parallel simplification
     return sp.powsimp(x, deep=True)
+
+
+def contains_periodic_subexpression(expr: sp.Expr, symbol: sp.Symbol) -> bool:
+    """
+    Check if a sympy expression contains any periodic subexpression.
+
+    :param expr: The sympy expression to check.
+    :param symbol: The variable with respect to which periodicity is checked.
+    :return: `True` if the expression contains a periodic subexpression,
+        `False` otherwise.
+    """
+    for subexpr in expr.atoms(sp.Function):
+        if sp.periodicity(subexpr, symbol) is not None:
+            return True
+    return False

--- a/python/tests/test_sbml_import.py
+++ b/python/tests/test_sbml_import.py
@@ -1143,3 +1143,16 @@ def test_t0(tempdir):
     solver = model.getSolver()
     rdata = amici.runAmiciSimulation(model, solver)
     assert rdata.x == [[2.0]], rdata.x
+
+
+@skip_on_valgrind
+def test_contains_periodic_subexpression():
+    """Test that periodic subexpressions are detected."""
+    from amici.import_utils import contains_periodic_subexpression as cps
+
+    t = sp.Symbol("t")
+
+    assert cps(t, t) is False
+    assert cps(sp.sin(t), t) is True
+    assert cps(sp.cos(t), t) is True
+    assert cps(t + sp.sin(t), t) is True


### PR DESCRIPTION
The previous implementation would maximally handle the first two roots of `sin(t)` correctly.