### PR TITLE
No event trigger reinitialization after pre-equilibration and pre-simulation

### DIFF
--- a/doc/glossary.rst
+++ b/doc/glossary.rst
@@ -93,6 +93,9 @@ Glossary
         be specified for each period, except for post-equilibration, which
         always uses the fixed parameters of the main simulation period.
 
+        For SBML models, initial assignments and initial values of event
+        triggers are only applied once at the start of the first period.
+
     steady state
         In AMICI, a model is considered to be at steady state if the time
         derivative of the state variables is zero, up to the specified

--- a/include/amici/model.h
+++ b/include/amici/model.h
@@ -299,6 +299,22 @@ class Model : public AbstractModel, public ModelDimensions {
     );
 
     /**
+     * @brief Re-initialize the Heaviside variables `h` at the beginning
+     * of the second or subsequent simulation.
+     *
+     * @param t Timepoint
+     * @param x Reference to state variables
+     * @param dx Reference to time derivative of states (DAE only)
+     * @param h_old Previous values of Heaviside variables
+     * @param roots_found boolean indicators indicating whether roots were found
+     * at t0 by this fun
+     */
+    void reinit_events(
+        realtype t, AmiVector const& x, AmiVector const& dx,
+        std::vector<realtype> const& h_old, std::vector<int>& roots_found
+    );
+
+    /**
      * @brief Re-compute the explicit roots.
      *
      * Re-compute the explicit roots based on the current model parameters.

--- a/python/tests/test_preequilibration.py
+++ b/python/tests/test_preequilibration.py
@@ -761,8 +761,8 @@ def test_preequilibration_events(tempdir):
         bolus2 = 1
         bolus3 = 1
         bolus4 = 1
-        # E1 & E2 will both trigger during pre-equilibration and main
-        #  simulation (Heaviside is reset after pre-equilibration)
+        # E1 & E2 will only trigger during pre-equilibration
+        # (initialValue is only used once at the start of pre-equilibration)
         E1: at some_time >= 0, t0 = false: target1 = target1 + bolus1
         E2: at time >= 0, t0 = false: target2 = target2 + bolus2
         # requires early time point
@@ -815,8 +815,8 @@ def test_preequilibration_events(tempdir):
     assert rdata.x_ss[target2_idx] == 1
     assert rdata.x_ss[target3_idx] == 1
     assert rdata.x_ss[target4_idx] == 1
-    assert np.all(rdata.x[:, target1_idx] == [2, 2])
-    assert np.all(rdata.x[:, target2_idx] == [2, 2])
+    assert np.all(rdata.x[:, target1_idx] == [1, 1])
+    assert np.all(rdata.x[:, target2_idx] == [1, 1])
     assert np.all(rdata.x[:, target3_idx] == [1, 1])
     assert np.all(rdata.x[:, target4_idx] == [1, 2])
 

--- a/python/tests/test_sbml_import.py
+++ b/python/tests/test_sbml_import.py
@@ -378,9 +378,7 @@ def test_presimulation_events_and_sensitivities(tempdir):
     xx = 0
     xx' = piecewise(k_pre, time < 0, k_main)
 
-    # this will trigger twice, once in presimulation
-    # and once in the main simulation
-    at time >= -1 , t0=false: some_time = some_time + bolus
+    at time < -1 , t0=false: some_time = some_time + bolus
     """,
         model_name=model_name,
         output_dir=tempdir,
@@ -412,22 +410,10 @@ def test_presimulation_events_and_sensitivities(tempdir):
 
         assert rdata.status == amici.AMICI_SUCCESS
         assert_allclose(
-            rdata.by_id("some_time"), np.array([0, 1, 2]) + 2.1, atol=1e-14
+            rdata.by_id("some_time"), np.array([0, 1, 2]) + 1.1, atol=1e-14
         )
 
-        if sensi_method == amici.SensitivityMethod.forward:
-            model.requireSensitivitiesForAllParameters()
-        else:
-            # FIXME ASA with events:
-            #   https://github.com/AMICI-dev/AMICI/pull/1539
-            model.setParameterList(
-                [
-                    i
-                    for i, p in enumerate(model.getParameterIds())
-                    if p != "bolus"
-                ]
-            )
-
+        model.requireSensitivitiesForAllParameters()
         check_derivatives(
             model,
             solver,

--- a/src/forwardproblem.cpp
+++ b/src/forwardproblem.cpp
@@ -297,7 +297,11 @@ void ForwardProblem::handlePresimulation() {
             ws_.roots_found
         );
     } else if (model->ne) {
-        model->initEvents(ws_.sol.t, ws_.sol.x, ws_.sol.dx, ws_.roots_found);
+        // copy, since model state will be updated in reinit_events
+        auto h_old = model->getModelState().h;
+        model->reinit_events(
+            ws_.sol.t, ws_.sol.x, ws_.sol.dx, h_old, ws_.roots_found
+        );
     }
     solver->setup(ws_.sol.t, model, ws_.sol.x, ws_.sol.dx, ws_.sol.sx, ws_.sdx);
     solver->updateAndReinitStatesAndSensitivities(model);
@@ -338,8 +342,10 @@ void ForwardProblem::handleMainSimulation() {
         // Reset the time and re-initialize events for the main simulation
         solver->updateAndReinitStatesAndSensitivities(model);
         if (model->ne) {
-            model->initEvents(
-                model->t0(), ws_.sol.x, ws_.sol.dx, ws_.roots_found
+            // copy, since model state will be updated in reinit_events
+            auto h_old = model->getModelState().h;
+            model->reinit_events(
+                ws_.sol.t, ws_.sol.x, ws_.sol.dx, h_old, ws_.roots_found
             );
         }
     }

--- a/swig/model.i
+++ b/swig/model.i
@@ -34,6 +34,7 @@ using namespace amici;
 %ignore getObservableSensitivity;
 %ignore getExpression;
 %ignore initEvents;
+%ignore reinit_events;
 %ignore initialize;
 %ignore initializeB;
 %ignore initializeStateSensitivities;


### PR DESCRIPTION
Meanwhile, events are handled during pre-equilibration and pre-simulation. So far, SBML's `event.trigger.initialValue` was applied at the beginning of each period. However, this should only be applied at the beginning of the very first simulation period. This is fixed and tested here.

Closes #2918.