### PR TITLE
Swig-ignore some unnecessary types

### DIFF
--- a/swig/amici.i
+++ b/swig/amici.i
@@ -164,6 +164,9 @@ wrap_unique_ptr(ExpDataPtr, amici::ExpData)
 %ignore amici::backtraceString;
 %ignore amici::Logger;
 %ignore amici::SimulationState;
+%ignore amici::BLASLayout;
+%ignore amici::SolutionState;
+%ignore amici::ModelQuantity;
 
 // Include before any other header which uses enums defined there
 %include "amici/defines.h"

--- a/swig/model.i
+++ b/swig/model.i
@@ -99,6 +99,8 @@ using namespace amici;
 
 %newobject amici::Model::clone;
 
+%rename(create_solver) amici::Model::getSolver;
+
 %extend amici::Model {
 %pythoncode %{
 def __deepcopy__(self, memo):


### PR DESCRIPTION
and add `Model.create_solver` as a more pythonic alias to `getSolver`.