### PR TITLE
Fix pre-equilibration error with `generate_sensitivity_code=False`

### DIFF
--- a/src/forwardproblem.cpp
+++ b/src/forwardproblem.cpp
@@ -262,7 +262,10 @@ void ForwardProblem::handlePreequilibration() {
         solver->getSensitivityOrder() >= SensitivityOrder::first,
         ws_.roots_found
     );
-    model->initializeStateSensitivities(t0, ws_.sol.sx, ws_.sol.x);
+    if (solver->getSensitivityOrder() >= SensitivityOrder::first
+        and solver->getSensitivityMethod() != SensitivityMethod::none) {
+        model->initializeStateSensitivities(t0, ws_.sol.sx, ws_.sol.x);
+    }
     solver->setup(t0, model, ws_.sol.x, ws_.sol.dx, ws_.sol.sx, ws_.sdx);
 
     preeq_problem_->workSteadyStateProblem(*solver, -1, t0);


### PR DESCRIPTION
Only call `Model::initializeStateSensitivities` if we are computing sensitivities. Fixes a recently introduced bug that results in a simulation error when running pre-equilibration with models that were imported with `generate_sensitivity_code=False`.