### PR TITLE
Fix check for sign change, fix Heaviside update

### DIFF
--- a/include/amici/misc.h
+++ b/include/amici/misc.h
@@ -252,6 +252,20 @@ template <class T> bool is_equal(T const& a, T const& b) {
     return true;
 }
 
+/**
+ * @brief Check whether the value of a Heaviside function differs for the two
+ * arguments.
+ *
+ * Assumes H(x) = (x >= 1 ? 1 : 0).
+ *
+ * @param a First value
+ * @param b Second value
+ * @return H(a) != H(b).
+ */
+template <typename T> bool heaviside_differs(T a, T b) {
+    return (a < T{0} && b >= T{0}) || (a >= T{0} && b < T{0});
+}
+
 #ifdef BOOST_CHRONO_HAS_THREAD_CLOCK
 /** Tracks elapsed CPU time using boost::chrono::thread_clock. */
 class CpuTimer {

--- a/src/forwardproblem.cpp
+++ b/src/forwardproblem.cpp
@@ -495,9 +495,7 @@ void EventHandlingSimulator::handle_events(
 
             store_pre_event_info(true);
 
-            if (!initial_event) {
-                model_->updateHeaviside(ws_->roots_found);
-            }
+            model_->updateHeaviside(ws_->roots_found);
         }
     }
     store_post_event_info();
@@ -616,8 +614,8 @@ int EventHandlingSimulator::detect_secondary_events() {
     for (int ie = 0; ie < model_->ne; ie++) {
         // the same event should not trigger itself
         if (ws_->roots_found.at(ie) == 0) {
-            // check whether there was a zero-crossing
-            if (0 > ws_->rval_tmp.at(ie) * ws_->rootvals.at(ie)) {
+            // check whether the value of the Heaviside function changed
+            if (heaviside_differs(ws_->rval_tmp.at(ie), ws_->rootvals.at(ie))) {
                 if (ws_->rval_tmp.at(ie) < ws_->rootvals.at(ie)) {
                     ws_->roots_found.at(ie) = 1;
                     auto const& event = model_->get_event(ie);


### PR DESCRIPTION
The old check for sign changes did not work if one values was zero.

Heaviside state has to be updated independent of whether the event occurs at the initial timepoint or not.

Fixes #2926.