### PR TITLE
RTD: don't build PDF

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -11,9 +11,6 @@ sphinx:
   configuration: doc/conf.py
   fail_on_warning: True
 
-formats:
-  - pdf
-
 python:
   install:
     - requirements: doc/rtd_requirements.txt


### PR DESCRIPTION
I don't think anybody uses the PDF documentation. Let's disable that. Related to #293.