### PR TITLE
Fix handling of initial assignments containing splines

### DIFF
--- a/python/tests/test_sbml_import.py
+++ b/python/tests/test_sbml_import.py
@@ -1150,6 +1150,7 @@ def test_time_dependent_initial_assignment(compute_conservation_laws: bool):
     """Check that dynamic expressions for initial assignments are only
     evaluated at t=t0."""
     from amici.antimony_import import antimony2sbml
+    from amici.import_utils import amici_time_symbol
 
     ant_model = """
     x1' = 1
@@ -1158,10 +1159,23 @@ def test_time_dependent_initial_assignment(compute_conservation_laws: bool):
     p1 = x1
     x2 := x1
     p2 = x2
+    spline1 = 0 # replaced by actual spline below
+    x3' = 0
+    x3 = spline1
     """
+    sbml_str = antimony2sbml(ant_model)
+    sbml_reader = libsbml.SBMLReader()
+    sbml_document = sbml_reader.readSBMLFromString(sbml_str)
+    sbml_model = sbml_document.getModel()
 
-    sbml_model = antimony2sbml(ant_model)
-    print(sbml_model)
+    spline = amici.splines.CubicHermiteSpline(
+        sbml_id="spline1",
+        nodes=[0, 1, 2],
+        values_at_nodes=[3, 4, 5],
+    )
+    spline.add_to_sbml_model(sbml_model)
+    sbml_model.getElementBySId("spline1").setConstant(False)
+
     si = SbmlImporter(sbml_model, from_file=False)
     de_model = si._build_ode_model(
         observables={"obs_p1": {"formula": "p1"}, "obs_p2": {"formula": "p2"}},
@@ -1179,5 +1193,10 @@ def test_time_dependent_initial_assignment(compute_conservation_laws: bool):
     assert list(de_model.sym("x_rdata")) == [
         symbol_with_assumptions("p2"),
         symbol_with_assumptions("x1"),
+        symbol_with_assumptions("x3"),
     ]
-    assert list(de_model.eq("x0")) == [symbol_with_assumptions("p0")] * 2
+    assert list(de_model.eq("x0")) == [
+        symbol_with_assumptions("p0"),
+        symbol_with_assumptions("p0"),
+        amici_time_symbol * 1.0 + 3.0,
+    ]


### PR DESCRIPTION
Currently, `x0` must not depend on splines. Therefore, substitute the spline symbol by its piecewise expression when compiling x0 expressions.

Reported by @m-philipps.