### PR TITLE
Reduce includes in models

### DIFF
--- a/include/amici/abstract_model.h
+++ b/include/amici/abstract_model.h
@@ -2,14 +2,18 @@
 #define AMICI_ABSTRACT_MODEL_H
 
 #include "amici/defines.h"
-#include "amici/splinefunctions.h"
-#include "amici/sundials_matrix_wrapper.h"
-#include "amici/vector.h"
+
+#include <gsl/gsl-lite.hpp>
+#include <sundials/sundials_matrix.h>
 
 #include <memory>
+#include <vector>
 
 namespace amici {
 class Solver;
+class HermiteSpline;
+class SUNMatrixWrapper;
+class AmiVector;
 
 /**
  * @brief Abstract base class of amici::Model defining functions that need to

--- a/include/amici/model.h
+++ b/include/amici/model.h
@@ -4,13 +4,11 @@
 #include "amici/abstract_model.h"
 #include "amici/defines.h"
 #include "amici/event.h"
-#include "amici/logging.h"
 #include "amici/model_dimensions.h"
 #include "amici/model_state.h"
 #include "amici/simulation_parameters.h"
 #include "amici/splinefunctions.h"
 #include "amici/sundials_matrix_wrapper.h"
-#include "amici/vector.h"
 
 #include <map>
 #include <vector>
@@ -20,6 +18,9 @@ namespace amici {
 class ExpData;
 class Model;
 class Solver;
+class Logger;
+class AmiVector;
+class AmiVectorArray;
 
 } // namespace amici
 

--- a/python/sdist/amici/_codegen/cxx_functions.py
+++ b/python/sdist/amici/_codegen/cxx_functions.py
@@ -45,6 +45,20 @@ class _FunctionInfo:
     default_return_value: str = ""
     header: list[str] = field(default_factory=list)
 
+    def __post_init__(self):
+        common_header = [
+            '#include "amici/symbolic_functions.h"',
+            '#include "amici/defines.h"',
+            "",
+            # std::{min,find}
+            "#include <algorithm>",
+        ]
+        if self.sparse:
+            common_header.append("#include <sundials/sundials_types.h>")
+            common_header.append("#include <gsl/gsl-lite.hpp>")
+
+        self.header = common_header + self.header
+
     def arguments(self, ode: bool = True) -> str:
         """Get the arguments for the ODE or DAE function"""
         if ode or not self.dae_arguments:
@@ -324,6 +338,7 @@ functions = {
         "realtype *x0_fixedParameters, const realtype t, "
         "const realtype *p, const realtype *k, "
         "gsl::span<const int> reinitialization_state_idxs",
+        header=["#include <gsl/gsl-lite.hpp>"],
     ),
     "sx0": _FunctionInfo(
         "realtype *sx0, const realtype t, const realtype *x, "
@@ -333,6 +348,7 @@ functions = {
         "realtype *sx0_fixedParameters, const realtype t, "
         "const realtype *x0, const realtype *p, const realtype *k, "
         "const int ip, gsl::span<const int> reinitialization_state_idxs",
+        header=["#include <gsl/gsl-lite.hpp>"],
     ),
     "xdot": _FunctionInfo(
         "realtype *xdot, const realtype t, const realtype *x, "

--- a/python/sdist/amici/de_export.py
+++ b/python/sdist/amici/de_export.py
@@ -423,18 +423,7 @@ class DEExporter:
         func_info = self.functions[function]
 
         # function header
-        lines.extend(
-            [
-                '#include "amici/symbolic_functions.h"',
-                '#include "amici/defines.h"',
-                '#include "sundials/sundials_types.h"',
-                "",
-                "#include <gsl/gsl-lite.hpp>",
-                "#include <algorithm>",
-                "",
-                *func_info.header,
-            ]
-        )
+        lines.extend(func_info.header)
 
         # extract symbols that need definitions from signature
         # don't add includes for files that won't be generated.

--- a/src/abstract_model.cpp
+++ b/src/abstract_model.cpp
@@ -1,4 +1,6 @@
 #include "amici/abstract_model.h"
+#include "amici/exception.h"
+#include "amici/splinefunctions.h"
 
 namespace amici {
 


### PR DESCRIPTION
Remove unnecessary includes in the generated code. Reduces serial compilation time by a second or two.