### PR TITLE
Remove MATLAB-specific model code

### DIFF
--- a/include/amici/abstract_model.h
+++ b/include/amici/abstract_model.h
@@ -287,24 +287,6 @@ class AbstractModel {
      */
     virtual void fdx0(AmiVector& x0, AmiVector& dx0);
 
-    /**
-     * @brief Model-specific implementation of fstau (MATLAB-only, DEPRECATED)
-     * @param stau total derivative of event timepoint
-     * @param t current time
-     * @param x current state
-     * @param p parameter vector
-     * @param k constant vector
-     * @param h Heaviside vector
-     * @param tcl total abundances for conservation laws
-     * @param sx current state sensitivity
-     * @param ip sensitivity index
-     * @param ie event index
-     */
-    virtual void fstau(
-        realtype* stau, realtype t, realtype const* x, realtype const* p,
-        realtype const* k, realtype const* h, realtype const* tcl,
-        realtype const* sx, int ip, int ie
-    );
 
     /**
      * @brief Model-specific implementation of fstau
@@ -340,26 +322,9 @@ class AbstractModel {
     fy(realtype* y, realtype t, realtype const* x, realtype const* p,
        realtype const* k, realtype const* h, realtype const* w);
 
-    /**
-     * @brief Model-specific implementation of fdydp (MATLAB-only)
-     * @param dydp partial derivative of observables y w.r.t. model parameters p
-     * @param t current time
-     * @param x current state
-     * @param p parameter vector
-     * @param k constant vector
-     * @param h Heaviside vector
-     * @param ip parameter index w.r.t. which the derivative is requested
-     * @param w repeating elements vector
-     * @param dwdp Recurring terms in xdot, parameter derivative
-     */
-    virtual void fdydp(
-        realtype* dydp, realtype t, realtype const* x, realtype const* p,
-        realtype const* k, realtype const* h, int ip, realtype const* w,
-        realtype const* dwdp
-    );
 
     /**
-     * @brief Model-specific implementation of fdydp (Python)
+     * @brief Model-specific implementation of fdydp
      * @param dydp partial derivative of observables y w.r.t. model parameters p
      * @param t current time
      * @param x current state
@@ -526,25 +491,7 @@ class AbstractModel {
     );
 
     /**
-     * @brief Model-specific implementation of fdeltax (MATLAB-only)
-     * @param deltax state update
-     * @param t current time
-     * @param x current state
-     * @param p parameter vector
-     * @param k constant vector
-     * @param h Heaviside vector
-     * @param ie event index
-     * @param xdot new model right hand side
-     * @param xdot_old previous model right hand side
-     */
-    virtual void fdeltax(
-        realtype* deltax, realtype t, realtype const* x, realtype const* p,
-        realtype const* k, realtype const* h, int ie, realtype const* xdot,
-        realtype const* xdot_old
-    );
-
-    /**
-     * @brief Model-specific implementation of fdeltax (Python-only)
+     * @brief Model-specific implementation of fdeltax
      * @param deltax state update
      * @param t current time
      * @param x current state
@@ -563,31 +510,7 @@ class AbstractModel {
     );
 
     /**
-     * @brief Model-specific implementation of fdeltasx (MATLAB-only)
-     * @param deltasx sensitivity update
-     * @param t current time
-     * @param x current state
-     * @param p parameter vector
-     * @param k constant vector
-     * @param h Heaviside vector
-     * @param w repeating elements vector
-     * @param ip sensitivity index
-     * @param ie event index
-     * @param xdot new model right hand side
-     * @param xdot_old previous model right hand side
-     * @param sx state sensitivity
-     * @param stau event-time sensitivity
-     * @param tcl total abundances for conservation laws
-     */
-    virtual void fdeltasx(
-        realtype* deltasx, realtype t, realtype const* x, realtype const* p,
-        realtype const* k, realtype const* h, realtype const* w, int ip, int ie,
-        realtype const* xdot, realtype const* xdot_old, realtype const* sx,
-        realtype const* stau, realtype const* tcl
-    );
-
-    /**
-     * @brief Model-specific implementation of fdeltasx (Python-only)
+     * @brief Model-specific implementation of fdeltasx
      * @param deltasx sensitivity update
      * @param t current time
      * @param x current state
@@ -634,24 +557,6 @@ class AbstractModel {
         realtype const* xB, realtype const* tcl
     );
 
-    /**
-     * @brief Model-specific implementation of fdeltaxB (MATLAB-only!!)
-     * @param deltaxB adjoint state update
-     * @param t current time
-     * @param x current state
-     * @param p parameter vector
-     * @param k constant vector
-     * @param h Heaviside vector
-     * @param ie event index
-     * @param xdot new model right hand side
-     * @param xdot_old previous model right hand side
-     * @param xB current adjoint state
-     */
-    virtual void fdeltaxB(
-        realtype* deltaxB, realtype t, realtype const* x, realtype const* p,
-        realtype const* k, realtype const* h, int ie, realtype const* xdot,
-        realtype const* xdot_old, realtype const* xB
-    );
 
     /**
      * @brief Model-specific implementation of fdeltaqB
@@ -674,26 +579,6 @@ class AbstractModel {
         realtype const* k, realtype const* h, realtype const* dx, int ip,
         int ie, realtype const* xdot, realtype const* xdot_old,
         realtype const* x_old, realtype const* xB
-    );
-
-    /**
-     * @brief Model-specific implementation of fdeltaqB (MATLAB-only!!)
-     * @param deltaqB sensitivity update
-     * @param t current time
-     * @param x current state
-     * @param p parameter vector
-     * @param k constant vector
-     * @param h Heaviside vector
-     * @param ip sensitivity index
-     * @param ie event index
-     * @param xdot new model right hand side
-     * @param xdot_old previous model right hand side
-     * @param xB adjoint state
-     */
-    virtual void fdeltaqB(
-        realtype* deltaqB, realtype t, realtype const* x, realtype const* p,
-        realtype const* k, realtype const* h, int ip, int ie,
-        realtype const* xdot, realtype const* xdot_old, realtype const* xB
     );
 
     /**
@@ -1002,7 +887,7 @@ class AbstractModel {
     virtual void fdwdx_rowvals(SUNMatrixWrapper& dwdx);
 
     /**
-     * @brief Model-specific implementation of fdwdw, no w chainrule (Py)
+     * @brief Model-specific implementation of fdwdw, no w chainrule
      * @param dwdw partial derivative w wrt w
      * @param t timepoint
      * @param x Vector with the states

--- a/include/amici/abstract_model.h
+++ b/include/amici/abstract_model.h
@@ -287,7 +287,6 @@ class AbstractModel {
      */
     virtual void fdx0(AmiVector& x0, AmiVector& dx0);
 
-
     /**
      * @brief Model-specific implementation of fstau
      * @param stau total derivative of event timepoint
@@ -321,7 +320,6 @@ class AbstractModel {
     virtual void
     fy(realtype* y, realtype t, realtype const* x, realtype const* p,
        realtype const* k, realtype const* h, realtype const* w);
-
 
     /**
      * @brief Model-specific implementation of fdydp
@@ -556,7 +554,6 @@ class AbstractModel {
         realtype const* xdot, realtype const* xdot_old, realtype const* x_old,
         realtype const* xB, realtype const* tcl
     );
-
 
     /**
      * @brief Model-specific implementation of fdeltaqB

--- a/include/amici/model.h
+++ b/include/amici/model.h
@@ -72,7 +72,6 @@ enum class ModelQuantity {
     p,
     ts,
     dJydy,
-    dJydy_matlab,
     deltaqB,
     dsigmaydp,
     dsigmaydy,
@@ -1520,13 +1519,7 @@ class Model : public AbstractModel, public ModelDimensions {
     [[nodiscard]] std::vector<int> const& getReinitializationStateIdxs() const;
 
     /**
-     * @brief getter for dxdotdp (matlab generated)
-     * @return dxdotdp
-     */
-    [[nodiscard]] AmiVectorArray const& get_dxdotdp() const;
-
-    /**
-     * @brief getter for dxdotdp (python generated)
+     * @brief getter for dxdotdp
      * @return dxdotdp
      */
     [[nodiscard]] SUNMatrixWrapper const& get_dxdotdp_full() const;

--- a/include/amici/model_dae.h
+++ b/include/amici/model_dae.h
@@ -46,7 +46,6 @@ class Model_DAE : public Model {
               events
           ) {
         SUNContext sunctx = derived_state_.sunctx_;
-        derived_state_.M_ = SUNMatrixWrapper(nx_solver, nx_solver, sunctx);
         auto const M_nnz = static_cast<sunindextype>(
             std::reduce(idlist.begin(), idlist.end())
         );

--- a/include/amici/model_dimensions.h
+++ b/include/amici/model_dimensions.h
@@ -54,8 +54,6 @@ struct ModelDimensions {
      * @param nnz Number of nonzero elements in Jacobian
      * @param ubw Upper matrix bandwidth in the Jacobian
      * @param lbw Lower matrix bandwidth in the Jacobian
-     * @param pythonGenerated Flag indicating model creation from Matlab or
-     * Python
      * @param ndxdotdp_explicit Number of nonzero elements in `dxdotdp_explicit`
      * @param ndxdotdx_explicit Number of nonzero elements in `dxdotdx_explicit`
      * @param w_recursion_depth Recursion depth of fw
@@ -69,8 +67,8 @@ struct ModelDimensions {
         int const ndwdw, int const ndxdotdw, std::vector<int> ndJydy,
         int const ndxrdatadxsolver, int const ndxrdatadtcl,
         int const ndtotal_cldx_rdata, int const nnz, int const ubw,
-        int const lbw, bool pythonGenerated = false, int ndxdotdp_explicit = 0,
-        int ndxdotdx_explicit = 0, int w_recursion_depth = 0
+        int const lbw, int ndxdotdp_explicit = 0, int ndxdotdx_explicit = 0,
+        int w_recursion_depth = 0
     )
         : nx_rdata(nx_rdata)
         , nxtrue_rdata(nxtrue_rdata)
@@ -99,7 +97,6 @@ struct ModelDimensions {
         , nJ(nJ)
         , ubw(ubw)
         , lbw(lbw)
-        , pythonGenerated(pythonGenerated)
         , ndxdotdp_explicit(ndxdotdp_explicit)
         , ndxdotdx_explicit(ndxdotdx_explicit)
         , w_recursion_depth(w_recursion_depth) {
@@ -242,9 +239,6 @@ struct ModelDimensions {
 
     /** Lower bandwidth of the Jacobian */
     int lbw{0};
-
-    /** Flag indicating model creation from Matlab or Python */
-    bool pythonGenerated = false;
 
     /** Number of nonzero elements in `dxdotdx_explicit` */
     int ndxdotdp_explicit = 0;

--- a/include/amici/model_ode.h
+++ b/include/amici/model_ode.h
@@ -279,25 +279,9 @@ class Model_ODE : public Model {
     std::unique_ptr<Solver> getSolver() override;
 
   protected:
-    /**
-     * @brief Model specific implementation for fJSparse (Matlab)
-     * @param JSparse Matrix to which the Jacobian will be written
-     * @param t timepoint
-     * @param x Vector with the states
-     * @param p parameter vector
-     * @param k constants vector
-     * @param h Heaviside vector
-     * @param w vector with helper variables
-     * @param dwdx derivative of w wrt x
-     **/
-    virtual void fJSparse(
-        SUNMatrixContent_Sparse JSparse, realtype t, realtype const* x,
-        realtype const* p, realtype const* k, realtype const* h,
-        realtype const* w, realtype const* dwdx
-    );
 
     /**
-     * @brief Model specific implementation for fJSparse, data only (Py)
+     * @brief Model specific implementation for fJSparse, data only
      * @param JSparse Matrix to which the Jacobian will be written
      * @param t timepoint
      * @param x Vector with the states
@@ -355,28 +339,9 @@ class Model_ODE : public Model {
         realtype const* k, realtype const* h, realtype const* w
     ) = 0;
 
-    /**
-     * @brief Model specific implementation of fdxdotdp, with w chainrule
-     * (Matlab)
-     * @param dxdotdp partial derivative xdot wrt p
-     * @param t timepoint
-     * @param x Vector with the states
-     * @param p parameter vector
-     * @param k constants vector
-     * @param h Heaviside vector
-     * @param ip parameter index
-     * @param w vector with helper variables
-     * @param dwdp derivative of w wrt p
-     */
-    virtual void fdxdotdp(
-        realtype* dxdotdp, realtype t, realtype const* x, realtype const* p,
-        realtype const* k, realtype const* h, int ip, realtype const* w,
-        realtype const* dwdp
-    );
 
     /**
      * @brief Model specific implementation of fdxdotdp_explicit, no w chainrule
-     * (Py)
      * @param dxdotdp_explicit partial derivative xdot wrt p
      * @param t timepoint
      * @param x Vector with the states

--- a/include/amici/model_ode.h
+++ b/include/amici/model_ode.h
@@ -279,7 +279,6 @@ class Model_ODE : public Model {
     std::unique_ptr<Solver> getSolver() override;
 
   protected:
-
     /**
      * @brief Model specific implementation for fJSparse, data only
      * @param JSparse Matrix to which the Jacobian will be written
@@ -338,7 +337,6 @@ class Model_ODE : public Model {
         realtype* xdot, realtype t, realtype const* x, realtype const* p,
         realtype const* k, realtype const* h, realtype const* w
     ) = 0;
-
 
     /**
      * @brief Model specific implementation of fdxdotdp_explicit, no w chainrule

--- a/include/amici/model_state.h
+++ b/include/amici/model_state.h
@@ -93,7 +93,6 @@ struct ModelStateDerived {
         , dxdotdw_(other.dxdotdw_)
         , dwdx_(other.dwdx_)
         , dwdp_(other.dwdp_)
-        , M_(other.M_)
         , MSparse_(other.MSparse_)
         , dfdx_(other.dfdx_)
         , dxdotdp_full(other.dxdotdp_full)
@@ -106,7 +105,6 @@ struct ModelStateDerived {
         , dtotal_cldx_rdata(other.dtotal_cldx_rdata)
         , dxdotdp(other.dxdotdp)
         , dJydy_(other.dJydy_)
-        , dJydy_matlab_(other.dJydy_matlab_)
         , dJydsigma_(other.dJydsigma_)
         , dJydx_(other.dJydx_)
         , dJydp_(other.dJydp_)
@@ -152,7 +150,6 @@ struct ModelStateDerived {
         dxdotdw_.set_ctx(sunctx_);
         dwdx_.set_ctx(sunctx_);
         dwdp_.set_ctx(sunctx_);
-        M_.set_ctx(sunctx_);
         MSparse_.set_ctx(sunctx_);
         dfdx_.set_ctx(sunctx_);
         dxdotdp_full.set_ctx(sunctx_);
@@ -209,13 +206,6 @@ struct ModelStateDerived {
 
     /** Sparse dwdp temporary storage (dimension: `nw` x `np`, nnz: `ndwdp`) */
     SUNMatrixWrapper dwdp_;
-
-    /**
-     * Dense Mass matrix (dimension: `nx_solver` x `nx_solver`)
-     *
-     * MATLAB-generated-only, DEPRECATED.
-     */
-    SUNMatrixWrapper M_;
 
     /**
      * Sparse Mass matrix, Python-generated-only
@@ -295,12 +285,6 @@ struct ModelStateDerived {
      * `pythonGenerated` == `true` (dimension `nytrue`, `nJ` x `ny`, row-major)
      */
     std::vector<SUNMatrixWrapper> dJydy_;
-
-    /** Observable derivative of data likelihood, only used if
-     * `pythonGenerated` == `false` (dimension `nJ` x `ny` x `nytrue` ,
-     * row-major)
-     */
-    std::vector<realtype> dJydy_matlab_;
 
     /** Observable sigma derivative of data likelihood
      * (dimension nJ x ny x nytrue, row-major)

--- a/include/amici/serialization.h
+++ b/include/amici/serialization.h
@@ -149,7 +149,6 @@ void serialize(Archive& ar, amici::Model& m, unsigned int const /*version*/) {
     ar & m.sx0data_;
     ar & m.nmaxevent_;
     ar & m.state_is_non_negative_;
-    ar & m.pythonGenerated;
     ar & m.min_sigma_;
     ar & m.sigma_res_;
     ar & m.steadystate_computation_mode_;

--- a/models/model_calvetti_py/model_calvetti_py.h
+++ b/models/model_calvetti_py/model_calvetti_py.h
@@ -138,7 +138,6 @@ class Model_model_calvetti_py : public amici::Model_DAE {
                   0,                                       // nnz
                   6,                                 // ubw
                   6,                                 // lbw
-                  true,                                    // pythonGenerated
                   0,                   // ndxdotdp_explicit
                   5,                   // ndxdotdx_explicit
                   2                    // w_recursion_depth
@@ -558,7 +557,7 @@ class Model_model_calvetti_py : public amici::Model_DAE {
      * @return AMICI git commit hash
      */
     std::string getAmiciCommit() const override {
-        return "b12c68a7a02f1cbd33de59d47cbc0c4d77d30d6f";
+        return "dcbbae0f8e9b52afd7ab8b4b7a046da36b907139";
     }
 
     bool hasQuadraticLLH() const override {

--- a/models/model_dirac_py/model_dirac_py.h
+++ b/models/model_dirac_py/model_dirac_py.h
@@ -138,7 +138,6 @@ class Model_model_dirac_py : public amici::Model_ODE {
                   0,                                       // nnz
                   2,                                 // ubw
                   2,                                 // lbw
-                  true,                                    // pythonGenerated
                   3,                   // ndxdotdp_explicit
                   3,                   // ndxdotdx_explicit
                   0                    // w_recursion_depth
@@ -545,7 +544,7 @@ class Model_model_dirac_py : public amici::Model_ODE {
      * @return AMICI git commit hash
      */
     std::string getAmiciCommit() const override {
-        return "b12c68a7a02f1cbd33de59d47cbc0c4d77d30d6f";
+        return "dcbbae0f8e9b52afd7ab8b4b7a046da36b907139";
     }
 
     bool hasQuadraticLLH() const override {

--- a/models/model_events_py/model_events_py.h
+++ b/models/model_events_py/model_events_py.h
@@ -138,7 +138,6 @@ class Model_model_events_py : public amici::Model_ODE {
                   0,                                       // nnz
                   3,                                 // ubw
                   3,                                 // lbw
-                  true,                                    // pythonGenerated
                   3,                   // ndxdotdp_explicit
                   4,                   // ndxdotdx_explicit
                   0                    // w_recursion_depth
@@ -580,7 +579,7 @@ class Model_model_events_py : public amici::Model_ODE {
      * @return AMICI git commit hash
      */
     std::string getAmiciCommit() const override {
-        return "b12c68a7a02f1cbd33de59d47cbc0c4d77d30d6f";
+        return "dcbbae0f8e9b52afd7ab8b4b7a046da36b907139";
     }
 
     bool hasQuadraticLLH() const override {

--- a/models/model_jakstat_adjoint_py/model_jakstat_adjoint_py.h
+++ b/models/model_jakstat_adjoint_py/model_jakstat_adjoint_py.h
@@ -138,7 +138,6 @@ class Model_model_jakstat_adjoint_py : public amici::Model_ODE {
                   0,                                       // nnz
                   9,                                 // ubw
                   9,                                 // lbw
-                  true,                                    // pythonGenerated
                   13,                   // ndxdotdp_explicit
                   18,                   // ndxdotdx_explicit
                   0                    // w_recursion_depth
@@ -553,7 +552,7 @@ class Model_model_jakstat_adjoint_py : public amici::Model_ODE {
      * @return AMICI git commit hash
      */
     std::string getAmiciCommit() const override {
-        return "b12c68a7a02f1cbd33de59d47cbc0c4d77d30d6f";
+        return "dcbbae0f8e9b52afd7ab8b4b7a046da36b907139";
     }
 
     bool hasQuadraticLLH() const override {

--- a/models/model_nested_events_py/model_nested_events_py.h
+++ b/models/model_nested_events_py/model_nested_events_py.h
@@ -138,7 +138,6 @@ class Model_model_nested_events_py : public amici::Model_ODE {
                   0,                                       // nnz
                   1,                                 // ubw
                   1,                                 // lbw
-                  true,                                    // pythonGenerated
                   2,                   // ndxdotdp_explicit
                   1,                   // ndxdotdx_explicit
                   0                    // w_recursion_depth
@@ -553,7 +552,7 @@ class Model_model_nested_events_py : public amici::Model_ODE {
      * @return AMICI git commit hash
      */
     std::string getAmiciCommit() const override {
-        return "b12c68a7a02f1cbd33de59d47cbc0c4d77d30d6f";
+        return "dcbbae0f8e9b52afd7ab8b4b7a046da36b907139";
     }
 
     bool hasQuadraticLLH() const override {

--- a/models/model_neuron_py/model_neuron_py.h
+++ b/models/model_neuron_py/model_neuron_py.h
@@ -138,7 +138,6 @@ class Model_model_neuron_py : public amici::Model_ODE {
                   0,                                       // nnz
                   2,                                 // ubw
                   2,                                 // lbw
-                  true,                                    // pythonGenerated
                   2,                   // ndxdotdp_explicit
                   4,                   // ndxdotdx_explicit
                   0                    // w_recursion_depth
@@ -575,7 +574,7 @@ class Model_model_neuron_py : public amici::Model_ODE {
      * @return AMICI git commit hash
      */
     std::string getAmiciCommit() const override {
-        return "b12c68a7a02f1cbd33de59d47cbc0c4d77d30d6f";
+        return "dcbbae0f8e9b52afd7ab8b4b7a046da36b907139";
     }
 
     bool hasQuadraticLLH() const override {

--- a/models/model_robertson_py/model_robertson_py.h
+++ b/models/model_robertson_py/model_robertson_py.h
@@ -138,7 +138,6 @@ class Model_model_robertson_py : public amici::Model_DAE {
                   0,                                       // nnz
                   3,                                 // ubw
                   3,                                 // lbw
-                  true,                                    // pythonGenerated
                   5,                   // ndxdotdp_explicit
                   9,                   // ndxdotdx_explicit
                   0                    // w_recursion_depth
@@ -537,7 +536,7 @@ class Model_model_robertson_py : public amici::Model_DAE {
      * @return AMICI git commit hash
      */
     std::string getAmiciCommit() const override {
-        return "b12c68a7a02f1cbd33de59d47cbc0c4d77d30d6f";
+        return "dcbbae0f8e9b52afd7ab8b4b7a046da36b907139";
     }
 
     bool hasQuadraticLLH() const override {

--- a/models/model_steadystate_py/model_steadystate_py.h
+++ b/models/model_steadystate_py/model_steadystate_py.h
@@ -138,7 +138,6 @@ class Model_model_steadystate_py : public amici::Model_ODE {
                   0,                                       // nnz
                   3,                                 // ubw
                   3,                                 // lbw
-                  true,                                    // pythonGenerated
                   11,                   // ndxdotdp_explicit
                   9,                   // ndxdotdx_explicit
                   0                    // w_recursion_depth
@@ -537,7 +536,7 @@ class Model_model_steadystate_py : public amici::Model_ODE {
      * @return AMICI git commit hash
      */
     std::string getAmiciCommit() const override {
-        return "b12c68a7a02f1cbd33de59d47cbc0c4d77d30d6f";
+        return "dcbbae0f8e9b52afd7ab8b4b7a046da36b907139";
     }
 
     bool hasQuadraticLLH() const override {

--- a/src/abstract_model.cpp
+++ b/src/abstract_model.cpp
@@ -54,7 +54,6 @@ void AbstractModel::fdx0(AmiVector& /*x0*/, AmiVector& /*dx0*/) {
     // no-op default implementation
 }
 
-
 void AbstractModel::fstau(
     realtype* /*stau*/, realtype const /*t*/, realtype const* /*x*/,
     realtype const* /*p*/, realtype const* /*k*/, realtype const* /*h*/,
@@ -78,7 +77,6 @@ void AbstractModel::
         __func__
     );
 }
-
 
 void AbstractModel::fdydp(
     realtype* /*dydp*/, realtype const /*t*/, realtype const* /*x*/,
@@ -199,7 +197,6 @@ void AbstractModel::fdrzdx(
     );
 }
 
-
 void AbstractModel::fdeltax(
     realtype* /*deltax*/, realtype const /*t*/, realtype const* /*x*/,
     realtype const* /*p*/, realtype const* /*k*/, realtype const* /*h*/,
@@ -241,7 +238,6 @@ void AbstractModel::fdeltaxB(
         __func__
     );
 }
-
 
 void AbstractModel::fdeltaqB(
     realtype* /*deltaqB*/, realtype const /*t*/, realtype const* /*x*/,

--- a/src/abstract_model.cpp
+++ b/src/abstract_model.cpp
@@ -54,18 +54,6 @@ void AbstractModel::fdx0(AmiVector& /*x0*/, AmiVector& /*dx0*/) {
     // no-op default implementation
 }
 
-void AbstractModel::fstau(
-    realtype* /*stau*/, realtype const /*t*/, realtype const* /*x*/,
-    realtype const* /*p*/, realtype const* /*k*/, realtype const* /*h*/,
-    realtype const* /*tcl*/, realtype const* /*sx*/, int const /*ip*/,
-    int const /*ie*/
-) {
-    throw AmiException(
-        "Requested functionality is not supported as %s is "
-        "not implemented for this model!",
-        __func__
-    );
-}
 
 void AbstractModel::fstau(
     realtype* /*stau*/, realtype const /*t*/, realtype const* /*x*/,
@@ -91,17 +79,6 @@ void AbstractModel::
     );
 }
 
-void AbstractModel::fdydp(
-    realtype* /*dydp*/, realtype const /*t*/, realtype const* /*x*/,
-    realtype const* /*p*/, realtype const* /*k*/, realtype const* /*h*/,
-    int const /*ip*/, realtype const* /*w*/, realtype const* /*dwdp*/
-) {
-    throw AmiException(
-        "Requested functionality is not supported as %s is "
-        "not implemented for this model!",
-        __func__
-    );
-}
 
 void AbstractModel::fdydp(
     realtype* /*dydp*/, realtype const /*t*/, realtype const* /*x*/,
@@ -222,37 +199,12 @@ void AbstractModel::fdrzdx(
     );
 }
 
-void AbstractModel::fdeltax(
-    realtype* /*deltax*/, realtype const /*t*/, realtype const* /*x*/,
-    realtype const* /*p*/, realtype const* /*k*/, realtype const* /*h*/,
-    int const /*ie*/, realtype const* /*xdot*/, realtype const* /*xdot_old*/
-) {
-    throw AmiException(
-        "Requested functionality is not supported as %s is "
-        "not implemented for this model!",
-        __func__
-    );
-}
 
 void AbstractModel::fdeltax(
     realtype* /*deltax*/, realtype const /*t*/, realtype const* /*x*/,
     realtype const* /*p*/, realtype const* /*k*/, realtype const* /*h*/,
     int const /*ie*/, realtype const* /*xdot*/, realtype const* /*xdot_old*/,
     realtype const* /*x_old*/
-) {
-    throw AmiException(
-        "Requested functionality is not supported as %s is "
-        "not implemented for this model!",
-        __func__
-    );
-}
-
-void AbstractModel::fdeltasx(
-    realtype* /*deltasx*/, realtype const /*t*/, realtype const* /*x*/,
-    realtype const* /*p*/, realtype const* /*k*/, realtype const* /*h*/,
-    realtype const* /*w*/, int const /*ip*/, int const /*ie*/,
-    realtype const* /*xdot*/, realtype const* /*xdot_old*/,
-    realtype const* /*sx*/, realtype const* /*stau*/, realtype const* /*tcl*/
 ) {
     throw AmiException(
         "Requested functionality is not supported as %s is "
@@ -290,18 +242,6 @@ void AbstractModel::fdeltaxB(
     );
 }
 
-void AbstractModel::fdeltaxB(
-    realtype* /*deltaxB*/, realtype const /*t*/, realtype const* /*x*/,
-    realtype const* /*p*/, realtype const* /*k*/, realtype const* /*h*/,
-    int const /*ie*/, realtype const* /*xdot*/, realtype const* /*xdot_old*/,
-    realtype const* /*xB*/
-) {
-    throw AmiException(
-        "Requested functionality is not supported as %s is "
-        "not implemented for this model!",
-        __func__
-    );
-}
 
 void AbstractModel::fdeltaqB(
     realtype* /*deltaqB*/, realtype const /*t*/, realtype const* /*x*/,
@@ -309,19 +249,6 @@ void AbstractModel::fdeltaqB(
     realtype const* /*dx*/, int const /*ip*/, int const /*ie*/,
     realtype const* /*xdot*/, realtype const* /*xdot_old*/,
     realtype const* /*x_old*/, realtype const* /*xB*/
-) {
-    throw AmiException(
-        "Requested functionality is not supported as %s is "
-        "not implemented for this model!",
-        __func__
-    );
-}
-
-void AbstractModel::fdeltaqB(
-    realtype* /*deltaqB*/, realtype const /*t*/, realtype const* /*x*/,
-    realtype const* /*p*/, realtype const* /*k*/, realtype const* /*h*/,
-    int const /*ip*/, int const /*ie*/, realtype const* /*xdot*/,
-    realtype const* /*xdot_old*/, realtype const* /*xB*/
 ) {
     throw AmiException(
         "Requested functionality is not supported as %s is "

--- a/src/backwardproblem.cpp
+++ b/src/backwardproblem.cpp
@@ -342,17 +342,12 @@ void computeQBfromQ(
     // set to zero first, as multiplication adds to existing value
     yQB.zero();
     // yQB += dxdotdp * yQ
-    if (model.pythonGenerated) {
-        // fill dxdotdp with current values
-        auto const& plist = model.getParameterList();
-        model.fdxdotdp(state.t, state.x, state.dx);
-        model.get_dxdotdp_full().multiply(
-            yQB.getNVector(), yQ.getNVector(), plist, true
-        );
-    } else {
-        for (int ip = 0; ip < model.nplist(); ++ip)
-            yQB[ip] = dotProd(yQ, model.get_dxdotdp()[ip]);
-    }
+    // fill dxdotdp with current values
+    auto const& plist = model.getParameterList();
+    model.fdxdotdp(state.t, state.x, state.dx);
+    model.get_dxdotdp_full().multiply(
+        yQB.getNVector(), yQ.getNVector(), plist, true
+    );
 }
 
 SteadyStateBackwardProblem::SteadyStateBackwardProblem(

--- a/src/model.cpp
+++ b/src/model.cpp
@@ -57,7 +57,6 @@ std::map<ModelQuantity, std::string> const model_quantity_to_str{
     {ModelQuantity::p, "p"},
     {ModelQuantity::ts, "ts"},
     {ModelQuantity::dJydy, "dJydy"},
-    {ModelQuantity::dJydy_matlab, "dJydy"},
     {ModelQuantity::deltaqB, "deltaqB"},
     {ModelQuantity::dsigmaydp, "dsigmaydp"},
     {ModelQuantity::dsigmaydy, "dsigmaydy"},
@@ -197,23 +196,7 @@ Model::Model(
         == gsl::narrow<int>(simulation_parameters_.fixedParameters.size())
     );
 
-    Expects(
-        (events_.empty() && !pythonGenerated)
-        || (events_.size() == (unsigned long)ne)
-    );
-
-    if (events_.empty()) {
-        // for MATLAB generated models, create event objects here
-        for (int ie = 0; ie < ne; ie++) {
-            events_.emplace_back(
-                // The default for use_values_from_trigger_time used to be
-                // `true` in SBML. However, the MATLAB interface always
-                // implicitly used `false`, so we keep it that way until it
-                // will be removed completely.
-                std::string("event_") + std::to_string(ie), false, true, 0
-            );
-        }
-    }
+    Expects((events_.size() == (unsigned long)ne));
 
     simulation_parameters_.pscale = std::vector<ParameterScaling>(
         model_dimensions.np, ParameterScaling::none
@@ -1149,26 +1132,23 @@ void Model::getObservableSigmaSensitivity(
     fdsigmaydp(it, edata);
     writeSlice(derived_state_.dsigmaydp_, ssigmay);
 
-    if (pythonGenerated) {
-        // ssigmay = dsigmaydy*(dydx_solver*sx+dydp)+dsigmaydp
-        //         = dsigmaydy*sy+dsigmaydp
+    // ssigmay = dsigmaydy*(dydx_solver*sx+dydp)+dsigmaydp
+    //         = dsigmaydy*sy+dsigmaydp
 
-        fdsigmaydy(it, edata);
+    fdsigmaydy(it, edata);
 
-        // compute ssigmay = 1.0 * dsigmaydp + 1.0 * dsigmaydy * sy
-        // dsigmaydp C[ny,nplist] += dsigmaydy A[ny,ny] * sy B[ny,nplist]
-        //             M  N                      M  K          K  N
-        //             ldc                       lda           ldb
-        setNaNtoZero(derived_state_.dsigmaydy_);
-        derived_state_.sy_.assign(sy.begin(), sy.end());
-        setNaNtoZero(derived_state_.sy_);
-        amici_dgemm(
-            BLASLayout::colMajor, BLASTranspose::noTrans,
-            BLASTranspose::noTrans, ny, nplist(), ny, 1.0,
-            derived_state_.dsigmaydy_.data(), ny, derived_state_.sy_.data(), ny,
-            1.0, ssigmay.data(), ny
-        );
-    }
+    // compute ssigmay = 1.0 * dsigmaydp + 1.0 * dsigmaydy * sy
+    // dsigmaydp C[ny,nplist] += dsigmaydy A[ny,ny] * sy B[ny,nplist]
+    //             M  N                      M  K          K  N
+    //             ldc                       lda           ldb
+    setNaNtoZero(derived_state_.dsigmaydy_);
+    derived_state_.sy_.assign(sy.begin(), sy.end());
+    setNaNtoZero(derived_state_.sy_);
+    amici_dgemm(
+        BLASLayout::colMajor, BLASTranspose::noTrans, BLASTranspose::noTrans,
+        ny, nplist(), ny, 1.0, derived_state_.dsigmaydy_.data(), ny,
+        derived_state_.sy_.data(), ny, 1.0, ssigmay.data(), ny
+    );
 
     if (always_check_finite_)
         checkFinite(ssigmay, ModelQuantity::ssigmay, nplist());
@@ -1252,40 +1232,32 @@ void Model::getEventSensitivity(
     gsl::span<realtype> sz, int const ie, realtype const t, AmiVector const& x,
     AmiVectorArray const& sx
 ) {
-    if (pythonGenerated) {
-        if (!nz)
-            return;
+    if (!nz)
+        return;
 
-        fdzdx(ie, t, x);
-        fdzdp(ie, t, x);
+    fdzdx(ie, t, x);
+    fdzdp(ie, t, x);
 
-        derived_state_.sx_.resize(nx_solver * nplist());
-        sx.flatten_to_vector(derived_state_.sx_);
+    derived_state_.sx_.resize(nx_solver * nplist());
+    sx.flatten_to_vector(derived_state_.sx_);
 
-        // compute sz = 1.0*dzdx*sx + 1.0*dzdp
-        // dzdx A[nz,nx_solver] * sx B[nx_solver,nplist] = sz C[nz,nplist]
-        //        M  K                 K  N                     M  N
-        //        lda                  ldb                      ldc
-        setNaNtoZero(derived_state_.dzdx_);
-        setNaNtoZero(derived_state_.sx_);
-        amici_dgemm(
-            BLASLayout::colMajor, BLASTranspose::noTrans,
-            BLASTranspose::noTrans, nz, nplist(), nx_solver, 1.0,
-            derived_state_.dzdx_.data(), nz, derived_state_.sx_.data(),
-            nx_solver, 1.0, derived_state_.dzdp_.data(), nz
-        );
+    // compute sz = 1.0*dzdx*sx + 1.0*dzdp
+    // dzdx A[nz,nx_solver] * sx B[nx_solver,nplist] = sz C[nz,nplist]
+    //        M  K                 K  N                     M  N
+    //        lda                  ldb                      ldc
+    setNaNtoZero(derived_state_.dzdx_);
+    setNaNtoZero(derived_state_.sx_);
+    amici_dgemm(
+        BLASLayout::colMajor, BLASTranspose::noTrans, BLASTranspose::noTrans,
+        nz, nplist(), nx_solver, 1.0, derived_state_.dzdx_.data(), nz,
+        derived_state_.sx_.data(), nx_solver, 1.0, derived_state_.dzdp_.data(),
+        nz
+    );
 
-        addSlice(derived_state_.dzdp_, sz);
+    addSlice(derived_state_.dzdp_, sz);
 
-        if (always_check_finite_)
-            checkFinite(sz, ModelQuantity::sz, nplist());
-    } else {
-        for (int ip = 0; ip < nplist(); ip++) {
-            fsz(&sz[ip * nz], ie, t, computeX_pos(x),
-                state_.unscaledParameters.data(), state_.fixedParameters.data(),
-                state_.h.data(), sx.data(ip), plist(ip));
-        }
-    }
+    if (always_check_finite_)
+        checkFinite(sz, ModelQuantity::sz, nplist());
 }
 
 void Model::getUnobservedEventSensitivity(
@@ -1310,42 +1282,33 @@ void Model::getEventRegularizationSensitivity(
     gsl::span<realtype> srz, int const ie, realtype const t, AmiVector const& x,
     AmiVectorArray const& sx
 ) {
-    if (pythonGenerated) {
-        if (!nz)
-            return;
 
-        fdrzdx(ie, t, x);
-        fdrzdp(ie, t, x);
+    if (!nz)
+        return;
 
-        derived_state_.sx_.resize(nx_solver * nplist());
-        sx.flatten_to_vector(derived_state_.sx_);
+    fdrzdx(ie, t, x);
+    fdrzdp(ie, t, x);
 
-        // compute srz = 1.0*drzdx*sx + 1.0*drzdp
-        // drzdx A[nz,nx_solver] * sx B[nx_solver,nplist] = srz C[nz,nplist]
-        //         M  K                 K  N                      M  N
-        //         lda                  ldb                       ldc
-        setNaNtoZero(derived_state_.drzdx_);
-        setNaNtoZero(derived_state_.sx_);
-        amici_dgemm(
-            BLASLayout::colMajor, BLASTranspose::noTrans,
-            BLASTranspose::noTrans, nz, nplist(), nx_solver, 1.0,
-            derived_state_.drzdx_.data(), nz, derived_state_.sx_.data(),
-            nx_solver, 1.0, derived_state_.drzdp_.data(), nz
-        );
+    derived_state_.sx_.resize(nx_solver * nplist());
+    sx.flatten_to_vector(derived_state_.sx_);
 
-        addSlice(derived_state_.drzdp_, srz);
+    // compute srz = 1.0*drzdx*sx + 1.0*drzdp
+    // drzdx A[nz,nx_solver] * sx B[nx_solver,nplist] = srz C[nz,nplist]
+    //         M  K                 K  N                      M  N
+    //         lda                  ldb                       ldc
+    setNaNtoZero(derived_state_.drzdx_);
+    setNaNtoZero(derived_state_.sx_);
+    amici_dgemm(
+        BLASLayout::colMajor, BLASTranspose::noTrans, BLASTranspose::noTrans,
+        nz, nplist(), nx_solver, 1.0, derived_state_.drzdx_.data(), nz,
+        derived_state_.sx_.data(), nx_solver, 1.0, derived_state_.drzdp_.data(),
+        nz
+    );
 
-        if (always_check_finite_)
-            checkFinite(srz, ModelQuantity::srz, nplist());
-    } else {
-        for (int ip = 0; ip < nplist(); ip++) {
-            fsrz(
-                &srz[ip * nz], ie, t, computeX_pos(x),
-                state_.unscaledParameters.data(), state_.fixedParameters.data(),
-                state_.h.data(), sx.data(ip), plist(ip)
-            );
-        }
-    }
+    addSlice(derived_state_.drzdp_, srz);
+
+    if (always_check_finite_)
+        checkFinite(srz, ModelQuantity::srz, nplist());
 }
 
 void Model::getEventSigma(
@@ -1468,24 +1431,12 @@ void Model::getEventTimeSensitivity(
 
     std::ranges::fill(stau, 0.0);
 
-    if (pythonGenerated) {
-        for (int ip = 0; ip < nplist(); ip++) {
-            fstau(
-                &stau.at(ip), t, computeX_pos(x),
-                state_.unscaledParameters.data(), state_.fixedParameters.data(),
-                state_.h.data(), dx.data(), state_.total_cl.data(), sx.data(ip),
-                plist(ip), ie
-            );
-        }
-    } else {
-        for (int ip = 0; ip < nplist(); ip++) {
-            fstau(
-                &stau.at(ip), t, computeX_pos(x),
-                state_.unscaledParameters.data(), state_.fixedParameters.data(),
-                state_.h.data(), state_.total_cl.data(), sx.data(ip), plist(ip),
-                ie
-            );
-        }
+    for (int ip = 0; ip < nplist(); ip++) {
+        fstau(
+            &stau.at(ip), t, computeX_pos(x), state_.unscaledParameters.data(),
+            state_.fixedParameters.data(), state_.h.data(), dx.data(),
+            state_.total_cl.data(), sx.data(ip), plist(ip), ie
+        );
     }
 }
 
@@ -1499,22 +1450,11 @@ void Model::addStateEventUpdate(
     std::copy_n(computeX_pos(x), nx_solver, x.data());
 
     // compute update
-    if (pythonGenerated) {
-        fdeltax(
-            derived_state_.deltax_.data(), t, x.data(),
-            state.unscaledParameters.data(), state.fixedParameters.data(),
-            state.h.data(), ie, xdot.data(), xdot_old.data(), x_old.data()
-        );
-
-    } else {
-        // For MATLAB-imported models, use_values_from_trigger_time=true
-        // is not supported, and thus, x_old == x, always.
-        fdeltax(
-            derived_state_.deltax_.data(), t, x_old.data(),
-            state.unscaledParameters.data(), state.fixedParameters.data(),
-            state.h.data(), ie, xdot.data(), xdot_old.data()
-        );
-    }
+    fdeltax(
+        derived_state_.deltax_.data(), t, x.data(),
+        state.unscaledParameters.data(), state.fixedParameters.data(),
+        state.h.data(), ie, xdot.data(), xdot_old.data(), x_old.data()
+    );
 
     if (always_check_finite_) {
         checkFinite(derived_state_.deltax_, ModelQuantity::deltax, t);
@@ -1536,25 +1476,13 @@ void Model::addStateSensitivityEventUpdate(
         derived_state_.deltasx_.assign(nx_solver, 0.0);
 
         // compute update
-        if (pythonGenerated) {
-            fdeltasx(
-                derived_state_.deltasx_.data(), t, x.data(),
-                state_.unscaledParameters.data(), state_.fixedParameters.data(),
-                state_.h.data(), derived_state_.w_.data(), plist(ip), ie,
-                xdot.data(), xdot_old.data(), sx_old.data(ip), &stau.at(ip),
-                state_.total_cl.data(), x_old.data()
-            );
-        } else {
-            // For MATLAB-imported models, use_values_from_trigger_time=true
-            // is not supported, and thus, x_old == x, always.
-            fdeltasx(
-                derived_state_.deltasx_.data(), t, x_old.data(),
-                state_.unscaledParameters.data(), state_.fixedParameters.data(),
-                state_.h.data(), derived_state_.w_.data(), plist(ip), ie,
-                xdot.data(), xdot_old.data(), sx.data(ip), &stau.at(ip),
-                state_.total_cl.data()
-            );
-        }
+        fdeltasx(
+            derived_state_.deltasx_.data(), t, x.data(),
+            state_.unscaledParameters.data(), state_.fixedParameters.data(),
+            state_.h.data(), derived_state_.w_.data(), plist(ip), ie,
+            xdot.data(), xdot_old.data(), sx_old.data(ip), &stau.at(ip),
+            state_.total_cl.data(), x_old.data()
+        );
         if (always_check_finite_) {
             checkFinite(
                 derived_state_.deltasx_, ModelQuantity::deltasx, nplist()
@@ -1576,20 +1504,12 @@ void Model::addAdjointStateEventUpdate(
     derived_state_.deltaxB_.assign(nxtrue_solver * nJ, 0.0);
 
     // compute update
-    if (pythonGenerated) {
-        fdeltaxB(
-            derived_state_.deltaxB_.data(), t, computeX_pos(x),
-            state_.unscaledParameters.data(), state_.fixedParameters.data(),
-            state_.h.data(), dx.data(), ie, xdot.data(), xdot_old.data(),
-            x_old.data(), xB.data(), state_.total_cl.data()
-        );
-    } else {
-        fdeltaxB(
-            derived_state_.deltaxB_.data(), t, computeX_pos(x),
-            state_.unscaledParameters.data(), state_.fixedParameters.data(),
-            state_.h.data(), ie, xdot.data(), xdot_old.data(), xB.data()
-        );
-    }
+    fdeltaxB(
+        derived_state_.deltaxB_.data(), t, computeX_pos(x),
+        state_.unscaledParameters.data(), state_.fixedParameters.data(),
+        state_.h.data(), dx.data(), ie, xdot.data(), xdot_old.data(),
+        x_old.data(), xB.data(), state_.total_cl.data()
+    );
 
     if (always_check_finite_) {
         checkFinite(derived_state_.deltaxB_, ModelQuantity::deltaxB, t);
@@ -1610,21 +1530,12 @@ void Model::addAdjointQuadratureEventUpdate(
     for (int ip = 0; ip < nplist(); ip++) {
         derived_state_.deltaqB_.assign(nJ, 0.0);
 
-        if (pythonGenerated) {
-            fdeltaqB(
-                derived_state_.deltaqB_.data(), t, computeX_pos(x),
-                state_.unscaledParameters.data(), state_.fixedParameters.data(),
-                state_.h.data(), dx.data(), plist(ip), ie, xdot.data(),
-                xdot_old.data(), x_old.data(), xB.data()
-            );
-        } else {
-            fdeltaqB(
-                derived_state_.deltaqB_.data(), t, computeX_pos(x),
-                state_.unscaledParameters.data(), state_.fixedParameters.data(),
-                state_.h.data(), plist(ip), ie, xdot.data(), xdot_old.data(),
-                xB.data()
-            );
-        }
+        fdeltaqB(
+            derived_state_.deltaqB_.data(), t, computeX_pos(x),
+            state_.unscaledParameters.data(), state_.fixedParameters.data(),
+            state_.h.data(), dx.data(), plist(ip), ie, xdot.data(),
+            xdot_old.data(), x_old.data(), xB.data()
+        );
 
         for (int iJ = 0; iJ < nJ; ++iJ)
             xQB.at(ip * nJ + iJ) += derived_state_.deltaqB_.at(iJ);
@@ -1789,7 +1700,6 @@ int Model::checkFinite(
             col_id += " " + getParameterIds()[plist(gsl::narrow<int>(col))];
         break;
     case ModelQuantity::dJydy:
-    case ModelQuantity::dJydy_matlab:
     case ModelQuantity::dJydsigma:
         if (hasObservableIds())
             col_id += " " + getObservableIds()[col];
@@ -2117,12 +2027,7 @@ void Model::checkLLHBufferSize(
         );
 }
 
-void Model::initializeVectors() {
-    sx0data_.clear();
-    if (!pythonGenerated)
-        derived_state_.dxdotdp
-            = AmiVectorArray(nx_solver, nplist(), derived_state_.sunctx_);
-}
+void Model::initializeVectors() { sx0data_.clear(); }
 
 void Model::fy(realtype const t, AmiVector const& x) {
     if (!ny)
@@ -2156,22 +2061,13 @@ void Model::fdydp(realtype const t, AmiVector const& x) {
 
     /* get dydp slice (ny) for current time and parameter */
     for (int ip = 0; ip < nplist(); ip++)
-        if (pythonGenerated) {
-            fdydp(
-                &derived_state_.dydp_.at(ip * ny), t, x_pos,
-                state_.unscaledParameters.data(), state_.fixedParameters.data(),
-                state_.h.data(), plist(ip), derived_state_.w_.data(),
-                state_.total_cl.data(), state_.stotal_cl.data(),
-                derived_state_.spl_.data(), derived_state_.sspl_.data()
-            );
-        } else {
-            fdydp(
-                &derived_state_.dydp_.at(ip * ny), t, x_pos,
-                state_.unscaledParameters.data(), state_.fixedParameters.data(),
-                state_.h.data(), plist(ip), derived_state_.w_.data(),
-                derived_state_.dwdp_.data()
-            );
-        }
+        fdydp(
+            &derived_state_.dydp_.at(ip * ny), t, x_pos,
+            state_.unscaledParameters.data(), state_.fixedParameters.data(),
+            state_.h.data(), plist(ip), derived_state_.w_.data(),
+            state_.total_cl.data(), state_.stotal_cl.data(),
+            derived_state_.spl_.data(), derived_state_.sspl_.data()
+        );
 
     if (always_check_finite_) {
         checkFinite(derived_state_.dydp_, ModelQuantity::dydp, nplist());
@@ -2310,81 +2206,57 @@ void Model::fdJydy(int const it, AmiVector const& x, ExpData const& edata) {
     fy(edata.getTimepoint(it), x);
     fsigmay(it, &edata);
 
-    if (pythonGenerated) {
-        fdJydsigma(it, x, edata);
-        fdsigmaydy(it, &edata);
+    fdJydsigma(it, x, edata);
+    fdsigmaydy(it, &edata);
 
-        setNaNtoZero(derived_state_.dJydsigma_);
-        setNaNtoZero(derived_state_.dsigmaydy_);
-        for (int iyt = 0; iyt < nytrue; iyt++) {
-            if (!derived_state_.dJydy_.at(iyt).capacity())
-                continue;
-            derived_state_.dJydy_.at(iyt).zero();
-            fdJydy_colptrs(derived_state_.dJydy_.at(iyt), iyt);
-            fdJydy_rowvals(derived_state_.dJydy_.at(iyt), iyt);
+    setNaNtoZero(derived_state_.dJydsigma_);
+    setNaNtoZero(derived_state_.dsigmaydy_);
+    for (int iyt = 0; iyt < nytrue; iyt++) {
+        if (!derived_state_.dJydy_.at(iyt).capacity())
+            continue;
+        derived_state_.dJydy_.at(iyt).zero();
+        fdJydy_colptrs(derived_state_.dJydy_.at(iyt), iyt);
+        fdJydy_rowvals(derived_state_.dJydy_.at(iyt), iyt);
 
-            if (!edata.isSetObservedData(it, iyt))
-                continue;
+        if (!edata.isSetObservedData(it, iyt))
+            continue;
 
-            // get dJydy slice (ny) for current timepoint and observable
-            fdJydy(
-                derived_state_.dJydy_.at(iyt).data(), iyt,
-                state_.unscaledParameters.data(), state_.fixedParameters.data(),
-                derived_state_.y_.data(), derived_state_.sigmay_.data(),
-                edata.getObservedDataPtr(it)
+        // get dJydy slice (ny) for current timepoint and observable
+        fdJydy(
+            derived_state_.dJydy_.at(iyt).data(), iyt,
+            state_.unscaledParameters.data(), state_.fixedParameters.data(),
+            derived_state_.y_.data(), derived_state_.sigmay_.data(),
+            edata.getObservedDataPtr(it)
+        );
+
+        // dJydy += dJydsigma * dsigmaydy
+        // C(nJ,ny)  A(nJ,ny)  * B(ny,ny)
+        // sparse    dense       dense
+        derived_state_.dJydy_dense_.zero();
+        amici_dgemm(
+            BLASLayout::colMajor, BLASTranspose::noTrans,
+            BLASTranspose::noTrans, nJ, ny, ny, 1.0,
+            &derived_state_.dJydsigma_.at(iyt * nJ * ny), nJ,
+            derived_state_.dsigmaydy_.data(), ny, 1.0,
+            derived_state_.dJydy_dense_.data(), nJ
+        );
+
+        auto tmp_sparse
+            = SUNMatrixWrapper(derived_state_.dJydy_dense_, 0.0, CSC_MAT);
+        auto ret
+            = SUNMatScaleAdd(1.0, derived_state_.dJydy_.at(iyt), tmp_sparse);
+        if (ret != SUN_SUCCESS) {
+            throw AmiException(
+                "SUNMatScaleAdd failed with status %d in %s", ret, __func__
             );
-
-            // dJydy += dJydsigma * dsigmaydy
-            // C(nJ,ny)  A(nJ,ny)  * B(ny,ny)
-            // sparse    dense       dense
-            derived_state_.dJydy_dense_.zero();
-            amici_dgemm(
-                BLASLayout::colMajor, BLASTranspose::noTrans,
-                BLASTranspose::noTrans, nJ, ny, ny, 1.0,
-                &derived_state_.dJydsigma_.at(iyt * nJ * ny), nJ,
-                derived_state_.dsigmaydy_.data(), ny, 1.0,
-                derived_state_.dJydy_dense_.data(), nJ
-            );
-
-            auto tmp_sparse
-                = SUNMatrixWrapper(derived_state_.dJydy_dense_, 0.0, CSC_MAT);
-            auto ret = SUNMatScaleAdd(
-                1.0, derived_state_.dJydy_.at(iyt), tmp_sparse
-            );
-            if (ret != SUN_SUCCESS) {
-                throw AmiException(
-                    "SUNMatScaleAdd failed with status %d in %s", ret, __func__
-                );
-            }
-            derived_state_.dJydy_.at(iyt).refresh();
-
-            if (always_check_finite_) {
-                checkFinite(
-                    gsl::make_span(derived_state_.dJydy_.at(iyt).get()),
-                    ModelQuantity::dJydy, ny
-                );
-            }
         }
-    } else {
-        std::ranges::fill(derived_state_.dJydy_matlab_, 0.0);
-        for (int iyt = 0; iyt < nytrue; iyt++) {
-            if (!edata.isSetObservedData(it, iyt))
-                continue;
-            fdJydy(
-                &derived_state_.dJydy_matlab_.at(iyt * ny * nJ), iyt,
-                state_.unscaledParameters.data(), state_.fixedParameters.data(),
-                derived_state_.y_.data(), derived_state_.sigmay_.data(),
-                edata.getObservedDataPtr(it)
+        derived_state_.dJydy_.at(iyt).refresh();
+
+        if (always_check_finite_) {
+            checkFinite(
+                gsl::make_span(derived_state_.dJydy_.at(iyt).get()),
+                ModelQuantity::dJydy, ny
             );
-            if (always_check_finite_) {
-                // get dJydy slice (ny) for current timepoint and observable
-                checkFinite(
-                    gsl::span<realtype>(
-                        &derived_state_.dJydy_matlab_[iyt * ny * nJ], ny * nJ
-                    ),
-                    ModelQuantity::dJydy, ny
-                );
-            }
         }
     }
 }
@@ -2440,27 +2312,16 @@ void Model::fdJydp(int const it, AmiVector const& x, ExpData const& edata) {
         if (!edata.isSetObservedData(it, iyt))
             continue;
 
-        if (pythonGenerated) {
-            // dJydp = 1.0 * dJydp +  1.0 * dJydy * dydp
-            for (int iplist = 0; iplist < nplist(); ++iplist) {
-                derived_state_.dJydy_.at(iyt).multiply(
-                    gsl::span<realtype>(
-                        &derived_state_.dJydp_.at(iplist * nJ), nJ
-                    ),
-                    gsl::span<realtype const>(
-                        &derived_state_.dydp_.at(iplist * ny), ny
-                    )
-                );
-            }
-        } else {
-            amici_dgemm(
-                BLASLayout::colMajor, BLASTranspose::noTrans,
-                BLASTranspose::noTrans, nJ, nplist(), ny, 1.0,
-                &derived_state_.dJydy_matlab_.at(iyt * nJ * ny), nJ,
-                derived_state_.dydp_.data(), ny, 1.0,
-                derived_state_.dJydp_.data(), nJ
+        // dJydp = 1.0 * dJydp +  1.0 * dJydy * dydp
+        for (int iplist = 0; iplist < nplist(); ++iplist) {
+            derived_state_.dJydy_.at(iyt).multiply(
+                gsl::span<realtype>(&derived_state_.dJydp_.at(iplist * nJ), nJ),
+                gsl::span<realtype const>(
+                    &derived_state_.dydp_.at(iplist * ny), ny
+                )
             );
         }
+
         // dJydp = 1.0 * dJydp +  1.0 * dJydsigma * dsigmaydp
         amici_dgemm(
             BLASLayout::colMajor, BLASTranspose::noTrans,
@@ -2492,22 +2353,10 @@ void Model::fdJydx(int const it, AmiVector const& x, ExpData const& edata) {
         //          M  K            K  N                       M  N
         //           lda             ldb                        ldc
 
-        if (pythonGenerated) {
-            for (int ix = 0; ix < nx_solver; ++ix) {
-                derived_state_.dJydy_.at(iyt).multiply(
-                    gsl::span<realtype>(&derived_state_.dJydx_.at(ix * nJ), nJ),
-                    gsl::span<realtype const>(
-                        &derived_state_.dydx_.at(ix * ny), ny
-                    )
-                );
-            }
-        } else {
-            amici_dgemm(
-                BLASLayout::colMajor, BLASTranspose::noTrans,
-                BLASTranspose::noTrans, nJ, nx_solver, ny, 1.0,
-                &derived_state_.dJydy_matlab_.at(iyt * ny * nJ), nJ,
-                derived_state_.dydx_.data(), ny, 1.0,
-                derived_state_.dJydx_.data(), nJ
+        for (int ix = 0; ix < nx_solver; ++ix) {
+            derived_state_.dJydy_.at(iyt).multiply(
+                gsl::span<realtype>(&derived_state_.dJydx_.at(ix * nJ), nJ),
+                gsl::span<realtype const>(&derived_state_.dydx_.at(ix * ny), ny)
             );
         }
     }
@@ -2958,45 +2807,30 @@ void Model::fdwdp(realtype const t, realtype const* x, bool include_static) {
 
     fw(t, x, include_static);
     derived_state_.dwdp_.zero();
-    if (pythonGenerated) {
-        if (!ndwdp)
-            return;
-        fsspl(t);
-        fdwdw(t, x, include_static);
-        if (include_static) {
-            derived_state_.dwdp_hierarchical_.at(0).zero();
-            fdwdp_colptrs(derived_state_.dwdp_hierarchical_.at(0));
-            fdwdp_rowvals(derived_state_.dwdp_hierarchical_.at(0));
-        }
-        fdwdp(
-            derived_state_.dwdp_hierarchical_.at(0).data(), t, x,
-            state_.unscaledParameters.data(), state_.fixedParameters.data(),
-            state_.h.data(), derived_state_.w_.data(), state_.total_cl.data(),
-            state_.stotal_cl.data(), derived_state_.spl_.data(),
-            derived_state_.sspl_.data(), include_static
-        );
+    if (!ndwdp)
+        return;
+    fsspl(t);
+    fdwdw(t, x, include_static);
+    if (include_static) {
+        derived_state_.dwdp_hierarchical_.at(0).zero();
+        fdwdp_colptrs(derived_state_.dwdp_hierarchical_.at(0));
+        fdwdp_rowvals(derived_state_.dwdp_hierarchical_.at(0));
+    }
+    fdwdp(
+        derived_state_.dwdp_hierarchical_.at(0).data(), t, x,
+        state_.unscaledParameters.data(), state_.fixedParameters.data(),
+        state_.h.data(), derived_state_.w_.data(), state_.total_cl.data(),
+        state_.stotal_cl.data(), derived_state_.spl_.data(),
+        derived_state_.sspl_.data(), include_static
+    );
 
-        for (int irecursion = 1; irecursion <= w_recursion_depth;
-             irecursion++) {
-            derived_state_.dwdw_.sparse_multiply(
-                derived_state_.dwdp_hierarchical_.at(irecursion),
-                derived_state_.dwdp_hierarchical_.at(irecursion - 1)
-            );
-        }
-        derived_state_.dwdp_.sparse_sum(derived_state_.dwdp_hierarchical_);
-
-    } else {
-        if (!derived_state_.dwdp_.capacity())
-            return;
-        // matlab generated
-        fdwdp(
-            derived_state_.dwdp_.data(), t, x, state_.unscaledParameters.data(),
-            state_.fixedParameters.data(), state_.h.data(),
-            derived_state_.w_.data(), state_.total_cl.data(),
-            state_.stotal_cl.data(), derived_state_.spl_.data(),
-            derived_state_.sspl_.data()
+    for (int irecursion = 1; irecursion <= w_recursion_depth; irecursion++) {
+        derived_state_.dwdw_.sparse_multiply(
+            derived_state_.dwdp_hierarchical_.at(irecursion),
+            derived_state_.dwdp_hierarchical_.at(irecursion - 1)
         );
     }
+    derived_state_.dwdp_.sparse_sum(derived_state_.dwdp_hierarchical_);
 
     if (always_check_finite_) {
         checkFinite(derived_state_.dwdp_, ModelQuantity::dwdp, t);
@@ -3012,7 +2846,6 @@ void Model::fdwdx(realtype const t, realtype const* x, bool include_static) {
     fw(t, x, include_static);
 
     derived_state_.dwdx_.zero();
-    if (pythonGenerated) {
         fdwdw(t, x, include_static);
 
         auto&& dwdx_hierarchical_0 = derived_state_.dwdx_hierarchical_.at(0);
@@ -3039,18 +2872,6 @@ void Model::fdwdx(realtype const t, realtype const* x, bool include_static) {
             );
         }
         derived_state_.dwdx_.sparse_sum(derived_state_.dwdx_hierarchical_);
-
-    } else {
-        if (!derived_state_.dwdx_.capacity())
-            return;
-        derived_state_.dwdx_.zero();
-        fdwdx(
-            derived_state_.dwdx_.data(), t, x, state_.unscaledParameters.data(),
-            state_.fixedParameters.data(), state_.h.data(),
-            derived_state_.w_.data(), state_.total_cl.data(),
-            derived_state_.spl_.data()
-        );
-    }
 
     if (always_check_finite_) {
         checkFinite(derived_state_.dwdx_, ModelQuantity::dwdx, t);
@@ -3250,13 +3071,7 @@ std::vector<int> const& Model::getReinitializationStateIdxs() const {
     return simulation_parameters_.reinitialization_state_idxs_sim;
 }
 
-AmiVectorArray const& Model::get_dxdotdp() const {
-    assert(!pythonGenerated);
-    return derived_state_.dxdotdp;
-}
-
 SUNMatrixWrapper const& Model::get_dxdotdp_full() const {
-    assert(pythonGenerated);
     return derived_state_.dxdotdp_full;
 }
 

--- a/src/model_header.template.h
+++ b/src/model_header.template.h
@@ -138,7 +138,6 @@ class Model_TPL_MODELNAME : public amici::Model_TPL_MODEL_TYPE_UPPER {
                   0,                                       // nnz
                   TPL_UBW,                                 // ubw
                   TPL_LBW,                                 // lbw
-                  true,                                    // pythonGenerated
                   TPL_NDXDOTDP_EXPLICIT,                   // ndxdotdp_explicit
                   TPL_NDXDOTDX_EXPLICIT,                   // ndxdotdx_explicit
                   TPL_W_RECURSION_DEPTH                    // w_recursion_depth

--- a/src/model_ode.cpp
+++ b/src/model_ode.cpp
@@ -30,40 +30,31 @@ void Model_ODE::fJSparse(
 void Model_ODE::fJSparse(realtype const t, const_N_Vector x, SUNMatrix J) {
     auto const x_pos = computeX_pos(x);
     fdwdx(t, N_VGetArrayPointerConst(x_pos), false);
-    if (pythonGenerated) {
-        auto JSparse = SUNMatrixWrapper(J);
-        // python generated
-        derived_state_.dxdotdx_explicit.zero();
-        derived_state_.dxdotdx_implicit.zero();
-        if (derived_state_.dxdotdx_explicit.capacity()) {
-            fdxdotdx_explicit_colptrs(derived_state_.dxdotdx_explicit);
-            fdxdotdx_explicit_rowvals(derived_state_.dxdotdx_explicit);
-            fdxdotdx_explicit(
-                derived_state_.dxdotdx_explicit.data(), t,
-                N_VGetArrayPointerConst(x_pos),
-                state_.unscaledParameters.data(), state_.fixedParameters.data(),
-                state_.h.data(), derived_state_.w_.data()
-            );
-        }
-        fdxdotdw(t, x_pos);
-        /* Sparse matrix multiplication
-         dxdotdx_implicit += dxdotdw * dwdx */
-        derived_state_.dxdotdw_.sparse_multiply(
-            derived_state_.dxdotdx_implicit, derived_state_.dwdx_
-        );
-
-        JSparse.sparse_add(
-            derived_state_.dxdotdx_explicit, 1.0,
-            derived_state_.dxdotdx_implicit, 1.0
-        );
-    } else {
-        fJSparse(
-            static_cast<SUNMatrixContent_Sparse>(SM_CONTENT_S(J)), t,
+    auto JSparse = SUNMatrixWrapper(J);
+    // python generated
+    derived_state_.dxdotdx_explicit.zero();
+    derived_state_.dxdotdx_implicit.zero();
+    if (derived_state_.dxdotdx_explicit.capacity()) {
+        fdxdotdx_explicit_colptrs(derived_state_.dxdotdx_explicit);
+        fdxdotdx_explicit_rowvals(derived_state_.dxdotdx_explicit);
+        fdxdotdx_explicit(
+            derived_state_.dxdotdx_explicit.data(), t,
             N_VGetArrayPointerConst(x_pos), state_.unscaledParameters.data(),
             state_.fixedParameters.data(), state_.h.data(),
-            derived_state_.w_.data(), derived_state_.dwdx_.data()
+            derived_state_.w_.data()
         );
     }
+    fdxdotdw(t, x_pos);
+    /* Sparse matrix multiplication
+     dxdotdx_implicit += dxdotdw * dwdx */
+    derived_state_.dxdotdw_.sparse_multiply(
+        derived_state_.dxdotdx_implicit, derived_state_.dwdx_
+    );
+
+    JSparse.sparse_add(
+        derived_state_.dxdotdx_explicit, 1.0, derived_state_.dxdotdx_implicit,
+        1.0
+    );
 }
 
 void Model_ODE::
@@ -148,45 +139,31 @@ void Model_ODE::fdxdotdp(realtype const t, const_N_Vector x) {
     auto const x_pos = computeX_pos(x);
     fdwdp(t, N_VGetArrayPointerConst(x_pos), false);
 
-    if (pythonGenerated) {
-        // python generated
-        derived_state_.dxdotdp_explicit.zero();
-        derived_state_.dxdotdp_implicit.zero();
-        if (derived_state_.dxdotdp_explicit.capacity()) {
-            fdxdotdp_explicit_colptrs(derived_state_.dxdotdp_explicit);
-            fdxdotdp_explicit_rowvals(derived_state_.dxdotdp_explicit);
-            fdxdotdp_explicit(
-                derived_state_.dxdotdp_explicit.data(), t,
-                N_VGetArrayPointerConst(x_pos),
-                state_.unscaledParameters.data(), state_.fixedParameters.data(),
-                state_.h.data(), derived_state_.w_.data()
-            );
-        }
-
-        fdxdotdw(t, x_pos);
-        /* Sparse matrix multiplication
-         dxdotdp_implicit += dxdotdw * dwdp */
-        derived_state_.dxdotdw_.sparse_multiply(
-            derived_state_.dxdotdp_implicit, derived_state_.dwdp_
+    // python generated
+    derived_state_.dxdotdp_explicit.zero();
+    derived_state_.dxdotdp_implicit.zero();
+    if (derived_state_.dxdotdp_explicit.capacity()) {
+        fdxdotdp_explicit_colptrs(derived_state_.dxdotdp_explicit);
+        fdxdotdp_explicit_rowvals(derived_state_.dxdotdp_explicit);
+        fdxdotdp_explicit(
+            derived_state_.dxdotdp_explicit.data(), t,
+            N_VGetArrayPointerConst(x_pos), state_.unscaledParameters.data(),
+            state_.fixedParameters.data(), state_.h.data(),
+            derived_state_.w_.data()
         );
-
-        derived_state_.dxdotdp_full.sparse_add(
-            derived_state_.dxdotdp_explicit, 1.0,
-            derived_state_.dxdotdp_implicit, 1.0
-        );
-    } else {
-        // matlab generated
-        for (int ip = 0; ip < nplist(); ip++) {
-            N_VConst(0.0, derived_state_.dxdotdp.getNVector(ip));
-            fdxdotdp(
-                derived_state_.dxdotdp.data(ip), t,
-                N_VGetArrayPointerConst(x_pos),
-                state_.unscaledParameters.data(), state_.fixedParameters.data(),
-                state_.h.data(), plist(ip), derived_state_.w_.data(),
-                derived_state_.dwdp_.data()
-            );
-        }
     }
+
+    fdxdotdw(t, x_pos);
+    /* Sparse matrix multiplication
+     dxdotdp_implicit += dxdotdw * dwdp */
+    derived_state_.dxdotdw_.sparse_multiply(
+        derived_state_.dxdotdp_implicit, derived_state_.dwdp_
+    );
+
+    derived_state_.dxdotdp_full.sparse_add(
+        derived_state_.dxdotdp_explicit, 1.0, derived_state_.dxdotdp_implicit,
+        1.0
+    );
 }
 
 void Model_ODE::
@@ -198,17 +175,6 @@ std::unique_ptr<Solver> Model_ODE::getSolver() {
     return std::unique_ptr<Solver>(new CVodeSolver());
 }
 
-void Model_ODE::fJSparse(
-    SUNMatrixContent_Sparse /*JSparse*/, realtype const /*t*/,
-    realtype const* /*x*/, realtype const* /*p*/, realtype const* /*k*/,
-    realtype const* /*h*/, realtype const* /*w*/, realtype const* /*dwdx*/
-) {
-    throw AmiException(
-        "Requested functionality is not supported as %s "
-        "is not implemented for this model!",
-        __func__
-    ); // not implemented
-}
 
 void Model_ODE::fJSparse(
     realtype* /*JSparse*/, realtype const /*t*/, realtype const* /*x*/,
@@ -250,17 +216,6 @@ void Model_ODE::froot(
     ); // not implemented
 }
 
-void Model_ODE::fdxdotdp(
-    realtype* /*dxdotdp*/, realtype const /*t*/, realtype const* /*x*/,
-    realtype const* /*p*/, realtype const* /*k*/, realtype const* /*h*/,
-    int const /*ip*/, realtype const* /*w*/, realtype const* /*dwdp*/
-) {
-    throw AmiException(
-        "Requested functionality is not supported as %s "
-        "is not implemented for this model!",
-        __func__
-    ); // not implemented
-}
 
 void Model_ODE::fdxdotdp_explicit(
     realtype* /*dxdotdp_explicit*/, realtype const /*t*/, realtype const* /*x*/,
@@ -412,28 +367,9 @@ void Model_ODE::fqBdot(
     N_VConst(0.0, qBdot);
     fdxdotdp(t, x);
 
-    if (pythonGenerated) {
-        /* call multiplication */
-        derived_state_.dxdotdp_full.multiply(qBdot, xB, state_.plist, true);
-        N_VScale(-1.0, qBdot, qBdot);
-    } else {
-        /* was matlab generated */
-        for (int ip = 0; ip < nplist(); ip++) {
-            for (int ix = 0; ix < nxtrue_solver; ix++)
-                NV_Ith_S(qBdot, ip * nJ)
-                    -= NV_Ith_S(xB, ix) * derived_state_.dxdotdp.at(ix, ip);
-            // second order part
-            for (int iJ = 1; iJ < nJ; iJ++)
-                for (int ix = 0; ix < nxtrue_solver; ix++)
-                    NV_Ith_S(qBdot, ip * nJ + iJ)
-                        -= NV_Ith_S(xB, ix)
-                               * derived_state_.dxdotdp.at(
-                                   ix + iJ * nxtrue_solver, ip
-                               )
-                           + NV_Ith_S(xB, ix + iJ * nxtrue_solver)
-                                 * derived_state_.dxdotdp.at(ix, ip);
-        }
-    }
+    /* call multiplication */
+    derived_state_.dxdotdp_full.multiply(qBdot, xB, state_.plist, true);
+    N_VScale(-1.0, qBdot, qBdot);
 }
 
 void Model_ODE::fxBdot_ss(
@@ -499,21 +435,16 @@ void Model_ODE::fsxdot(
         fJSparse(t, x, derived_state_.J_);
         derived_state_.J_.refresh();
     }
-    if (pythonGenerated) {
-        /* copy dxdotdp and the implicit version over */
-        // initialize
-        N_VConst(0.0, sxdot);
-        realtype* sxdot_tmp = N_VGetArrayPointer(sxdot);
 
-        derived_state_.dxdotdp_full.scatter(
-            plist(ip), 1.0, nullptr, gsl::make_span(sxdot_tmp, nx_solver), 0,
-            nullptr, 0
-        );
+    /* copy dxdotdp and the implicit version over */
+    // initialize
+    N_VConst(0.0, sxdot);
+    realtype* sxdot_tmp = N_VGetArrayPointer(sxdot);
+    derived_state_.dxdotdp_full.scatter(
+        plist(ip), 1.0, nullptr, gsl::make_span(sxdot_tmp, nx_solver), 0,
+        nullptr, 0
+    );
 
-    } else {
-        /* copy dxdotdp over */
-        N_VScale(1.0, derived_state_.dxdotdp.getNVector(ip), sxdot);
-    }
     derived_state_.J_.multiply(sxdot, sx);
 }
 

--- a/src/model_ode.cpp
+++ b/src/model_ode.cpp
@@ -175,7 +175,6 @@ std::unique_ptr<Solver> Model_ODE::getSolver() {
     return std::unique_ptr<Solver>(new CVodeSolver());
 }
 
-
 void Model_ODE::fJSparse(
     realtype* /*JSparse*/, realtype const /*t*/, realtype const* /*x*/,
     realtype const* /*p*/, realtype const* /*k*/, realtype const* /*h*/,
@@ -215,7 +214,6 @@ void Model_ODE::froot(
         __func__
     ); // not implemented
 }
-
 
 void Model_ODE::fdxdotdp_explicit(
     realtype* /*dxdotdp_explicit*/, realtype const /*t*/, realtype const* /*x*/,

--- a/src/model_state.cpp
+++ b/src/model_state.cpp
@@ -23,69 +23,52 @@ ModelStateDerived::ModelStateDerived(ModelDimensions const& dim)
     , x_rdata_(dim.nx_rdata, 0.0)
     , sx_rdata_(dim.nx_rdata, 0.0)
     , x_pos_tmp_(dim.nx_solver, sunctx_) {
-    // If Matlab wrapped: dxdotdp is a full AmiVector,
-    // if Python wrapped: dxdotdp_explicit and dxdotdp_implicit are CSC matrices
-    if (dim.pythonGenerated) {
+    dwdw_ = SUNMatrixWrapper(dim.nw, dim.nw, dim.ndwdw, CSC_MAT, sunctx_);
+    // size dynamically adapted for dwdx_ and dwdp_
+    dwdx_ = SUNMatrixWrapper(dim.nw, dim.nx_solver, 0, CSC_MAT, sunctx_);
+    dwdp_ = SUNMatrixWrapper(dim.nw, dim.np, 0, CSC_MAT, sunctx_);
 
-        dwdw_ = SUNMatrixWrapper(dim.nw, dim.nw, dim.ndwdw, CSC_MAT, sunctx_);
-        // size dynamically adapted for dwdx_ and dwdp_
-        dwdx_ = SUNMatrixWrapper(dim.nw, dim.nx_solver, 0, CSC_MAT, sunctx_);
-        dwdp_ = SUNMatrixWrapper(dim.nw, dim.np, 0, CSC_MAT, sunctx_);
-
-        for (int irec = 0; irec <= dim.w_recursion_depth; ++irec) {
-            /* for the first element we know the exact size, while for all
-               others we guess the size*/
-            dwdp_hierarchical_.emplace_back(
-                dim.nw, dim.np, irec * dim.ndwdw + dim.ndwdp, CSC_MAT, sunctx_
-            );
-            dwdx_hierarchical_.emplace_back(
-                dim.nw, dim.nx_solver, irec * dim.ndwdw + dim.ndwdx, CSC_MAT,
-                sunctx_
-            );
-        }
-        assert(
-            gsl::narrow<int>(dwdp_hierarchical_.size())
-            == dim.w_recursion_depth + 1
+    for (int irec = 0; irec <= dim.w_recursion_depth; ++irec) {
+        /* for the first element we know the exact size, while for all
+           others we guess the size*/
+        dwdp_hierarchical_.emplace_back(
+            dim.nw, dim.np, irec * dim.ndwdw + dim.ndwdp, CSC_MAT, sunctx_
         );
-        assert(
-            gsl::narrow<int>(dwdx_hierarchical_.size())
-            == dim.w_recursion_depth + 1
-        );
-
-        dxdotdp_explicit = SUNMatrixWrapper(
-            dim.nx_solver, dim.np, dim.ndxdotdp_explicit, CSC_MAT, sunctx_
-        );
-        // guess size, will be dynamically reallocated
-        dxdotdp_implicit = SUNMatrixWrapper(
-            dim.nx_solver, dim.np, dim.ndwdp + dim.ndxdotdw, CSC_MAT, sunctx_
-        );
-        dxdotdx_explicit = SUNMatrixWrapper(
-            dim.nx_solver, dim.nx_solver, dim.ndxdotdx_explicit, CSC_MAT,
+        dwdx_hierarchical_.emplace_back(
+            dim.nw, dim.nx_solver, irec * dim.ndwdw + dim.ndwdx, CSC_MAT,
             sunctx_
         );
-        // guess size, will be dynamically reallocated
-        dxdotdx_implicit = SUNMatrixWrapper(
-            dim.nx_solver, dim.nx_solver, dim.ndwdx + dim.ndxdotdw, CSC_MAT,
-            sunctx_
-        );
-        // dynamically allocate on first call
-        dxdotdp_full
-            = SUNMatrixWrapper(dim.nx_solver, dim.np, 0, CSC_MAT, sunctx_);
-
-        for (int iytrue = 0; iytrue < dim.nytrue; ++iytrue)
-            dJydy_.emplace_back(
-                dim.nJ, dim.ny, dim.ndJydy.at(iytrue), CSC_MAT, sunctx_
-            );
-
-        dJydy_dense_ = SUNMatrixWrapper(dim.nJ, dim.ny, sunctx_);
-    } else {
-        dwdx_ = SUNMatrixWrapper(
-            dim.nw, dim.nx_solver, dim.ndwdx, CSC_MAT, sunctx_
-        );
-        dwdp_ = SUNMatrixWrapper(dim.nw, dim.np, dim.ndwdp, CSC_MAT, sunctx_);
-        dJydy_matlab_
-            = std::vector<realtype>(dim.nJ * dim.nytrue * dim.ny, 0.0);
     }
+    assert(
+        gsl::narrow<int>(dwdp_hierarchical_.size()) == dim.w_recursion_depth + 1
+    );
+    assert(
+        gsl::narrow<int>(dwdx_hierarchical_.size()) == dim.w_recursion_depth + 1
+    );
+
+    dxdotdp_explicit = SUNMatrixWrapper(
+        dim.nx_solver, dim.np, dim.ndxdotdp_explicit, CSC_MAT, sunctx_
+    );
+    // guess size, will be dynamically reallocated
+    dxdotdp_implicit = SUNMatrixWrapper(
+        dim.nx_solver, dim.np, dim.ndwdp + dim.ndxdotdw, CSC_MAT, sunctx_
+    );
+    dxdotdx_explicit = SUNMatrixWrapper(
+        dim.nx_solver, dim.nx_solver, dim.ndxdotdx_explicit, CSC_MAT, sunctx_
+    );
+    // guess size, will be dynamically reallocated
+    dxdotdx_implicit = SUNMatrixWrapper(
+        dim.nx_solver, dim.nx_solver, dim.ndwdx + dim.ndxdotdw, CSC_MAT, sunctx_
+    );
+    // dynamically allocate on first call
+    dxdotdp_full = SUNMatrixWrapper(dim.nx_solver, dim.np, 0, CSC_MAT, sunctx_);
+
+    for (int iytrue = 0; iytrue < dim.nytrue; ++iytrue)
+        dJydy_.emplace_back(
+            dim.nJ, dim.ny, dim.ndJydy.at(iytrue), CSC_MAT, sunctx_
+        );
+
+    dJydy_dense_ = SUNMatrixWrapper(dim.nJ, dim.ny, sunctx_);
 }
 
 } // namespace amici

--- a/src/newton_solver.cpp
+++ b/src/newton_solver.cpp
@@ -64,15 +64,15 @@ void NewtonSolver::computeNewtonSensis(
         );
     }
 
-        for (int ip = 0; ip < model.nplist(); ip++) {
-            N_VConst(0.0, sx.getNVector(ip));
-            model.get_dxdotdp_full().scatter(
-                model.plist(ip), -1.0, nullptr,
-                gsl::make_span(sx.getNVector(ip)), 0, nullptr, 0
-            );
+    for (int ip = 0; ip < model.nplist(); ip++) {
+        N_VConst(0.0, sx.getNVector(ip));
+        model.get_dxdotdp_full().scatter(
+            model.plist(ip), -1.0, nullptr, gsl::make_span(sx.getNVector(ip)),
+            0, nullptr, 0
+        );
 
-            solveLinearSystem(sx[ip]);
-        }
+        solveLinearSystem(sx[ip]);
+    }
 }
 
 void NewtonSolver::prepareLinearSystem(Model& model, DEStateView const& state) {

--- a/src/newton_solver.cpp
+++ b/src/newton_solver.cpp
@@ -64,7 +64,6 @@ void NewtonSolver::computeNewtonSensis(
         );
     }
 
-    if (model.pythonGenerated) {
         for (int ip = 0; ip < model.nplist(); ip++) {
             N_VConst(0.0, sx.getNVector(ip));
             model.get_dxdotdp_full().scatter(
@@ -74,14 +73,6 @@ void NewtonSolver::computeNewtonSensis(
 
             solveLinearSystem(sx[ip]);
         }
-    } else {
-        for (int ip = 0; ip < model.nplist(); ip++) {
-            for (int ix = 0; ix < model.nx_solver; ix++)
-                sx.at(ix, ip) = -model.get_dxdotdp().at(ix, ip);
-
-            solveLinearSystem(sx[ip]);
-        }
-    }
 }
 
 void NewtonSolver::prepareLinearSystem(Model& model, DEStateView const& state) {


### PR DESCRIPTION
Get rid of the Python-generated code flag and any MATLAB-specific model functions.

Related to #2727.