### PR TITLE
refactor: 0-based indexing in `Model::z2event_`

### DIFF
--- a/models/model_calvetti_py/Jy.cpp
+++ b/models/model_calvetti_py/Jy.cpp
@@ -1,10 +1,7 @@
 #include "amici/symbolic_functions.h"
 #include "amici/defines.h"
-#include "sundials/sundials_types.h"
 
-#include <gsl/gsl-lite.hpp>
 #include <algorithm>
-
 #include "k.h"
 #include "y.h"
 #include "sigmay.h"

--- a/models/model_calvetti_py/create_splines.cpp
+++ b/models/model_calvetti_py/create_splines.cpp
@@ -1,10 +1,7 @@
 #include "amici/symbolic_functions.h"
 #include "amici/defines.h"
-#include "sundials/sundials_types.h"
 
-#include <gsl/gsl-lite.hpp>
 #include <algorithm>
-
 #include "amici/splinefunctions.h"
 #include <vector>
 #include "k.h"

--- a/models/model_calvetti_py/dJydsigma.cpp
+++ b/models/model_calvetti_py/dJydsigma.cpp
@@ -1,10 +1,7 @@
 #include "amici/symbolic_functions.h"
 #include "amici/defines.h"
-#include "sundials/sundials_types.h"
 
-#include <gsl/gsl-lite.hpp>
 #include <algorithm>
-
 #include "k.h"
 #include "y.h"
 #include "sigmay.h"

--- a/models/model_calvetti_py/dJydy.cpp
+++ b/models/model_calvetti_py/dJydy.cpp
@@ -51,11 +51,10 @@ void dJydy_rowvals_model_calvetti_py(SUNMatrixWrapper &dJydy, int index){
 
 #include "amici/symbolic_functions.h"
 #include "amici/defines.h"
-#include "sundials/sundials_types.h"
 
-#include <gsl/gsl-lite.hpp>
 #include <algorithm>
-
+#include <sundials/sundials_types.h>
+#include <gsl/gsl-lite.hpp>
 #include "k.h"
 #include "y.h"
 #include "sigmay.h"

--- a/models/model_calvetti_py/dwdw.cpp
+++ b/models/model_calvetti_py/dwdw.cpp
@@ -41,11 +41,10 @@ void dwdw_rowvals_model_calvetti_py(SUNMatrixWrapper &dwdw){
 
 #include "amici/symbolic_functions.h"
 #include "amici/defines.h"
-#include "sundials/sundials_types.h"
 
-#include <gsl/gsl-lite.hpp>
 #include <algorithm>
-
+#include <sundials/sundials_types.h>
+#include <gsl/gsl-lite.hpp>
 #include "x.h"
 #include "k.h"
 #include "h.h"

--- a/models/model_calvetti_py/dwdx.cpp
+++ b/models/model_calvetti_py/dwdx.cpp
@@ -41,11 +41,10 @@ void dwdx_rowvals_model_calvetti_py(SUNMatrixWrapper &dwdx){
 
 #include "amici/symbolic_functions.h"
 #include "amici/defines.h"
-#include "sundials/sundials_types.h"
 
-#include <gsl/gsl-lite.hpp>
 #include <algorithm>
-
+#include <sundials/sundials_types.h>
+#include <gsl/gsl-lite.hpp>
 #include "x.h"
 #include "k.h"
 #include "h.h"

--- a/models/model_calvetti_py/dxdotdw.cpp
+++ b/models/model_calvetti_py/dxdotdw.cpp
@@ -41,11 +41,10 @@ void dxdotdw_rowvals_model_calvetti_py(SUNMatrixWrapper &dxdotdw){
 
 #include "amici/symbolic_functions.h"
 #include "amici/defines.h"
-#include "sundials/sundials_types.h"
 
-#include <gsl/gsl-lite.hpp>
 #include <algorithm>
-
+#include <sundials/sundials_types.h>
+#include <gsl/gsl-lite.hpp>
 #include "x.h"
 #include "k.h"
 #include "h.h"

--- a/models/model_calvetti_py/dxdotdx_explicit.cpp
+++ b/models/model_calvetti_py/dxdotdx_explicit.cpp
@@ -41,11 +41,10 @@ void dxdotdx_explicit_rowvals_model_calvetti_py(SUNMatrixWrapper &dxdotdx_explic
 
 #include "amici/symbolic_functions.h"
 #include "amici/defines.h"
-#include "sundials/sundials_types.h"
 
-#include <gsl/gsl-lite.hpp>
 #include <algorithm>
-
+#include <sundials/sundials_types.h>
+#include <gsl/gsl-lite.hpp>
 #include "x.h"
 #include "k.h"
 #include "h.h"

--- a/models/model_calvetti_py/dydx.cpp
+++ b/models/model_calvetti_py/dydx.cpp
@@ -1,10 +1,7 @@
 #include "amici/symbolic_functions.h"
 #include "amici/defines.h"
-#include "sundials/sundials_types.h"
 
-#include <gsl/gsl-lite.hpp>
 #include <algorithm>
-
 #include "x.h"
 #include "k.h"
 #include "h.h"

--- a/models/model_calvetti_py/explicit_roots.cpp
+++ b/models/model_calvetti_py/explicit_roots.cpp
@@ -1,10 +1,7 @@
 #include "amici/symbolic_functions.h"
 #include "amici/defines.h"
-#include "sundials/sundials_types.h"
 
-#include <gsl/gsl-lite.hpp>
 #include <algorithm>
-
 #include <vector>
 #include "k.h"
 

--- a/models/model_calvetti_py/model_calvetti_py.h
+++ b/models/model_calvetti_py/model_calvetti_py.h
@@ -557,7 +557,7 @@ class Model_model_calvetti_py : public amici::Model_DAE {
      * @return AMICI git commit hash
      */
     std::string getAmiciCommit() const override {
-        return "570c71d2a041ed15d548e826df3d97e05d124309";
+        return "d5492c37f7dbc5faa374128e3559b96518e9a937";
     }
 
     bool hasQuadraticLLH() const override {

--- a/models/model_calvetti_py/root.cpp
+++ b/models/model_calvetti_py/root.cpp
@@ -1,10 +1,7 @@
 #include "amici/symbolic_functions.h"
 #include "amici/defines.h"
-#include "sundials/sundials_types.h"
 
-#include <gsl/gsl-lite.hpp>
 #include <algorithm>
-
 #include "x.h"
 #include "k.h"
 #include "h.h"

--- a/models/model_calvetti_py/sigmay.cpp
+++ b/models/model_calvetti_py/sigmay.cpp
@@ -1,10 +1,7 @@
 #include "amici/symbolic_functions.h"
 #include "amici/defines.h"
-#include "sundials/sundials_types.h"
 
-#include <gsl/gsl-lite.hpp>
 #include <algorithm>
-
 #include "k.h"
 #include "y.h"
 #include "sigmay.h"

--- a/models/model_calvetti_py/w.cpp
+++ b/models/model_calvetti_py/w.cpp
@@ -1,10 +1,7 @@
 #include "amici/symbolic_functions.h"
 #include "amici/defines.h"
-#include "sundials/sundials_types.h"
 
-#include <gsl/gsl-lite.hpp>
 #include <algorithm>
-
 #include "x.h"
 #include "k.h"
 #include "h.h"

--- a/models/model_calvetti_py/x0.cpp
+++ b/models/model_calvetti_py/x0.cpp
@@ -1,10 +1,7 @@
 #include "amici/symbolic_functions.h"
 #include "amici/defines.h"
-#include "sundials/sundials_types.h"
 
-#include <gsl/gsl-lite.hpp>
 #include <algorithm>
-
 #include "k.h"
 
 namespace amici {

--- a/models/model_calvetti_py/x0_fixedParameters.cpp
+++ b/models/model_calvetti_py/x0_fixedParameters.cpp
@@ -1,10 +1,8 @@
 #include "amici/symbolic_functions.h"
 #include "amici/defines.h"
-#include "sundials/sundials_types.h"
 
-#include <gsl/gsl-lite.hpp>
 #include <algorithm>
-
+#include <gsl/gsl-lite.hpp>
 #include "k.h"
 
 namespace amici {

--- a/models/model_calvetti_py/x_rdata.cpp
+++ b/models/model_calvetti_py/x_rdata.cpp
@@ -1,10 +1,7 @@
 #include "amici/symbolic_functions.h"
 #include "amici/defines.h"
-#include "sundials/sundials_types.h"
 
-#include <gsl/gsl-lite.hpp>
 #include <algorithm>
-
 #include "x.h"
 #include "k.h"
 

--- a/models/model_calvetti_py/x_solver.cpp
+++ b/models/model_calvetti_py/x_solver.cpp
@@ -1,10 +1,7 @@
 #include "amici/symbolic_functions.h"
 #include "amici/defines.h"
-#include "sundials/sundials_types.h"
 
-#include <gsl/gsl-lite.hpp>
 #include <algorithm>
-
 #include "x_rdata.h"
 
 namespace amici {

--- a/models/model_calvetti_py/xdot.cpp
+++ b/models/model_calvetti_py/xdot.cpp
@@ -1,10 +1,7 @@
 #include "amici/symbolic_functions.h"
 #include "amici/defines.h"
-#include "sundials/sundials_types.h"
 
-#include <gsl/gsl-lite.hpp>
 #include <algorithm>
-
 #include "x.h"
 #include "k.h"
 #include "h.h"

--- a/models/model_calvetti_py/y.cpp
+++ b/models/model_calvetti_py/y.cpp
@@ -1,10 +1,7 @@
 #include "amici/symbolic_functions.h"
 #include "amici/defines.h"
-#include "sundials/sundials_types.h"
 
-#include <gsl/gsl-lite.hpp>
 #include <algorithm>
-
 #include "x.h"
 #include "k.h"
 #include "h.h"

--- a/models/model_dirac_py/Jy.cpp
+++ b/models/model_dirac_py/Jy.cpp
@@ -1,10 +1,7 @@
 #include "amici/symbolic_functions.h"
 #include "amici/defines.h"
-#include "sundials/sundials_types.h"
 
-#include <gsl/gsl-lite.hpp>
 #include <algorithm>
-
 #include "p.h"
 #include "y.h"
 #include "sigmay.h"

--- a/models/model_dirac_py/create_splines.cpp
+++ b/models/model_dirac_py/create_splines.cpp
@@ -1,10 +1,7 @@
 #include "amici/symbolic_functions.h"
 #include "amici/defines.h"
-#include "sundials/sundials_types.h"
 
-#include <gsl/gsl-lite.hpp>
 #include <algorithm>
-
 #include "amici/splinefunctions.h"
 #include <vector>
 #include "p.h"

--- a/models/model_dirac_py/dJydsigma.cpp
+++ b/models/model_dirac_py/dJydsigma.cpp
@@ -1,10 +1,7 @@
 #include "amici/symbolic_functions.h"
 #include "amici/defines.h"
-#include "sundials/sundials_types.h"
 
-#include <gsl/gsl-lite.hpp>
 #include <algorithm>
-
 #include "p.h"
 #include "y.h"
 #include "sigmay.h"

--- a/models/model_dirac_py/dJydy.cpp
+++ b/models/model_dirac_py/dJydy.cpp
@@ -41,11 +41,10 @@ void dJydy_rowvals_model_dirac_py(SUNMatrixWrapper &dJydy, int index){
 
 #include "amici/symbolic_functions.h"
 #include "amici/defines.h"
-#include "sundials/sundials_types.h"
 
-#include <gsl/gsl-lite.hpp>
 #include <algorithm>
-
+#include <sundials/sundials_types.h>
+#include <gsl/gsl-lite.hpp>
 #include "p.h"
 #include "y.h"
 #include "sigmay.h"

--- a/models/model_dirac_py/deltaqB.cpp
+++ b/models/model_dirac_py/deltaqB.cpp
@@ -1,10 +1,7 @@
 #include "amici/symbolic_functions.h"
 #include "amici/defines.h"
-#include "sundials/sundials_types.h"
 
-#include <gsl/gsl-lite.hpp>
 #include <algorithm>
-
 #include "x.h"
 #include "p.h"
 #include "h.h"

--- a/models/model_dirac_py/deltasx.cpp
+++ b/models/model_dirac_py/deltasx.cpp
@@ -1,10 +1,7 @@
 #include "amici/symbolic_functions.h"
 #include "amici/defines.h"
-#include "sundials/sundials_types.h"
 
-#include <gsl/gsl-lite.hpp>
 #include <algorithm>
-
 #include "x.h"
 #include "p.h"
 #include "h.h"

--- a/models/model_dirac_py/deltax.cpp
+++ b/models/model_dirac_py/deltax.cpp
@@ -1,10 +1,7 @@
 #include "amici/symbolic_functions.h"
 #include "amici/defines.h"
-#include "sundials/sundials_types.h"
 
-#include <gsl/gsl-lite.hpp>
 #include <algorithm>
-
 #include "x.h"
 #include "p.h"
 #include "h.h"

--- a/models/model_dirac_py/dxdotdp_explicit.cpp
+++ b/models/model_dirac_py/dxdotdp_explicit.cpp
@@ -41,11 +41,10 @@ void dxdotdp_explicit_rowvals_model_dirac_py(SUNMatrixWrapper &dxdotdp_explicit)
 
 #include "amici/symbolic_functions.h"
 #include "amici/defines.h"
-#include "sundials/sundials_types.h"
 
-#include <gsl/gsl-lite.hpp>
 #include <algorithm>
-
+#include <sundials/sundials_types.h>
+#include <gsl/gsl-lite.hpp>
 #include "x.h"
 #include "p.h"
 #include "h.h"

--- a/models/model_dirac_py/dxdotdx_explicit.cpp
+++ b/models/model_dirac_py/dxdotdx_explicit.cpp
@@ -41,11 +41,10 @@ void dxdotdx_explicit_rowvals_model_dirac_py(SUNMatrixWrapper &dxdotdx_explicit)
 
 #include "amici/symbolic_functions.h"
 #include "amici/defines.h"
-#include "sundials/sundials_types.h"
 
-#include <gsl/gsl-lite.hpp>
 #include <algorithm>
-
+#include <sundials/sundials_types.h>
+#include <gsl/gsl-lite.hpp>
 #include "x.h"
 #include "p.h"
 #include "h.h"

--- a/models/model_dirac_py/dydx.cpp
+++ b/models/model_dirac_py/dydx.cpp
@@ -1,10 +1,7 @@
 #include "amici/symbolic_functions.h"
 #include "amici/defines.h"
-#include "sundials/sundials_types.h"
 
-#include <gsl/gsl-lite.hpp>
 #include <algorithm>
-
 #include "x.h"
 #include "p.h"
 #include "h.h"

--- a/models/model_dirac_py/explicit_roots.cpp
+++ b/models/model_dirac_py/explicit_roots.cpp
@@ -1,10 +1,7 @@
 #include "amici/symbolic_functions.h"
 #include "amici/defines.h"
-#include "sundials/sundials_types.h"
 
-#include <gsl/gsl-lite.hpp>
 #include <algorithm>
-
 #include <vector>
 #include "p.h"
 

--- a/models/model_dirac_py/model_dirac_py.h
+++ b/models/model_dirac_py/model_dirac_py.h
@@ -544,7 +544,7 @@ class Model_model_dirac_py : public amici::Model_ODE {
      * @return AMICI git commit hash
      */
     std::string getAmiciCommit() const override {
-        return "570c71d2a041ed15d548e826df3d97e05d124309";
+        return "d5492c37f7dbc5faa374128e3559b96518e9a937";
     }
 
     bool hasQuadraticLLH() const override {

--- a/models/model_dirac_py/root.cpp
+++ b/models/model_dirac_py/root.cpp
@@ -1,10 +1,7 @@
 #include "amici/symbolic_functions.h"
 #include "amici/defines.h"
-#include "sundials/sundials_types.h"
 
-#include <gsl/gsl-lite.hpp>
 #include <algorithm>
-
 #include "x.h"
 #include "p.h"
 #include "h.h"

--- a/models/model_dirac_py/sigmay.cpp
+++ b/models/model_dirac_py/sigmay.cpp
@@ -1,10 +1,7 @@
 #include "amici/symbolic_functions.h"
 #include "amici/defines.h"
-#include "sundials/sundials_types.h"
 
-#include <gsl/gsl-lite.hpp>
 #include <algorithm>
-
 #include "p.h"
 #include "y.h"
 #include "sigmay.h"

--- a/models/model_dirac_py/stau.cpp
+++ b/models/model_dirac_py/stau.cpp
@@ -1,10 +1,7 @@
 #include "amici/symbolic_functions.h"
 #include "amici/defines.h"
-#include "sundials/sundials_types.h"
 
-#include <gsl/gsl-lite.hpp>
 #include <algorithm>
-
 #include "x.h"
 #include "p.h"
 #include "h.h"

--- a/models/model_dirac_py/x_rdata.cpp
+++ b/models/model_dirac_py/x_rdata.cpp
@@ -1,10 +1,7 @@
 #include "amici/symbolic_functions.h"
 #include "amici/defines.h"
-#include "sundials/sundials_types.h"
 
-#include <gsl/gsl-lite.hpp>
 #include <algorithm>
-
 #include "x.h"
 #include "p.h"
 

--- a/models/model_dirac_py/x_solver.cpp
+++ b/models/model_dirac_py/x_solver.cpp
@@ -1,10 +1,7 @@
 #include "amici/symbolic_functions.h"
 #include "amici/defines.h"
-#include "sundials/sundials_types.h"
 
-#include <gsl/gsl-lite.hpp>
 #include <algorithm>
-
 #include "x_rdata.h"
 
 namespace amici {

--- a/models/model_dirac_py/xdot.cpp
+++ b/models/model_dirac_py/xdot.cpp
@@ -1,10 +1,7 @@
 #include "amici/symbolic_functions.h"
 #include "amici/defines.h"
-#include "sundials/sundials_types.h"
 
-#include <gsl/gsl-lite.hpp>
 #include <algorithm>
-
 #include "x.h"
 #include "p.h"
 #include "h.h"

--- a/models/model_dirac_py/y.cpp
+++ b/models/model_dirac_py/y.cpp
@@ -1,10 +1,7 @@
 #include "amici/symbolic_functions.h"
 #include "amici/defines.h"
-#include "sundials/sundials_types.h"
 
-#include <gsl/gsl-lite.hpp>
 #include <algorithm>
-
 #include "x.h"
 #include "p.h"
 #include "h.h"

--- a/models/model_events_py/Jrz.cpp
+++ b/models/model_events_py/Jrz.cpp
@@ -1,10 +1,7 @@
 #include "amici/symbolic_functions.h"
 #include "amici/defines.h"
-#include "sundials/sundials_types.h"
 
-#include <gsl/gsl-lite.hpp>
 #include <algorithm>
-
 #include "p.h"
 #include "k.h"
 #include "rz.h"

--- a/models/model_events_py/Jy.cpp
+++ b/models/model_events_py/Jy.cpp
@@ -1,10 +1,7 @@
 #include "amici/symbolic_functions.h"
 #include "amici/defines.h"
-#include "sundials/sundials_types.h"
 
-#include <gsl/gsl-lite.hpp>
 #include <algorithm>
-
 #include "p.h"
 #include "k.h"
 #include "y.h"

--- a/models/model_events_py/Jz.cpp
+++ b/models/model_events_py/Jz.cpp
@@ -1,10 +1,7 @@
 #include "amici/symbolic_functions.h"
 #include "amici/defines.h"
-#include "sundials/sundials_types.h"
 
-#include <gsl/gsl-lite.hpp>
 #include <algorithm>
-
 #include "p.h"
 #include "k.h"
 #include "z.h"

--- a/models/model_events_py/create_splines.cpp
+++ b/models/model_events_py/create_splines.cpp
@@ -1,10 +1,7 @@
 #include "amici/symbolic_functions.h"
 #include "amici/defines.h"
-#include "sundials/sundials_types.h"
 
-#include <gsl/gsl-lite.hpp>
 #include <algorithm>
-
 #include "amici/splinefunctions.h"
 #include <vector>
 #include "p.h"

--- a/models/model_events_py/dJrzdsigma.cpp
+++ b/models/model_events_py/dJrzdsigma.cpp
@@ -1,10 +1,7 @@
 #include "amici/symbolic_functions.h"
 #include "amici/defines.h"
-#include "sundials/sundials_types.h"
 
-#include <gsl/gsl-lite.hpp>
 #include <algorithm>
-
 #include "p.h"
 #include "k.h"
 #include "rz.h"

--- a/models/model_events_py/dJrzdz.cpp
+++ b/models/model_events_py/dJrzdz.cpp
@@ -1,10 +1,7 @@
 #include "amici/symbolic_functions.h"
 #include "amici/defines.h"
-#include "sundials/sundials_types.h"
 
-#include <gsl/gsl-lite.hpp>
 #include <algorithm>
-
 #include "p.h"
 #include "k.h"
 #include "rz.h"

--- a/models/model_events_py/dJydsigma.cpp
+++ b/models/model_events_py/dJydsigma.cpp
@@ -1,10 +1,7 @@
 #include "amici/symbolic_functions.h"
 #include "amici/defines.h"
-#include "sundials/sundials_types.h"
 
-#include <gsl/gsl-lite.hpp>
 #include <algorithm>
-
 #include "p.h"
 #include "k.h"
 #include "y.h"

--- a/models/model_events_py/dJydy.cpp
+++ b/models/model_events_py/dJydy.cpp
@@ -41,11 +41,10 @@ void dJydy_rowvals_model_events_py(SUNMatrixWrapper &dJydy, int index){
 
 #include "amici/symbolic_functions.h"
 #include "amici/defines.h"
-#include "sundials/sundials_types.h"
 
-#include <gsl/gsl-lite.hpp>
 #include <algorithm>
-
+#include <sundials/sundials_types.h>
+#include <gsl/gsl-lite.hpp>
 #include "p.h"
 #include "k.h"
 #include "y.h"

--- a/models/model_events_py/dJzdsigma.cpp
+++ b/models/model_events_py/dJzdsigma.cpp
@@ -1,10 +1,7 @@
 #include "amici/symbolic_functions.h"
 #include "amici/defines.h"
-#include "sundials/sundials_types.h"
 
-#include <gsl/gsl-lite.hpp>
 #include <algorithm>
-
 #include "p.h"
 #include "k.h"
 #include "z.h"

--- a/models/model_events_py/dJzdz.cpp
+++ b/models/model_events_py/dJzdz.cpp
@@ -1,10 +1,7 @@
 #include "amici/symbolic_functions.h"
 #include "amici/defines.h"
-#include "sundials/sundials_types.h"
 
-#include <gsl/gsl-lite.hpp>
 #include <algorithm>
-
 #include "p.h"
 #include "k.h"
 #include "z.h"

--- a/models/model_events_py/deltaqB.cpp
+++ b/models/model_events_py/deltaqB.cpp
@@ -1,10 +1,7 @@
 #include "amici/symbolic_functions.h"
 #include "amici/defines.h"
-#include "sundials/sundials_types.h"
 
-#include <gsl/gsl-lite.hpp>
 #include <algorithm>
-
 #include "x.h"
 #include "p.h"
 #include "k.h"

--- a/models/model_events_py/deltasx.cpp
+++ b/models/model_events_py/deltasx.cpp
@@ -1,10 +1,7 @@
 #include "amici/symbolic_functions.h"
 #include "amici/defines.h"
-#include "sundials/sundials_types.h"
 
-#include <gsl/gsl-lite.hpp>
 #include <algorithm>
-
 #include "x.h"
 #include "p.h"
 #include "k.h"

--- a/models/model_events_py/deltaxB.cpp
+++ b/models/model_events_py/deltaxB.cpp
@@ -1,10 +1,7 @@
 #include "amici/symbolic_functions.h"
 #include "amici/defines.h"
-#include "sundials/sundials_types.h"
 
-#include <gsl/gsl-lite.hpp>
 #include <algorithm>
-
 #include "x.h"
 #include "p.h"
 #include "k.h"

--- a/models/model_events_py/drzdx.cpp
+++ b/models/model_events_py/drzdx.cpp
@@ -1,10 +1,7 @@
 #include "amici/symbolic_functions.h"
 #include "amici/defines.h"
-#include "sundials/sundials_types.h"
 
-#include <gsl/gsl-lite.hpp>
 #include <algorithm>
-
 #include "x.h"
 #include "p.h"
 #include "k.h"

--- a/models/model_events_py/dxdotdp_explicit.cpp
+++ b/models/model_events_py/dxdotdp_explicit.cpp
@@ -41,11 +41,10 @@ void dxdotdp_explicit_rowvals_model_events_py(SUNMatrixWrapper &dxdotdp_explicit
 
 #include "amici/symbolic_functions.h"
 #include "amici/defines.h"
-#include "sundials/sundials_types.h"
 
-#include <gsl/gsl-lite.hpp>
 #include <algorithm>
-
+#include <sundials/sundials_types.h>
+#include <gsl/gsl-lite.hpp>
 #include "x.h"
 #include "p.h"
 #include "k.h"

--- a/models/model_events_py/dxdotdx_explicit.cpp
+++ b/models/model_events_py/dxdotdx_explicit.cpp
@@ -41,11 +41,10 @@ void dxdotdx_explicit_rowvals_model_events_py(SUNMatrixWrapper &dxdotdx_explicit
 
 #include "amici/symbolic_functions.h"
 #include "amici/defines.h"
-#include "sundials/sundials_types.h"
 
-#include <gsl/gsl-lite.hpp>
 #include <algorithm>
-
+#include <sundials/sundials_types.h>
+#include <gsl/gsl-lite.hpp>
 #include "x.h"
 #include "p.h"
 #include "k.h"

--- a/models/model_events_py/dydp.cpp
+++ b/models/model_events_py/dydp.cpp
@@ -1,10 +1,7 @@
 #include "amici/symbolic_functions.h"
 #include "amici/defines.h"
-#include "sundials/sundials_types.h"
 
-#include <gsl/gsl-lite.hpp>
 #include <algorithm>
-
 #include "x.h"
 #include "p.h"
 #include "k.h"

--- a/models/model_events_py/dydx.cpp
+++ b/models/model_events_py/dydx.cpp
@@ -1,10 +1,7 @@
 #include "amici/symbolic_functions.h"
 #include "amici/defines.h"
-#include "sundials/sundials_types.h"
 
-#include <gsl/gsl-lite.hpp>
 #include <algorithm>
-
 #include "x.h"
 #include "p.h"
 #include "k.h"

--- a/models/model_events_py/dzdx.cpp
+++ b/models/model_events_py/dzdx.cpp
@@ -1,10 +1,7 @@
 #include "amici/symbolic_functions.h"
 #include "amici/defines.h"
-#include "sundials/sundials_types.h"
 
-#include <gsl/gsl-lite.hpp>
 #include <algorithm>
-
 #include "x.h"
 #include "p.h"
 #include "k.h"

--- a/models/model_events_py/explicit_roots.cpp
+++ b/models/model_events_py/explicit_roots.cpp
@@ -1,10 +1,7 @@
 #include "amici/symbolic_functions.h"
 #include "amici/defines.h"
-#include "sundials/sundials_types.h"
 
-#include <gsl/gsl-lite.hpp>
 #include <algorithm>
-
 #include <vector>
 #include "p.h"
 #include "k.h"

--- a/models/model_events_py/model_events_py.h
+++ b/models/model_events_py/model_events_py.h
@@ -148,7 +148,7 @@ class Model_model_events_py : public amici::Model_ODE {
               ),
               amici::SecondOrderMode::none,                                  // o2mode
               std::vector<realtype>{1.0, 1.0, 1.0},   // idlist
-              std::vector<int>{1, 2},               // z2events
+              std::vector<int>{0, 1},               // z2events
               std::vector<Event>{
                   Event("event_1", false, true, NAN),
                   Event("event_2", false, true, NAN),
@@ -579,7 +579,7 @@ class Model_model_events_py : public amici::Model_ODE {
      * @return AMICI git commit hash
      */
     std::string getAmiciCommit() const override {
-        return "570c71d2a041ed15d548e826df3d97e05d124309";
+        return "d5492c37f7dbc5faa374128e3559b96518e9a937";
     }
 
     bool hasQuadraticLLH() const override {

--- a/models/model_events_py/root.cpp
+++ b/models/model_events_py/root.cpp
@@ -1,10 +1,7 @@
 #include "amici/symbolic_functions.h"
 #include "amici/defines.h"
-#include "sundials/sundials_types.h"
 
-#include <gsl/gsl-lite.hpp>
 #include <algorithm>
-
 #include "x.h"
 #include "p.h"
 #include "k.h"

--- a/models/model_events_py/rz.cpp
+++ b/models/model_events_py/rz.cpp
@@ -1,10 +1,7 @@
 #include "amici/symbolic_functions.h"
 #include "amici/defines.h"
-#include "sundials/sundials_types.h"
 
-#include <gsl/gsl-lite.hpp>
 #include <algorithm>
-
 #include "x.h"
 #include "p.h"
 #include "k.h"

--- a/models/model_events_py/sigmay.cpp
+++ b/models/model_events_py/sigmay.cpp
@@ -1,10 +1,7 @@
 #include "amici/symbolic_functions.h"
 #include "amici/defines.h"
-#include "sundials/sundials_types.h"
 
-#include <gsl/gsl-lite.hpp>
 #include <algorithm>
-
 #include "p.h"
 #include "k.h"
 #include "y.h"

--- a/models/model_events_py/sigmaz.cpp
+++ b/models/model_events_py/sigmaz.cpp
@@ -1,10 +1,7 @@
 #include "amici/symbolic_functions.h"
 #include "amici/defines.h"
-#include "sundials/sundials_types.h"
 
-#include <gsl/gsl-lite.hpp>
 #include <algorithm>
-
 #include "p.h"
 #include "k.h"
 #include "sigmaz.h"

--- a/models/model_events_py/stau.cpp
+++ b/models/model_events_py/stau.cpp
@@ -1,10 +1,7 @@
 #include "amici/symbolic_functions.h"
 #include "amici/defines.h"
-#include "sundials/sundials_types.h"
 
-#include <gsl/gsl-lite.hpp>
 #include <algorithm>
-
 #include "x.h"
 #include "p.h"
 #include "k.h"

--- a/models/model_events_py/sx0_fixedParameters.cpp
+++ b/models/model_events_py/sx0_fixedParameters.cpp
@@ -1,10 +1,8 @@
 #include "amici/symbolic_functions.h"
 #include "amici/defines.h"
-#include "sundials/sundials_types.h"
 
-#include <gsl/gsl-lite.hpp>
 #include <algorithm>
-
+#include <gsl/gsl-lite.hpp>
 #include "p.h"
 #include "k.h"
 

--- a/models/model_events_py/x0.cpp
+++ b/models/model_events_py/x0.cpp
@@ -1,10 +1,7 @@
 #include "amici/symbolic_functions.h"
 #include "amici/defines.h"
-#include "sundials/sundials_types.h"
 
-#include <gsl/gsl-lite.hpp>
 #include <algorithm>
-
 #include "p.h"
 #include "k.h"
 

--- a/models/model_events_py/x0_fixedParameters.cpp
+++ b/models/model_events_py/x0_fixedParameters.cpp
@@ -1,10 +1,8 @@
 #include "amici/symbolic_functions.h"
 #include "amici/defines.h"
-#include "sundials/sundials_types.h"
 
-#include <gsl/gsl-lite.hpp>
 #include <algorithm>
-
+#include <gsl/gsl-lite.hpp>
 #include "p.h"
 #include "k.h"
 

--- a/models/model_events_py/x_rdata.cpp
+++ b/models/model_events_py/x_rdata.cpp
@@ -1,10 +1,7 @@
 #include "amici/symbolic_functions.h"
 #include "amici/defines.h"
-#include "sundials/sundials_types.h"
 
-#include <gsl/gsl-lite.hpp>
 #include <algorithm>
-
 #include "x.h"
 #include "p.h"
 #include "k.h"

--- a/models/model_events_py/x_solver.cpp
+++ b/models/model_events_py/x_solver.cpp
@@ -1,10 +1,7 @@
 #include "amici/symbolic_functions.h"
 #include "amici/defines.h"
-#include "sundials/sundials_types.h"
 
-#include <gsl/gsl-lite.hpp>
 #include <algorithm>
-
 #include "x_rdata.h"
 
 namespace amici {

--- a/models/model_events_py/xdot.cpp
+++ b/models/model_events_py/xdot.cpp
@@ -1,10 +1,7 @@
 #include "amici/symbolic_functions.h"
 #include "amici/defines.h"
-#include "sundials/sundials_types.h"
 
-#include <gsl/gsl-lite.hpp>
 #include <algorithm>
-
 #include "x.h"
 #include "p.h"
 #include "k.h"

--- a/models/model_events_py/y.cpp
+++ b/models/model_events_py/y.cpp
@@ -1,10 +1,7 @@
 #include "amici/symbolic_functions.h"
 #include "amici/defines.h"
-#include "sundials/sundials_types.h"
 
-#include <gsl/gsl-lite.hpp>
 #include <algorithm>
-
 #include "x.h"
 #include "p.h"
 #include "k.h"

--- a/models/model_events_py/z.cpp
+++ b/models/model_events_py/z.cpp
@@ -1,10 +1,7 @@
 #include "amici/symbolic_functions.h"
 #include "amici/defines.h"
-#include "sundials/sundials_types.h"
 
-#include <gsl/gsl-lite.hpp>
 #include <algorithm>
-
 #include "x.h"
 #include "p.h"
 #include "k.h"

--- a/models/model_jakstat_adjoint_py/Jy.cpp
+++ b/models/model_jakstat_adjoint_py/Jy.cpp
@@ -1,10 +1,7 @@
 #include "amici/symbolic_functions.h"
 #include "amici/defines.h"
-#include "sundials/sundials_types.h"
 
-#include <gsl/gsl-lite.hpp>
 #include <algorithm>
-
 #include "p.h"
 #include "k.h"
 #include "y.h"

--- a/models/model_jakstat_adjoint_py/create_splines.cpp
+++ b/models/model_jakstat_adjoint_py/create_splines.cpp
@@ -1,10 +1,7 @@
 #include "amici/symbolic_functions.h"
 #include "amici/defines.h"
-#include "sundials/sundials_types.h"
 
-#include <gsl/gsl-lite.hpp>
 #include <algorithm>
-
 #include "amici/splinefunctions.h"
 #include <vector>
 #include "p.h"

--- a/models/model_jakstat_adjoint_py/dJydsigma.cpp
+++ b/models/model_jakstat_adjoint_py/dJydsigma.cpp
@@ -1,10 +1,7 @@
 #include "amici/symbolic_functions.h"
 #include "amici/defines.h"
-#include "sundials/sundials_types.h"
 
-#include <gsl/gsl-lite.hpp>
 #include <algorithm>
-
 #include "p.h"
 #include "k.h"
 #include "y.h"

--- a/models/model_jakstat_adjoint_py/dJydy.cpp
+++ b/models/model_jakstat_adjoint_py/dJydy.cpp
@@ -45,11 +45,10 @@ void dJydy_rowvals_model_jakstat_adjoint_py(SUNMatrixWrapper &dJydy, int index){
 
 #include "amici/symbolic_functions.h"
 #include "amici/defines.h"
-#include "sundials/sundials_types.h"
 
-#include <gsl/gsl-lite.hpp>
 #include <algorithm>
-
+#include <sundials/sundials_types.h>
+#include <gsl/gsl-lite.hpp>
 #include "p.h"
 #include "k.h"
 #include "y.h"

--- a/models/model_jakstat_adjoint_py/dsigmaydp.cpp
+++ b/models/model_jakstat_adjoint_py/dsigmaydp.cpp
@@ -1,10 +1,7 @@
 #include "amici/symbolic_functions.h"
 #include "amici/defines.h"
-#include "sundials/sundials_types.h"
 
-#include <gsl/gsl-lite.hpp>
 #include <algorithm>
-
 #include "p.h"
 #include "k.h"
 #include "y.h"

--- a/models/model_jakstat_adjoint_py/dspline_valuesdp.cpp
+++ b/models/model_jakstat_adjoint_py/dspline_valuesdp.cpp
@@ -1,10 +1,7 @@
 #include "amici/symbolic_functions.h"
 #include "amici/defines.h"
-#include "sundials/sundials_types.h"
 
-#include <gsl/gsl-lite.hpp>
 #include <algorithm>
-
 #include "p.h"
 #include "k.h"
 

--- a/models/model_jakstat_adjoint_py/dwdp.cpp
+++ b/models/model_jakstat_adjoint_py/dwdp.cpp
@@ -41,11 +41,10 @@ void dwdp_rowvals_model_jakstat_adjoint_py(SUNMatrixWrapper &dwdp){
 
 #include "amici/symbolic_functions.h"
 #include "amici/defines.h"
-#include "sundials/sundials_types.h"
 
-#include <gsl/gsl-lite.hpp>
 #include <algorithm>
-
+#include <sundials/sundials_types.h>
+#include <gsl/gsl-lite.hpp>
 #include "x.h"
 #include "p.h"
 #include "k.h"

--- a/models/model_jakstat_adjoint_py/dxdotdp_explicit.cpp
+++ b/models/model_jakstat_adjoint_py/dxdotdp_explicit.cpp
@@ -41,11 +41,10 @@ void dxdotdp_explicit_rowvals_model_jakstat_adjoint_py(SUNMatrixWrapper &dxdotdp
 
 #include "amici/symbolic_functions.h"
 #include "amici/defines.h"
-#include "sundials/sundials_types.h"
 
-#include <gsl/gsl-lite.hpp>
 #include <algorithm>
-
+#include <sundials/sundials_types.h>
+#include <gsl/gsl-lite.hpp>
 #include "x.h"
 #include "p.h"
 #include "k.h"

--- a/models/model_jakstat_adjoint_py/dxdotdw.cpp
+++ b/models/model_jakstat_adjoint_py/dxdotdw.cpp
@@ -41,11 +41,10 @@ void dxdotdw_rowvals_model_jakstat_adjoint_py(SUNMatrixWrapper &dxdotdw){
 
 #include "amici/symbolic_functions.h"
 #include "amici/defines.h"
-#include "sundials/sundials_types.h"
 
-#include <gsl/gsl-lite.hpp>
 #include <algorithm>
-
+#include <sundials/sundials_types.h>
+#include <gsl/gsl-lite.hpp>
 #include "x.h"
 #include "p.h"
 #include "k.h"

--- a/models/model_jakstat_adjoint_py/dxdotdx_explicit.cpp
+++ b/models/model_jakstat_adjoint_py/dxdotdx_explicit.cpp
@@ -41,11 +41,10 @@ void dxdotdx_explicit_rowvals_model_jakstat_adjoint_py(SUNMatrixWrapper &dxdotdx
 
 #include "amici/symbolic_functions.h"
 #include "amici/defines.h"
-#include "sundials/sundials_types.h"
 
-#include <gsl/gsl-lite.hpp>
 #include <algorithm>
-
+#include <sundials/sundials_types.h>
+#include <gsl/gsl-lite.hpp>
 #include "x.h"
 #include "p.h"
 #include "k.h"

--- a/models/model_jakstat_adjoint_py/dydp.cpp
+++ b/models/model_jakstat_adjoint_py/dydp.cpp
@@ -1,10 +1,7 @@
 #include "amici/symbolic_functions.h"
 #include "amici/defines.h"
-#include "sundials/sundials_types.h"
 
-#include <gsl/gsl-lite.hpp>
 #include <algorithm>
-
 #include "x.h"
 #include "p.h"
 #include "k.h"

--- a/models/model_jakstat_adjoint_py/dydx.cpp
+++ b/models/model_jakstat_adjoint_py/dydx.cpp
@@ -1,10 +1,7 @@
 #include "amici/symbolic_functions.h"
 #include "amici/defines.h"
-#include "sundials/sundials_types.h"
 
-#include <gsl/gsl-lite.hpp>
 #include <algorithm>
-
 #include "x.h"
 #include "p.h"
 #include "k.h"

--- a/models/model_jakstat_adjoint_py/model_jakstat_adjoint_py.h
+++ b/models/model_jakstat_adjoint_py/model_jakstat_adjoint_py.h
@@ -552,7 +552,7 @@ class Model_model_jakstat_adjoint_py : public amici::Model_ODE {
      * @return AMICI git commit hash
      */
     std::string getAmiciCommit() const override {
-        return "570c71d2a041ed15d548e826df3d97e05d124309";
+        return "d5492c37f7dbc5faa374128e3559b96518e9a937";
     }
 
     bool hasQuadraticLLH() const override {

--- a/models/model_jakstat_adjoint_py/sigmay.cpp
+++ b/models/model_jakstat_adjoint_py/sigmay.cpp
@@ -1,10 +1,7 @@
 #include "amici/symbolic_functions.h"
 #include "amici/defines.h"
-#include "sundials/sundials_types.h"
 
-#include <gsl/gsl-lite.hpp>
 #include <algorithm>
-
 #include "p.h"
 #include "k.h"
 #include "y.h"

--- a/models/model_jakstat_adjoint_py/w.cpp
+++ b/models/model_jakstat_adjoint_py/w.cpp
@@ -1,10 +1,7 @@
 #include "amici/symbolic_functions.h"
 #include "amici/defines.h"
-#include "sundials/sundials_types.h"
 
-#include <gsl/gsl-lite.hpp>
 #include <algorithm>
-
 #include "x.h"
 #include "p.h"
 #include "k.h"

--- a/models/model_jakstat_adjoint_py/x0.cpp
+++ b/models/model_jakstat_adjoint_py/x0.cpp
@@ -1,10 +1,7 @@
 #include "amici/symbolic_functions.h"
 #include "amici/defines.h"
-#include "sundials/sundials_types.h"
 
-#include <gsl/gsl-lite.hpp>
 #include <algorithm>
-
 #include "p.h"
 #include "k.h"
 

--- a/models/model_jakstat_adjoint_py/x_rdata.cpp
+++ b/models/model_jakstat_adjoint_py/x_rdata.cpp
@@ -1,10 +1,7 @@
 #include "amici/symbolic_functions.h"
 #include "amici/defines.h"
-#include "sundials/sundials_types.h"
 
-#include <gsl/gsl-lite.hpp>
 #include <algorithm>
-
 #include "x.h"
 #include "p.h"
 #include "k.h"

--- a/models/model_jakstat_adjoint_py/x_solver.cpp
+++ b/models/model_jakstat_adjoint_py/x_solver.cpp
@@ -1,10 +1,7 @@
 #include "amici/symbolic_functions.h"
 #include "amici/defines.h"
-#include "sundials/sundials_types.h"
 
-#include <gsl/gsl-lite.hpp>
 #include <algorithm>
-
 #include "x_rdata.h"
 
 namespace amici {

--- a/models/model_jakstat_adjoint_py/xdot.cpp
+++ b/models/model_jakstat_adjoint_py/xdot.cpp
@@ -1,10 +1,7 @@
 #include "amici/symbolic_functions.h"
 #include "amici/defines.h"
-#include "sundials/sundials_types.h"
 
-#include <gsl/gsl-lite.hpp>
 #include <algorithm>
-
 #include "x.h"
 #include "p.h"
 #include "k.h"

--- a/models/model_jakstat_adjoint_py/y.cpp
+++ b/models/model_jakstat_adjoint_py/y.cpp
@@ -1,10 +1,7 @@
 #include "amici/symbolic_functions.h"
 #include "amici/defines.h"
-#include "sundials/sundials_types.h"
 
-#include <gsl/gsl-lite.hpp>
 #include <algorithm>
-
 #include "x.h"
 #include "p.h"
 #include "k.h"

--- a/models/model_nested_events_py/Jy.cpp
+++ b/models/model_nested_events_py/Jy.cpp
@@ -1,10 +1,7 @@
 #include "amici/symbolic_functions.h"
 #include "amici/defines.h"
-#include "sundials/sundials_types.h"
 
-#include <gsl/gsl-lite.hpp>
 #include <algorithm>
-
 #include "p.h"
 #include "y.h"
 #include "sigmay.h"

--- a/models/model_nested_events_py/create_splines.cpp
+++ b/models/model_nested_events_py/create_splines.cpp
@@ -1,10 +1,7 @@
 #include "amici/symbolic_functions.h"
 #include "amici/defines.h"
-#include "sundials/sundials_types.h"
 
-#include <gsl/gsl-lite.hpp>
 #include <algorithm>
-
 #include "amici/splinefunctions.h"
 #include <vector>
 #include "p.h"

--- a/models/model_nested_events_py/dJydsigma.cpp
+++ b/models/model_nested_events_py/dJydsigma.cpp
@@ -1,10 +1,7 @@
 #include "amici/symbolic_functions.h"
 #include "amici/defines.h"
-#include "sundials/sundials_types.h"
 
-#include <gsl/gsl-lite.hpp>
 #include <algorithm>
-
 #include "p.h"
 #include "y.h"
 #include "sigmay.h"

--- a/models/model_nested_events_py/dJydy.cpp
+++ b/models/model_nested_events_py/dJydy.cpp
@@ -41,11 +41,10 @@ void dJydy_rowvals_model_nested_events_py(SUNMatrixWrapper &dJydy, int index){
 
 #include "amici/symbolic_functions.h"
 #include "amici/defines.h"
-#include "sundials/sundials_types.h"
 
-#include <gsl/gsl-lite.hpp>
 #include <algorithm>
-
+#include <sundials/sundials_types.h>
+#include <gsl/gsl-lite.hpp>
 #include "p.h"
 #include "y.h"
 #include "sigmay.h"

--- a/models/model_nested_events_py/deltaqB.cpp
+++ b/models/model_nested_events_py/deltaqB.cpp
@@ -1,10 +1,7 @@
 #include "amici/symbolic_functions.h"
 #include "amici/defines.h"
-#include "sundials/sundials_types.h"
 
-#include <gsl/gsl-lite.hpp>
 #include <algorithm>
-
 #include "x.h"
 #include "p.h"
 #include "h.h"

--- a/models/model_nested_events_py/deltasx.cpp
+++ b/models/model_nested_events_py/deltasx.cpp
@@ -1,10 +1,7 @@
 #include "amici/symbolic_functions.h"
 #include "amici/defines.h"
-#include "sundials/sundials_types.h"
 
-#include <gsl/gsl-lite.hpp>
 #include <algorithm>
-
 #include "x.h"
 #include "p.h"
 #include "h.h"

--- a/models/model_nested_events_py/deltax.cpp
+++ b/models/model_nested_events_py/deltax.cpp
@@ -1,10 +1,7 @@
 #include "amici/symbolic_functions.h"
 #include "amici/defines.h"
-#include "sundials/sundials_types.h"
 
-#include <gsl/gsl-lite.hpp>
 #include <algorithm>
-
 #include "x.h"
 #include "p.h"
 #include "h.h"

--- a/models/model_nested_events_py/deltaxB.cpp
+++ b/models/model_nested_events_py/deltaxB.cpp
@@ -1,10 +1,7 @@
 #include "amici/symbolic_functions.h"
 #include "amici/defines.h"
-#include "sundials/sundials_types.h"
 
-#include <gsl/gsl-lite.hpp>
 #include <algorithm>
-
 #include "x.h"
 #include "p.h"
 #include "h.h"

--- a/models/model_nested_events_py/dxdotdp_explicit.cpp
+++ b/models/model_nested_events_py/dxdotdp_explicit.cpp
@@ -41,11 +41,10 @@ void dxdotdp_explicit_rowvals_model_nested_events_py(SUNMatrixWrapper &dxdotdp_e
 
 #include "amici/symbolic_functions.h"
 #include "amici/defines.h"
-#include "sundials/sundials_types.h"
 
-#include <gsl/gsl-lite.hpp>
 #include <algorithm>
-
+#include <sundials/sundials_types.h>
+#include <gsl/gsl-lite.hpp>
 #include "x.h"
 #include "p.h"
 #include "h.h"

--- a/models/model_nested_events_py/dxdotdx_explicit.cpp
+++ b/models/model_nested_events_py/dxdotdx_explicit.cpp
@@ -41,11 +41,10 @@ void dxdotdx_explicit_rowvals_model_nested_events_py(SUNMatrixWrapper &dxdotdx_e
 
 #include "amici/symbolic_functions.h"
 #include "amici/defines.h"
-#include "sundials/sundials_types.h"
 
-#include <gsl/gsl-lite.hpp>
 #include <algorithm>
-
+#include <sundials/sundials_types.h>
+#include <gsl/gsl-lite.hpp>
 #include "x.h"
 #include "p.h"
 #include "h.h"

--- a/models/model_nested_events_py/dydx.cpp
+++ b/models/model_nested_events_py/dydx.cpp
@@ -1,10 +1,7 @@
 #include "amici/symbolic_functions.h"
 #include "amici/defines.h"
-#include "sundials/sundials_types.h"
 
-#include <gsl/gsl-lite.hpp>
 #include <algorithm>
-
 #include "x.h"
 #include "p.h"
 #include "h.h"

--- a/models/model_nested_events_py/explicit_roots.cpp
+++ b/models/model_nested_events_py/explicit_roots.cpp
@@ -1,10 +1,7 @@
 #include "amici/symbolic_functions.h"
 #include "amici/defines.h"
-#include "sundials/sundials_types.h"
 
-#include <gsl/gsl-lite.hpp>
 #include <algorithm>
-
 #include <vector>
 #include "p.h"
 

--- a/models/model_nested_events_py/model_nested_events_py.h
+++ b/models/model_nested_events_py/model_nested_events_py.h
@@ -552,7 +552,7 @@ class Model_model_nested_events_py : public amici::Model_ODE {
      * @return AMICI git commit hash
      */
     std::string getAmiciCommit() const override {
-        return "570c71d2a041ed15d548e826df3d97e05d124309";
+        return "d5492c37f7dbc5faa374128e3559b96518e9a937";
     }
 
     bool hasQuadraticLLH() const override {

--- a/models/model_nested_events_py/root.cpp
+++ b/models/model_nested_events_py/root.cpp
@@ -1,10 +1,7 @@
 #include "amici/symbolic_functions.h"
 #include "amici/defines.h"
-#include "sundials/sundials_types.h"
 
-#include <gsl/gsl-lite.hpp>
 #include <algorithm>
-
 #include "x.h"
 #include "p.h"
 #include "h.h"

--- a/models/model_nested_events_py/sigmay.cpp
+++ b/models/model_nested_events_py/sigmay.cpp
@@ -1,10 +1,7 @@
 #include "amici/symbolic_functions.h"
 #include "amici/defines.h"
-#include "sundials/sundials_types.h"
 
-#include <gsl/gsl-lite.hpp>
 #include <algorithm>
-
 #include "p.h"
 #include "y.h"
 #include "sigmay.h"

--- a/models/model_nested_events_py/stau.cpp
+++ b/models/model_nested_events_py/stau.cpp
@@ -1,10 +1,7 @@
 #include "amici/symbolic_functions.h"
 #include "amici/defines.h"
-#include "sundials/sundials_types.h"
 
-#include <gsl/gsl-lite.hpp>
 #include <algorithm>
-
 #include "x.h"
 #include "p.h"
 #include "h.h"

--- a/models/model_nested_events_py/sx0.cpp
+++ b/models/model_nested_events_py/sx0.cpp
@@ -1,10 +1,7 @@
 #include "amici/symbolic_functions.h"
 #include "amici/defines.h"
-#include "sundials/sundials_types.h"
 
-#include <gsl/gsl-lite.hpp>
 #include <algorithm>
-
 #include "x.h"
 #include "p.h"
 

--- a/models/model_nested_events_py/x0.cpp
+++ b/models/model_nested_events_py/x0.cpp
@@ -1,10 +1,7 @@
 #include "amici/symbolic_functions.h"
 #include "amici/defines.h"
-#include "sundials/sundials_types.h"
 
-#include <gsl/gsl-lite.hpp>
 #include <algorithm>
-
 #include "p.h"
 
 namespace amici {

--- a/models/model_nested_events_py/x_rdata.cpp
+++ b/models/model_nested_events_py/x_rdata.cpp
@@ -1,10 +1,7 @@
 #include "amici/symbolic_functions.h"
 #include "amici/defines.h"
-#include "sundials/sundials_types.h"
 
-#include <gsl/gsl-lite.hpp>
 #include <algorithm>
-
 #include "x.h"
 #include "p.h"
 

--- a/models/model_nested_events_py/x_solver.cpp
+++ b/models/model_nested_events_py/x_solver.cpp
@@ -1,10 +1,7 @@
 #include "amici/symbolic_functions.h"
 #include "amici/defines.h"
-#include "sundials/sundials_types.h"
 
-#include <gsl/gsl-lite.hpp>
 #include <algorithm>
-
 #include "x_rdata.h"
 
 namespace amici {

--- a/models/model_nested_events_py/xdot.cpp
+++ b/models/model_nested_events_py/xdot.cpp
@@ -1,10 +1,7 @@
 #include "amici/symbolic_functions.h"
 #include "amici/defines.h"
-#include "sundials/sundials_types.h"
 
-#include <gsl/gsl-lite.hpp>
 #include <algorithm>
-
 #include "x.h"
 #include "p.h"
 #include "h.h"

--- a/models/model_nested_events_py/y.cpp
+++ b/models/model_nested_events_py/y.cpp
@@ -1,10 +1,7 @@
 #include "amici/symbolic_functions.h"
 #include "amici/defines.h"
-#include "sundials/sundials_types.h"
 
-#include <gsl/gsl-lite.hpp>
 #include <algorithm>
-
 #include "x.h"
 #include "p.h"
 #include "h.h"

--- a/models/model_neuron_py/Jrz.cpp
+++ b/models/model_neuron_py/Jrz.cpp
@@ -1,10 +1,7 @@
 #include "amici/symbolic_functions.h"
 #include "amici/defines.h"
-#include "sundials/sundials_types.h"
 
-#include <gsl/gsl-lite.hpp>
 #include <algorithm>
-
 #include "p.h"
 #include "k.h"
 #include "rz.h"

--- a/models/model_neuron_py/Jy.cpp
+++ b/models/model_neuron_py/Jy.cpp
@@ -1,10 +1,7 @@
 #include "amici/symbolic_functions.h"
 #include "amici/defines.h"
-#include "sundials/sundials_types.h"
 
-#include <gsl/gsl-lite.hpp>
 #include <algorithm>
-
 #include "p.h"
 #include "k.h"
 #include "y.h"

--- a/models/model_neuron_py/Jz.cpp
+++ b/models/model_neuron_py/Jz.cpp
@@ -1,10 +1,7 @@
 #include "amici/symbolic_functions.h"
 #include "amici/defines.h"
-#include "sundials/sundials_types.h"
 
-#include <gsl/gsl-lite.hpp>
 #include <algorithm>
-
 #include "p.h"
 #include "k.h"
 #include "z.h"

--- a/models/model_neuron_py/create_splines.cpp
+++ b/models/model_neuron_py/create_splines.cpp
@@ -1,10 +1,7 @@
 #include "amici/symbolic_functions.h"
 #include "amici/defines.h"
-#include "sundials/sundials_types.h"
 
-#include <gsl/gsl-lite.hpp>
 #include <algorithm>
-
 #include "amici/splinefunctions.h"
 #include <vector>
 #include "p.h"

--- a/models/model_neuron_py/dJrzdsigma.cpp
+++ b/models/model_neuron_py/dJrzdsigma.cpp
@@ -1,10 +1,7 @@
 #include "amici/symbolic_functions.h"
 #include "amici/defines.h"
-#include "sundials/sundials_types.h"
 
-#include <gsl/gsl-lite.hpp>
 #include <algorithm>
-
 #include "p.h"
 #include "k.h"
 #include "rz.h"

--- a/models/model_neuron_py/dJrzdz.cpp
+++ b/models/model_neuron_py/dJrzdz.cpp
@@ -1,10 +1,7 @@
 #include "amici/symbolic_functions.h"
 #include "amici/defines.h"
-#include "sundials/sundials_types.h"
 
-#include <gsl/gsl-lite.hpp>
 #include <algorithm>
-
 #include "p.h"
 #include "k.h"
 #include "rz.h"

--- a/models/model_neuron_py/dJydsigma.cpp
+++ b/models/model_neuron_py/dJydsigma.cpp
@@ -1,10 +1,7 @@
 #include "amici/symbolic_functions.h"
 #include "amici/defines.h"
-#include "sundials/sundials_types.h"
 
-#include <gsl/gsl-lite.hpp>
 #include <algorithm>
-
 #include "p.h"
 #include "k.h"
 #include "y.h"

--- a/models/model_neuron_py/dJydy.cpp
+++ b/models/model_neuron_py/dJydy.cpp
@@ -41,11 +41,10 @@ void dJydy_rowvals_model_neuron_py(SUNMatrixWrapper &dJydy, int index){
 
 #include "amici/symbolic_functions.h"
 #include "amici/defines.h"
-#include "sundials/sundials_types.h"
 
-#include <gsl/gsl-lite.hpp>
 #include <algorithm>
-
+#include <sundials/sundials_types.h>
+#include <gsl/gsl-lite.hpp>
 #include "p.h"
 #include "k.h"
 #include "y.h"

--- a/models/model_neuron_py/dJzdsigma.cpp
+++ b/models/model_neuron_py/dJzdsigma.cpp
@@ -1,10 +1,7 @@
 #include "amici/symbolic_functions.h"
 #include "amici/defines.h"
-#include "sundials/sundials_types.h"
 
-#include <gsl/gsl-lite.hpp>
 #include <algorithm>
-
 #include "p.h"
 #include "k.h"
 #include "z.h"

--- a/models/model_neuron_py/dJzdz.cpp
+++ b/models/model_neuron_py/dJzdz.cpp
@@ -1,10 +1,7 @@
 #include "amici/symbolic_functions.h"
 #include "amici/defines.h"
-#include "sundials/sundials_types.h"
 
-#include <gsl/gsl-lite.hpp>
 #include <algorithm>
-
 #include "p.h"
 #include "k.h"
 #include "z.h"

--- a/models/model_neuron_py/deltaqB.cpp
+++ b/models/model_neuron_py/deltaqB.cpp
@@ -1,10 +1,7 @@
 #include "amici/symbolic_functions.h"
 #include "amici/defines.h"
-#include "sundials/sundials_types.h"
 
-#include <gsl/gsl-lite.hpp>
 #include <algorithm>
-
 #include "x.h"
 #include "p.h"
 #include "k.h"

--- a/models/model_neuron_py/deltasx.cpp
+++ b/models/model_neuron_py/deltasx.cpp
@@ -1,10 +1,7 @@
 #include "amici/symbolic_functions.h"
 #include "amici/defines.h"
-#include "sundials/sundials_types.h"
 
-#include <gsl/gsl-lite.hpp>
 #include <algorithm>
-
 #include "x.h"
 #include "p.h"
 #include "k.h"

--- a/models/model_neuron_py/deltax.cpp
+++ b/models/model_neuron_py/deltax.cpp
@@ -1,10 +1,7 @@
 #include "amici/symbolic_functions.h"
 #include "amici/defines.h"
-#include "sundials/sundials_types.h"
 
-#include <gsl/gsl-lite.hpp>
 #include <algorithm>
-
 #include "x.h"
 #include "p.h"
 #include "k.h"

--- a/models/model_neuron_py/deltaxB.cpp
+++ b/models/model_neuron_py/deltaxB.cpp
@@ -1,10 +1,7 @@
 #include "amici/symbolic_functions.h"
 #include "amici/defines.h"
-#include "sundials/sundials_types.h"
 
-#include <gsl/gsl-lite.hpp>
 #include <algorithm>
-
 #include "x.h"
 #include "p.h"
 #include "k.h"

--- a/models/model_neuron_py/drzdx.cpp
+++ b/models/model_neuron_py/drzdx.cpp
@@ -1,10 +1,7 @@
 #include "amici/symbolic_functions.h"
 #include "amici/defines.h"
-#include "sundials/sundials_types.h"
 
-#include <gsl/gsl-lite.hpp>
 #include <algorithm>
-
 #include "x.h"
 #include "p.h"
 #include "k.h"

--- a/models/model_neuron_py/dxdotdp_explicit.cpp
+++ b/models/model_neuron_py/dxdotdp_explicit.cpp
@@ -41,11 +41,10 @@ void dxdotdp_explicit_rowvals_model_neuron_py(SUNMatrixWrapper &dxdotdp_explicit
 
 #include "amici/symbolic_functions.h"
 #include "amici/defines.h"
-#include "sundials/sundials_types.h"
 
-#include <gsl/gsl-lite.hpp>
 #include <algorithm>
-
+#include <sundials/sundials_types.h>
+#include <gsl/gsl-lite.hpp>
 #include "x.h"
 #include "p.h"
 #include "k.h"

--- a/models/model_neuron_py/dxdotdx_explicit.cpp
+++ b/models/model_neuron_py/dxdotdx_explicit.cpp
@@ -41,11 +41,10 @@ void dxdotdx_explicit_rowvals_model_neuron_py(SUNMatrixWrapper &dxdotdx_explicit
 
 #include "amici/symbolic_functions.h"
 #include "amici/defines.h"
-#include "sundials/sundials_types.h"
 
-#include <gsl/gsl-lite.hpp>
 #include <algorithm>
-
+#include <sundials/sundials_types.h>
+#include <gsl/gsl-lite.hpp>
 #include "x.h"
 #include "p.h"
 #include "k.h"

--- a/models/model_neuron_py/dydx.cpp
+++ b/models/model_neuron_py/dydx.cpp
@@ -1,10 +1,7 @@
 #include "amici/symbolic_functions.h"
 #include "amici/defines.h"
-#include "sundials/sundials_types.h"
 
-#include <gsl/gsl-lite.hpp>
 #include <algorithm>
-
 #include "x.h"
 #include "p.h"
 #include "k.h"

--- a/models/model_neuron_py/dzdx.cpp
+++ b/models/model_neuron_py/dzdx.cpp
@@ -1,10 +1,7 @@
 #include "amici/symbolic_functions.h"
 #include "amici/defines.h"
-#include "sundials/sundials_types.h"
 
-#include <gsl/gsl-lite.hpp>
 #include <algorithm>
-
 #include "x.h"
 #include "p.h"
 #include "k.h"

--- a/models/model_neuron_py/model_neuron_py.h
+++ b/models/model_neuron_py/model_neuron_py.h
@@ -148,7 +148,7 @@ class Model_model_neuron_py : public amici::Model_ODE {
               ),
               amici::SecondOrderMode::none,                                  // o2mode
               std::vector<realtype>{1.0, 1.0},   // idlist
-              std::vector<int>{1},               // z2events
+              std::vector<int>{0},               // z2events
               std::vector<Event>{
                   Event("event_1", false, true, NAN)
               } // events
@@ -574,7 +574,7 @@ class Model_model_neuron_py : public amici::Model_ODE {
      * @return AMICI git commit hash
      */
     std::string getAmiciCommit() const override {
-        return "570c71d2a041ed15d548e826df3d97e05d124309";
+        return "d5492c37f7dbc5faa374128e3559b96518e9a937";
     }
 
     bool hasQuadraticLLH() const override {

--- a/models/model_neuron_py/root.cpp
+++ b/models/model_neuron_py/root.cpp
@@ -1,10 +1,7 @@
 #include "amici/symbolic_functions.h"
 #include "amici/defines.h"
-#include "sundials/sundials_types.h"
 
-#include <gsl/gsl-lite.hpp>
 #include <algorithm>
-
 #include "x.h"
 #include "p.h"
 #include "k.h"

--- a/models/model_neuron_py/rz.cpp
+++ b/models/model_neuron_py/rz.cpp
@@ -1,10 +1,7 @@
 #include "amici/symbolic_functions.h"
 #include "amici/defines.h"
-#include "sundials/sundials_types.h"
 
-#include <gsl/gsl-lite.hpp>
 #include <algorithm>
-
 #include "x.h"
 #include "p.h"
 #include "k.h"

--- a/models/model_neuron_py/sigmay.cpp
+++ b/models/model_neuron_py/sigmay.cpp
@@ -1,10 +1,7 @@
 #include "amici/symbolic_functions.h"
 #include "amici/defines.h"
-#include "sundials/sundials_types.h"
 
-#include <gsl/gsl-lite.hpp>
 #include <algorithm>
-
 #include "p.h"
 #include "k.h"
 #include "y.h"

--- a/models/model_neuron_py/sigmaz.cpp
+++ b/models/model_neuron_py/sigmaz.cpp
@@ -1,10 +1,7 @@
 #include "amici/symbolic_functions.h"
 #include "amici/defines.h"
-#include "sundials/sundials_types.h"
 
-#include <gsl/gsl-lite.hpp>
 #include <algorithm>
-
 #include "p.h"
 #include "k.h"
 #include "sigmaz.h"

--- a/models/model_neuron_py/stau.cpp
+++ b/models/model_neuron_py/stau.cpp
@@ -1,10 +1,7 @@
 #include "amici/symbolic_functions.h"
 #include "amici/defines.h"
-#include "sundials/sundials_types.h"
 
-#include <gsl/gsl-lite.hpp>
 #include <algorithm>
-
 #include "x.h"
 #include "p.h"
 #include "k.h"

--- a/models/model_neuron_py/sx0.cpp
+++ b/models/model_neuron_py/sx0.cpp
@@ -1,10 +1,7 @@
 #include "amici/symbolic_functions.h"
 #include "amici/defines.h"
-#include "sundials/sundials_types.h"
 
-#include <gsl/gsl-lite.hpp>
 #include <algorithm>
-
 #include "x.h"
 #include "p.h"
 #include "k.h"

--- a/models/model_neuron_py/sx0_fixedParameters.cpp
+++ b/models/model_neuron_py/sx0_fixedParameters.cpp
@@ -1,10 +1,8 @@
 #include "amici/symbolic_functions.h"
 #include "amici/defines.h"
-#include "sundials/sundials_types.h"
 
-#include <gsl/gsl-lite.hpp>
 #include <algorithm>
-
+#include <gsl/gsl-lite.hpp>
 #include "p.h"
 #include "k.h"
 

--- a/models/model_neuron_py/x0.cpp
+++ b/models/model_neuron_py/x0.cpp
@@ -1,10 +1,7 @@
 #include "amici/symbolic_functions.h"
 #include "amici/defines.h"
-#include "sundials/sundials_types.h"
 
-#include <gsl/gsl-lite.hpp>
 #include <algorithm>
-
 #include "p.h"
 #include "k.h"
 

--- a/models/model_neuron_py/x0_fixedParameters.cpp
+++ b/models/model_neuron_py/x0_fixedParameters.cpp
@@ -1,10 +1,8 @@
 #include "amici/symbolic_functions.h"
 #include "amici/defines.h"
-#include "sundials/sundials_types.h"
 
-#include <gsl/gsl-lite.hpp>
 #include <algorithm>
-
+#include <gsl/gsl-lite.hpp>
 #include "p.h"
 #include "k.h"
 

--- a/models/model_neuron_py/x_rdata.cpp
+++ b/models/model_neuron_py/x_rdata.cpp
@@ -1,10 +1,7 @@
 #include "amici/symbolic_functions.h"
 #include "amici/defines.h"
-#include "sundials/sundials_types.h"
 
-#include <gsl/gsl-lite.hpp>
 #include <algorithm>
-
 #include "x.h"
 #include "p.h"
 #include "k.h"

--- a/models/model_neuron_py/x_solver.cpp
+++ b/models/model_neuron_py/x_solver.cpp
@@ -1,10 +1,7 @@
 #include "amici/symbolic_functions.h"
 #include "amici/defines.h"
-#include "sundials/sundials_types.h"
 
-#include <gsl/gsl-lite.hpp>
 #include <algorithm>
-
 #include "x_rdata.h"
 
 namespace amici {

--- a/models/model_neuron_py/xdot.cpp
+++ b/models/model_neuron_py/xdot.cpp
@@ -1,10 +1,7 @@
 #include "amici/symbolic_functions.h"
 #include "amici/defines.h"
-#include "sundials/sundials_types.h"
 
-#include <gsl/gsl-lite.hpp>
 #include <algorithm>
-
 #include "x.h"
 #include "p.h"
 #include "k.h"

--- a/models/model_neuron_py/y.cpp
+++ b/models/model_neuron_py/y.cpp
@@ -1,10 +1,7 @@
 #include "amici/symbolic_functions.h"
 #include "amici/defines.h"
-#include "sundials/sundials_types.h"
 
-#include <gsl/gsl-lite.hpp>
 #include <algorithm>
-
 #include "x.h"
 #include "p.h"
 #include "k.h"

--- a/models/model_neuron_py/z.cpp
+++ b/models/model_neuron_py/z.cpp
@@ -1,10 +1,7 @@
 #include "amici/symbolic_functions.h"
 #include "amici/defines.h"
-#include "sundials/sundials_types.h"
 
-#include <gsl/gsl-lite.hpp>
 #include <algorithm>
-
 #include "x.h"
 #include "p.h"
 #include "k.h"

--- a/models/model_robertson_py/Jy.cpp
+++ b/models/model_robertson_py/Jy.cpp
@@ -1,10 +1,7 @@
 #include "amici/symbolic_functions.h"
 #include "amici/defines.h"
-#include "sundials/sundials_types.h"
 
-#include <gsl/gsl-lite.hpp>
 #include <algorithm>
-
 #include "p.h"
 #include "k.h"
 #include "y.h"

--- a/models/model_robertson_py/create_splines.cpp
+++ b/models/model_robertson_py/create_splines.cpp
@@ -1,10 +1,7 @@
 #include "amici/symbolic_functions.h"
 #include "amici/defines.h"
-#include "sundials/sundials_types.h"
 
-#include <gsl/gsl-lite.hpp>
 #include <algorithm>
-
 #include "amici/splinefunctions.h"
 #include <vector>
 #include "p.h"

--- a/models/model_robertson_py/dJydsigma.cpp
+++ b/models/model_robertson_py/dJydsigma.cpp
@@ -1,10 +1,7 @@
 #include "amici/symbolic_functions.h"
 #include "amici/defines.h"
-#include "sundials/sundials_types.h"
 
-#include <gsl/gsl-lite.hpp>
 #include <algorithm>
-
 #include "p.h"
 #include "k.h"
 #include "y.h"

--- a/models/model_robertson_py/dJydy.cpp
+++ b/models/model_robertson_py/dJydy.cpp
@@ -45,11 +45,10 @@ void dJydy_rowvals_model_robertson_py(SUNMatrixWrapper &dJydy, int index){
 
 #include "amici/symbolic_functions.h"
 #include "amici/defines.h"
-#include "sundials/sundials_types.h"
 
-#include <gsl/gsl-lite.hpp>
 #include <algorithm>
-
+#include <sundials/sundials_types.h>
+#include <gsl/gsl-lite.hpp>
 #include "p.h"
 #include "k.h"
 #include "y.h"

--- a/models/model_robertson_py/dxdotdp_explicit.cpp
+++ b/models/model_robertson_py/dxdotdp_explicit.cpp
@@ -41,11 +41,10 @@ void dxdotdp_explicit_rowvals_model_robertson_py(SUNMatrixWrapper &dxdotdp_expli
 
 #include "amici/symbolic_functions.h"
 #include "amici/defines.h"
-#include "sundials/sundials_types.h"
 
-#include <gsl/gsl-lite.hpp>
 #include <algorithm>
-
+#include <sundials/sundials_types.h>
+#include <gsl/gsl-lite.hpp>
 #include "x.h"
 #include "p.h"
 #include "k.h"

--- a/models/model_robertson_py/dxdotdx_explicit.cpp
+++ b/models/model_robertson_py/dxdotdx_explicit.cpp
@@ -41,11 +41,10 @@ void dxdotdx_explicit_rowvals_model_robertson_py(SUNMatrixWrapper &dxdotdx_expli
 
 #include "amici/symbolic_functions.h"
 #include "amici/defines.h"
-#include "sundials/sundials_types.h"
 
-#include <gsl/gsl-lite.hpp>
 #include <algorithm>
-
+#include <sundials/sundials_types.h>
+#include <gsl/gsl-lite.hpp>
 #include "x.h"
 #include "p.h"
 #include "k.h"

--- a/models/model_robertson_py/dydx.cpp
+++ b/models/model_robertson_py/dydx.cpp
@@ -1,10 +1,7 @@
 #include "amici/symbolic_functions.h"
 #include "amici/defines.h"
-#include "sundials/sundials_types.h"
 
-#include <gsl/gsl-lite.hpp>
 #include <algorithm>
-
 #include "x.h"
 #include "p.h"
 #include "k.h"

--- a/models/model_robertson_py/model_robertson_py.h
+++ b/models/model_robertson_py/model_robertson_py.h
@@ -536,7 +536,7 @@ class Model_model_robertson_py : public amici::Model_DAE {
      * @return AMICI git commit hash
      */
     std::string getAmiciCommit() const override {
-        return "570c71d2a041ed15d548e826df3d97e05d124309";
+        return "d5492c37f7dbc5faa374128e3559b96518e9a937";
     }
 
     bool hasQuadraticLLH() const override {

--- a/models/model_robertson_py/sigmay.cpp
+++ b/models/model_robertson_py/sigmay.cpp
@@ -1,10 +1,7 @@
 #include "amici/symbolic_functions.h"
 #include "amici/defines.h"
-#include "sundials/sundials_types.h"
 
-#include <gsl/gsl-lite.hpp>
 #include <algorithm>
-
 #include "p.h"
 #include "k.h"
 #include "y.h"

--- a/models/model_robertson_py/sx0_fixedParameters.cpp
+++ b/models/model_robertson_py/sx0_fixedParameters.cpp
@@ -1,10 +1,8 @@
 #include "amici/symbolic_functions.h"
 #include "amici/defines.h"
-#include "sundials/sundials_types.h"
 
-#include <gsl/gsl-lite.hpp>
 #include <algorithm>
-
+#include <gsl/gsl-lite.hpp>
 #include "p.h"
 #include "k.h"
 

--- a/models/model_robertson_py/x0.cpp
+++ b/models/model_robertson_py/x0.cpp
@@ -1,10 +1,7 @@
 #include "amici/symbolic_functions.h"
 #include "amici/defines.h"
-#include "sundials/sundials_types.h"
 
-#include <gsl/gsl-lite.hpp>
 #include <algorithm>
-
 #include "p.h"
 #include "k.h"
 

--- a/models/model_robertson_py/x0_fixedParameters.cpp
+++ b/models/model_robertson_py/x0_fixedParameters.cpp
@@ -1,10 +1,8 @@
 #include "amici/symbolic_functions.h"
 #include "amici/defines.h"
-#include "sundials/sundials_types.h"
 
-#include <gsl/gsl-lite.hpp>
 #include <algorithm>
-
+#include <gsl/gsl-lite.hpp>
 #include "p.h"
 #include "k.h"
 

--- a/models/model_robertson_py/x_rdata.cpp
+++ b/models/model_robertson_py/x_rdata.cpp
@@ -1,10 +1,7 @@
 #include "amici/symbolic_functions.h"
 #include "amici/defines.h"
-#include "sundials/sundials_types.h"
 
-#include <gsl/gsl-lite.hpp>
 #include <algorithm>
-
 #include "x.h"
 #include "p.h"
 #include "k.h"

--- a/models/model_robertson_py/x_solver.cpp
+++ b/models/model_robertson_py/x_solver.cpp
@@ -1,10 +1,7 @@
 #include "amici/symbolic_functions.h"
 #include "amici/defines.h"
-#include "sundials/sundials_types.h"
 
-#include <gsl/gsl-lite.hpp>
 #include <algorithm>
-
 #include "x_rdata.h"
 
 namespace amici {

--- a/models/model_robertson_py/xdot.cpp
+++ b/models/model_robertson_py/xdot.cpp
@@ -1,10 +1,7 @@
 #include "amici/symbolic_functions.h"
 #include "amici/defines.h"
-#include "sundials/sundials_types.h"
 
-#include <gsl/gsl-lite.hpp>
 #include <algorithm>
-
 #include "x.h"
 #include "p.h"
 #include "k.h"

--- a/models/model_robertson_py/y.cpp
+++ b/models/model_robertson_py/y.cpp
@@ -1,10 +1,7 @@
 #include "amici/symbolic_functions.h"
 #include "amici/defines.h"
-#include "sundials/sundials_types.h"
 
-#include <gsl/gsl-lite.hpp>
 #include <algorithm>
-
 #include "x.h"
 #include "p.h"
 #include "k.h"

--- a/models/model_steadystate_py/Jy.cpp
+++ b/models/model_steadystate_py/Jy.cpp
@@ -1,10 +1,7 @@
 #include "amici/symbolic_functions.h"
 #include "amici/defines.h"
-#include "sundials/sundials_types.h"
 
-#include <gsl/gsl-lite.hpp>
 #include <algorithm>
-
 #include "p.h"
 #include "k.h"
 #include "y.h"

--- a/models/model_steadystate_py/create_splines.cpp
+++ b/models/model_steadystate_py/create_splines.cpp
@@ -1,10 +1,7 @@
 #include "amici/symbolic_functions.h"
 #include "amici/defines.h"
-#include "sundials/sundials_types.h"
 
-#include <gsl/gsl-lite.hpp>
 #include <algorithm>
-
 #include "amici/splinefunctions.h"
 #include <vector>
 #include "p.h"

--- a/models/model_steadystate_py/dJydsigma.cpp
+++ b/models/model_steadystate_py/dJydsigma.cpp
@@ -1,10 +1,7 @@
 #include "amici/symbolic_functions.h"
 #include "amici/defines.h"
-#include "sundials/sundials_types.h"
 
-#include <gsl/gsl-lite.hpp>
 #include <algorithm>
-
 #include "p.h"
 #include "k.h"
 #include "y.h"

--- a/models/model_steadystate_py/dJydy.cpp
+++ b/models/model_steadystate_py/dJydy.cpp
@@ -45,11 +45,10 @@ void dJydy_rowvals_model_steadystate_py(SUNMatrixWrapper &dJydy, int index){
 
 #include "amici/symbolic_functions.h"
 #include "amici/defines.h"
-#include "sundials/sundials_types.h"
 
-#include <gsl/gsl-lite.hpp>
 #include <algorithm>
-
+#include <sundials/sundials_types.h>
+#include <gsl/gsl-lite.hpp>
 #include "p.h"
 #include "k.h"
 #include "y.h"

--- a/models/model_steadystate_py/dxdotdp_explicit.cpp
+++ b/models/model_steadystate_py/dxdotdp_explicit.cpp
@@ -41,11 +41,10 @@ void dxdotdp_explicit_rowvals_model_steadystate_py(SUNMatrixWrapper &dxdotdp_exp
 
 #include "amici/symbolic_functions.h"
 #include "amici/defines.h"
-#include "sundials/sundials_types.h"
 
-#include <gsl/gsl-lite.hpp>
 #include <algorithm>
-
+#include <sundials/sundials_types.h>
+#include <gsl/gsl-lite.hpp>
 #include "x.h"
 #include "p.h"
 #include "k.h"

--- a/models/model_steadystate_py/dxdotdx_explicit.cpp
+++ b/models/model_steadystate_py/dxdotdx_explicit.cpp
@@ -41,11 +41,10 @@ void dxdotdx_explicit_rowvals_model_steadystate_py(SUNMatrixWrapper &dxdotdx_exp
 
 #include "amici/symbolic_functions.h"
 #include "amici/defines.h"
-#include "sundials/sundials_types.h"
 
-#include <gsl/gsl-lite.hpp>
 #include <algorithm>
-
+#include <sundials/sundials_types.h>
+#include <gsl/gsl-lite.hpp>
 #include "x.h"
 #include "p.h"
 #include "k.h"

--- a/models/model_steadystate_py/dydx.cpp
+++ b/models/model_steadystate_py/dydx.cpp
@@ -1,10 +1,7 @@
 #include "amici/symbolic_functions.h"
 #include "amici/defines.h"
-#include "sundials/sundials_types.h"
 
-#include <gsl/gsl-lite.hpp>
 #include <algorithm>
-
 #include "x.h"
 #include "p.h"
 #include "k.h"

--- a/models/model_steadystate_py/model_steadystate_py.h
+++ b/models/model_steadystate_py/model_steadystate_py.h
@@ -536,7 +536,7 @@ class Model_model_steadystate_py : public amici::Model_ODE {
      * @return AMICI git commit hash
      */
     std::string getAmiciCommit() const override {
-        return "570c71d2a041ed15d548e826df3d97e05d124309";
+        return "d5492c37f7dbc5faa374128e3559b96518e9a937";
     }
 
     bool hasQuadraticLLH() const override {

--- a/models/model_steadystate_py/sigmay.cpp
+++ b/models/model_steadystate_py/sigmay.cpp
@@ -1,10 +1,7 @@
 #include "amici/symbolic_functions.h"
 #include "amici/defines.h"
-#include "sundials/sundials_types.h"
 
-#include <gsl/gsl-lite.hpp>
 #include <algorithm>
-
 #include "p.h"
 #include "k.h"
 #include "y.h"

--- a/models/model_steadystate_py/sx0_fixedParameters.cpp
+++ b/models/model_steadystate_py/sx0_fixedParameters.cpp
@@ -1,10 +1,8 @@
 #include "amici/symbolic_functions.h"
 #include "amici/defines.h"
-#include "sundials/sundials_types.h"
 
-#include <gsl/gsl-lite.hpp>
 #include <algorithm>
-
+#include <gsl/gsl-lite.hpp>
 #include "p.h"
 #include "k.h"
 

--- a/models/model_steadystate_py/x0.cpp
+++ b/models/model_steadystate_py/x0.cpp
@@ -1,10 +1,7 @@
 #include "amici/symbolic_functions.h"
 #include "amici/defines.h"
-#include "sundials/sundials_types.h"
 
-#include <gsl/gsl-lite.hpp>
 #include <algorithm>
-
 #include "p.h"
 #include "k.h"
 

--- a/models/model_steadystate_py/x0_fixedParameters.cpp
+++ b/models/model_steadystate_py/x0_fixedParameters.cpp
@@ -1,10 +1,8 @@
 #include "amici/symbolic_functions.h"
 #include "amici/defines.h"
-#include "sundials/sundials_types.h"
 
-#include <gsl/gsl-lite.hpp>
 #include <algorithm>
-
+#include <gsl/gsl-lite.hpp>
 #include "p.h"
 #include "k.h"
 

--- a/models/model_steadystate_py/x_rdata.cpp
+++ b/models/model_steadystate_py/x_rdata.cpp
@@ -1,10 +1,7 @@
 #include "amici/symbolic_functions.h"
 #include "amici/defines.h"
-#include "sundials/sundials_types.h"
 
-#include <gsl/gsl-lite.hpp>
 #include <algorithm>
-
 #include "x.h"
 #include "p.h"
 #include "k.h"

--- a/models/model_steadystate_py/x_solver.cpp
+++ b/models/model_steadystate_py/x_solver.cpp
@@ -1,10 +1,7 @@
 #include "amici/symbolic_functions.h"
 #include "amici/defines.h"
-#include "sundials/sundials_types.h"
 
-#include <gsl/gsl-lite.hpp>
 #include <algorithm>
-
 #include "x_rdata.h"
 
 namespace amici {

--- a/models/model_steadystate_py/xdot.cpp
+++ b/models/model_steadystate_py/xdot.cpp
@@ -1,10 +1,7 @@
 #include "amici/symbolic_functions.h"
 #include "amici/defines.h"
-#include "sundials/sundials_types.h"
 
-#include <gsl/gsl-lite.hpp>
 #include <algorithm>
-
 #include "x.h"
 #include "p.h"
 #include "k.h"

--- a/models/model_steadystate_py/y.cpp
+++ b/models/model_steadystate_py/y.cpp
@@ -1,10 +1,7 @@
 #include "amici/symbolic_functions.h"
 #include "amici/defines.h"
-#include "sundials/sundials_types.h"
 
-#include <gsl/gsl-lite.hpp>
 #include <algorithm>
-
 #include "x.h"
 #include "p.h"
 #include "k.h"

--- a/python/sdist/amici/de_model.py
+++ b/python/sdist/amici/de_model.py
@@ -1680,16 +1680,14 @@ class DEModel:
                 sp.zeros(self.num_eventobs(), 1) for _ in self._events
             ]
             event_ids = [e.get_id() for e in self._events]
-            # TODO: get rid of this stupid 1-based indexing as soon as we can
-            #  drop the matlab interface
             z2event = [
-                event_ids.index(event_obs.get_event()) + 1
+                event_ids.index(event_obs.get_event())
                 for event_obs in self._event_observables
             ]
             for (iz, ie), event_obs in zip(
                 enumerate(z2event), self._event_observables, strict=True
             ):
-                event_observables[ie - 1][iz] = event_obs.get_val()
+                event_observables[ie][iz] = event_obs.get_val()
 
             self._eqs[name] = event_observables
             self._z2event = z2event
@@ -1715,7 +1713,7 @@ class DEModel:
                 dtaudx = self.eq("dtaudx")
                 for ie in range(self.num_events()):
                     for iz in range(self.num_eventobs()):
-                        if ie != self._z2event[iz] - 1:
+                        if ie != self._z2event[iz]:
                             continue
                         dzdt = sp.diff(self.eq("z")[ie][iz], time_symbol)
                         self._eqs[name][ie][iz, :] += dzdt * -dtaudx[ie]
@@ -1729,7 +1727,7 @@ class DEModel:
                 )
                 # match event observables to root function
                 for iz in range(self.num_eventobs()):
-                    if ie == self._z2event[iz] - 1:
+                    if ie == self._z2event[iz]:
                         val[iz, :] = self.eq(name.replace("rz", "root"))[ie, :]
                 eq_events.append(val)
 

--- a/src/model.cpp
+++ b/src/model.cpp
@@ -1267,7 +1267,7 @@ void Model::getUnobservedEventSensitivity(
     checkBufferSize(sz, nz * nplist());
 
     for (int iz = 0; iz < nz; ++iz)
-        if (z2event_.at(iz) - 1 == ie)
+        if (z2event_.at(iz) == ie)
             for (int ip = 0; ip < nplist(); ++ip)
                 sz[ip * nz + iz] = 0.0;
 }
@@ -1984,7 +1984,7 @@ void Model::writeSliceEvent(
     checkBufferSize(buffer, slice.size());
     checkBufferSize(buffer, z2event_.size());
     for (unsigned izt = 0; izt < z2event_.size(); ++izt)
-        if (z2event_.at(izt) - 1 == ie)
+        if (z2event_.at(izt) == ie)
             buffer[izt] = slice[izt];
 }
 
@@ -1995,7 +1995,7 @@ void Model::writeSensitivitySliceEvent(
     checkBufferSize(buffer, z2event_.size() * nplist());
     for (int ip = 0; ip < nplist(); ++ip)
         for (unsigned izt = 0; izt < z2event_.size(); ++izt)
-            if (z2event_.at(izt) - 1 == ie)
+            if (z2event_.at(izt) == ie)
                 buffer[ip * nztrue + izt] = slice[ip * nztrue + izt];
 }
 
@@ -2471,7 +2471,7 @@ void Model::fsigmaz(
 
     if (edata) {
         for (int iztrue = 0; iztrue < nztrue; iztrue++) {
-            if (z2event_.at(iztrue) - 1 == ie) {
+            if (z2event_.at(iztrue) == ie) {
                 if (edata->isSetObservedEventsStdDev(nroots, iztrue)) {
                     auto sigmaz_edata
                         = edata->getObservedEventsStdDevPtr(nroots);
@@ -2514,7 +2514,7 @@ void Model::fdsigmazdp(
     // to zero
     if (edata) {
         for (int iz = 0; iz < nztrue; iz++) {
-            if (z2event_.at(iz) - 1 == ie
+            if (z2event_.at(iz) == ie
                 && !edata->isSetObservedEventsStdDev(nroots, iz)) {
                 for (int ip = 0; ip < nplist(); ip++)
                     derived_state_.dsigmazdp_.at(iz + nz * ip) = 0;


### PR DESCRIPTION
Get rid of 1-based event-indexing in `Model::z2event_` from ancient MATLAB times.


Related to #2727.