### PR TITLE
Remove `amici.petab.petab_import.import_model` alias.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,9 @@ BREAKING CHANGES
   `(1, 3)`.
 * `AmiVector::getLength` and `AmiVectorArray::getLength` have been renamed to
   `size` to be more consistent with STL containers.
+* `amici.petab.petab_import.import_model` has been removed.
+  Use `amici.petab.petab_import.import_model_sbml` instead.
+  (The former was just an alias for the latter.)
 * The following deprecated functionality has been removed:
   * The complete MATLAB interface has been removed.
   * `NonlinearSolverIteration::functional` has been removed,

--- a/python/sdist/amici/petab/petab_import.py
+++ b/python/sdist/amici/petab/petab_import.py
@@ -174,7 +174,3 @@ def import_petab_problem(
     )
 
     return model
-
-
-# for backwards compatibility
-import_model = import_model_sbml

--- a/python/tests/test_petab_import.py
+++ b/python/tests/test_petab_import.py
@@ -116,7 +116,7 @@ def test_get_fixed_parameters(get_fixed_parameters_model):
 
 @skip_on_valgrind
 def test_default_output_parameters(simple_sbml_model, tempdir):
-    from amici.petab.petab_import import import_model
+    from amici.petab.petab_import import import_model_sbml
     from petab.v1.models.sbml_model import SbmlModel
 
     sbml_doc, sbml_model = simple_sbml_model
@@ -146,7 +146,7 @@ def test_default_output_parameters(simple_sbml_model, tempdir):
         observable_df=observable_df,
     )
 
-    sbml_importer = import_model(
+    sbml_importer = import_model_sbml(
         petab_problem=petab_problem,
         output_parameter_defaults={"observableParameter1_obs1": 1.0},
         compile=False,
@@ -160,7 +160,7 @@ def test_default_output_parameters(simple_sbml_model, tempdir):
     )
 
     with pytest.raises(ValueError):
-        import_model(
+        import_model_sbml(
             petab_problem=petab_problem,
             output_parameter_defaults={"nonExistentParameter": 1.0},
             compile=False,

--- a/tests/performance/test.py
+++ b/tests/performance/test.py
@@ -9,7 +9,7 @@ from pathlib import Path
 
 import amici
 import petab.v1 as petab
-from amici.petab.petab_import import import_model
+from amici.petab.petab_import import import_model_sbml
 
 
 def parse_args():
@@ -74,7 +74,7 @@ def run_import(model_name, model_dir: Path):
     petab.lint_problem(pp)
     amici.de_export.logger.setLevel(logging.DEBUG)
     amici.sbml_import.logger.setLevel(logging.DEBUG)
-    import_model(
+    import_model_sbml(
         model_name=model_name,
         model_output_dir=model_dir,
         petab_problem=pp,


### PR DESCRIPTION
Remove `amici.petab.petab_import.import_model` which was an alias for `amici.petab.petab_import.import_model_sbml` for backward compatibility.