### PR TITLE
Fix failing tests - `RuntimeError: Not a datatype (not a datatype)`

### DIFF
--- a/python/sdist/pyproject.toml
+++ b/python/sdist/pyproject.toml
@@ -63,7 +63,7 @@ classifiers = [
 petab = ["petab>=0.4.0"]
 pysb = ["pysb>=1.13.1"]
 test = [
-    "h5py!=3.15; platform_system=='Darwin'",
+    "h5py!=3.15",
     "pytest",
     "pytest-cov",
     # v16.0: https://github.com/pytest-dev/pytest-rerunfailures/issues/302


### PR DESCRIPTION
Require `h5py!=3.15`.

Closes #2978.