### PR TITLE
Enable pickling of `ModelPtr`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -61,6 +61,10 @@ See also our [versioning policy](https://amici.readthedocs.io/en/latest/versioni
   This is a wrapper for both `amici.run_simulation` and
   `amici.run_simulations`, depending on the type of the `edata` argument.
   It also supports passing some `Solver` options as keyword arguments.
+* `amici.ModelPtr` now supports sufficient pickling for use in
+  multi-processing contexts. This works only if the amici-generated model
+  package exists in the same file system location and does not change until
+  unpickling.
 
 ## v0.X Series
 

--- a/swig/model.i
+++ b/swig/model.i
@@ -195,6 +195,20 @@ def simulate(
 def __deepcopy__(self, memo):
     return self.clone()
 
+def __reduce__(self):
+    from amici.swig_wrappers import restore_model, get_model_settings, file_checksum
+
+    return (
+        restore_model,
+        (
+            self.get_name(),
+            Path(self.module.__spec__.origin).parent,
+            get_model_settings(self),
+            file_checksum(self.module.extension_path),
+        ),
+        {}
+    )
+
 
 @overload
 def simulate(

--- a/swig/modelname.template.i
+++ b/swig/modelname.template.i
@@ -8,10 +8,11 @@ import sysconfig
 from pathlib import Path
 
 ext_suffix = sysconfig.get_config_var('EXT_SUFFIX')
+extension_path = Path(__file__).parent / f'_TPL_MODELNAME{ext_suffix}'
 _TPL_MODELNAME = amici._module_from_path(
     'TPL_MODELNAME._TPL_MODELNAME' if __package__ or '.' in __name__
     else '_TPL_MODELNAME',
-    Path(__file__).parent / f'_TPL_MODELNAME{ext_suffix}',
+    extension_path,
 )
 
 def _get_import_time():


### PR DESCRIPTION
Enable pickling of `ModelPtr` for use in multiprocessing contexts.

Related to #1126.