### PR TITLE
Fix extension re-import check for swig v4.4.0

### DIFF
--- a/swig/modelname.template.i
+++ b/swig/modelname.template.i
@@ -57,7 +57,7 @@ using namespace amici;
 // store the time a module was imported
 %{
 #include <chrono>
-static std::chrono::time_point<std::chrono::system_clock> _module_import_time;
+static std::chrono::time_point<std::chrono::system_clock> _module_import_time = std::chrono::system_clock::now();
 
 static double _get_import_time() {
     auto epoch = _module_import_time.time_since_epoch();
@@ -68,7 +68,9 @@ static double _get_import_time() {
 static double _get_import_time();
 
 %init %{
-    _module_import_time = std::chrono::system_clock::now();
+    // NOTE: from SWIG 4.4.0 onwards, %init code is executed every time the
+    // module is executed - not only on first import
+    // This code ends up in `SWIG_mod_exec`.
 %}
 
 


### PR DESCRIPTION
Extension initialization changed there. `%init` code is now executed each time the extension is executed, not only during the initial import.

Fixes #2991.