### PR TITLE
Swig version mismatch warning

### DIFF
--- a/swig/amici.i
+++ b/swig/amici.i
@@ -64,6 +64,17 @@ nonstandard type conversions.
     }
 }
 
+// store swig version
+%constant int SWIG_VERSION_MAJOR = (SWIG_VERSION >> 16);
+%constant int SWIG_VERSION_MINOR = ((SWIG_VERSION >> 8) & 0xff);
+%constant int SWIG_VERSION_PATCH = (SWIG_VERSION & 0xff);
+
+%pythoncode %{
+# SWIG version used to build the amici extension as `(major, minor, patch)`
+_SWIG_VERSION = (SWIG_VERSION_MAJOR, SWIG_VERSION_MINOR, SWIG_VERSION_PATCH)
+%}
+
+
 // Warning 503: Can't wrap 'operator ==' unless renamed to a valid identifier.
 %rename("__eq__") operator ==;
 

--- a/swig/modelname.template.i
+++ b/swig/modelname.template.i
@@ -37,6 +37,28 @@ if t_imported < t_modified:
 
 %module(package="TPL_MODELNAME",moduleimport=MODULEIMPORT) TPL_MODELNAME
 
+// store swig version
+%constant int SWIG_VERSION_MAJOR = (SWIG_VERSION >> 16);
+%constant int SWIG_VERSION_MINOR = ((SWIG_VERSION >> 8) & 0xff);
+%constant int SWIG_VERSION_PATCH = (SWIG_VERSION & 0xff);
+
+%pythoncode %{
+# SWIG version used to build the model extension as `(major, minor, patch)`
+_SWIG_VERSION = (SWIG_VERSION_MAJOR, SWIG_VERSION_MINOR, SWIG_VERSION_PATCH)
+
+if (amici_swig := amici.amici._SWIG_VERSION) != (model_swig := _SWIG_VERSION):
+    import warnings
+    warnings.warn(
+        f"SWIG version mismatch between amici ({amici_swig}) and model "
+        f"({model_swig}). This may lead to unexpected behavior. "
+        "In that case, please recompile the model with swig=="
+        f"{amici_swig[0]}.{amici_swig[1]}.{amici_swig[2]} or rebuild amici "
+        f"with swig=={model_swig[0]}.{model_swig[1]}.{model_swig[2]}.",
+        RuntimeWarning,
+        stacklevel=2,
+    )
+%}
+
 %pythoncode %{
 # the model-package __init__.py module (will be set during import)
 _model_module = None


### PR DESCRIPTION
Store swig version used for the amici and model extensions. Emit a warning if versions don't match.

Closes #2993.