### PR TITLE
Don't build swig

### DIFF
--- a/.github/actions/setup-swig/action.yml
+++ b/.github/actions/setup-swig/action.yml
@@ -7,7 +7,7 @@ inputs:
   swig_version:
     description: 'Swig version to build'
     required: false
-    default: '4.2.0'
+    default: '4.4.0'
 
 runs:
   using: "composite"

--- a/.github/workflows/deploy_branch.yml
+++ b/.github/workflows/deploy_branch.yml
@@ -21,9 +21,6 @@ jobs:
       with:
         fetch-depth: 20
 
-    - name: Set up SWIG
-      uses: ./.github/actions/setup-swig
-
     - run: echo "AMICI_DIR=$(pwd)" >> $GITHUB_ENV
 
     - name: Create AMICI sdist

--- a/.github/workflows/deploy_release.yml
+++ b/.github/workflows/deploy_release.yml
@@ -31,9 +31,6 @@ jobs:
       with:
         fetch-depth: 20
 
-    - name: Set up SWIG
-      uses: ./.github/actions/setup-swig
-
     - run: echo "AMICI_DIR=$(pwd)" >> $GITHUB_ENV
 
     - name: sdist

--- a/.github/workflows/test_doc.yml
+++ b/.github/workflows/test_doc.yml
@@ -67,8 +67,5 @@ jobs:
               pandoc \
             && pip install tox
 
-      - name: Set up SWIG
-        uses: ./.github/actions/setup-swig
-
       - name: Run sphinx
         run: tox -e doc

--- a/scripts/downloadAndBuildSwig.sh
+++ b/scripts/downloadAndBuildSwig.sh
@@ -7,7 +7,7 @@ set -euo pipefail
 SCRIPT_PATH=$(dirname "$BASH_SOURCE")
 AMICI_PATH=$(cd "$SCRIPT_PATH/.." && pwd)
 
-swig_version="${1:-"4.3.1"}"
+swig_version="${1:-"4.4.0"}"
 SWIG_ARCHIVE="swig-${swig_version}.tar.gz"
 SWIG_URL="http://downloads.sourceforge.net/project/swig/swig/swig-${swig_version}/${SWIG_ARCHIVE}"
 SWIG_DIR="swig-${swig_version}"


### PR DESCRIPTION
Meanwhile, we use swig from PyPI. There is currently no need to build swig ourselves. That version was anyways shadowed by PyPI-swig.