### PR TITLE
Don't use `is` comparisons for sympy objects

### DIFF
--- a/python/sdist/amici/importers/sbml/__init__.py
+++ b/python/sdist/amici/importers/sbml/__init__.py
@@ -2714,7 +2714,7 @@ class SbmlImporter:
                 if old_symbol in symbols:
                     # reconstitute the whole dict in order to keep the ordering
                     self.symbols[symbols_ids] = {
-                        new_symbol if k is old_symbol else k: v
+                        new_symbol if k == old_symbol else k: v
                         for k, v in symbols.items()
                     }
 


### PR DESCRIPTION
`is` comparisons for `sympy.Symbol` or other sympy expressions are fragile and shouldn't be relied on.


`python -c "from sympy import Symbol; print(Symbol('a') is Symbol('a'))"` -> `True`
`SYMPY_USE_CACHE="no" python -c "from sympy import Symbol; print(Symbol('a') is Symbol('a'))"` -> `False`
