### PR TITLE
doc: Skip petab-sciml for now

### DIFF
--- a/doc/rtd_requirements.txt
+++ b/doc/rtd_requirements.txt
@@ -8,7 +8,6 @@ setuptools>=67.7.2
 #  for building the documentation, we don't care whether this fully works
 git+https://github.com/pysb/pysb@0afeaab385e9a1d813ecf6fdaf0153f4b91358af
 # For forward type definition in generate_equinox
-git+https://github.com/PEtab-dev/petab_sciml.git@727d177fd3f85509d0bdcc278b672e9eeafd2384#subdirectory=src/python
 matplotlib>=3.7.1
 optax
 nbsphinx


### PR DESCRIPTION
GitHub Action runners run out of disk space when installing petab-sciml with all its huge dependencies. Don't install that for now. So far, it's not used anywhere for the documentation build as far as I can see. This won't prevent enabling intersphinx later on.