### PR TITLE
Fix `DEModel._expr_is_time_dependent` not accounting for event assignment targets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -105,6 +105,11 @@ See also our [versioning policy](https://amici.readthedocs.io/en/latest/versioni
   can now be specified via the `AMICI_MODELS_ROOT` environment variable.
   See `amici.get_model_dir` for details.
 
+**Fixes**
+
+* Fixed a bug that potentially results in incorrect handling of
+  discontinuities their location depends on a state variable
+  that is subject to an event assignment but otherwise constant.
 
 ## v0.X Series
 


### PR DESCRIPTION
Fixes #3046.

Relax the faulty check. Better to track more root functions than missing some. Will optimize after https://github.com/AMICI-dev/AMICI/pull/3031.