### PR TITLE
Fix import performance regression and update time limits

### DIFF
--- a/python/tests/test_misc.py
+++ b/python/tests/test_misc.py
@@ -84,7 +84,8 @@ def test_cmake_compilation(sbml_example_presimulation_module):
 
 
 @skip_on_valgrind
-def test_smart_subs_dict():
+@pytest.mark.parametrize("flatten_first", [True, False])
+def test_smart_subs_dict(flatten_first):
     expr_str = "c + d"
     subs_dict = {
         "c": "a + b",
@@ -98,8 +99,12 @@ def test_smart_subs_dict():
     expected_default = sp.sympify(expected_default_str)
     expected_reverse = sp.sympify(expected_reverse_str)
 
-    result_default = smart_subs_dict(expr_sym, subs_sym)
-    result_reverse = smart_subs_dict(expr_sym, subs_sym, reverse=False)
+    result_default = smart_subs_dict(
+        expr_sym, subs_sym, flatten_first=flatten_first
+    )
+    result_reverse = smart_subs_dict(
+        expr_sym, subs_sym, reverse=False, flatten_first=flatten_first
+    )
 
     assert sp.simplify(result_default - expected_default).is_zero
     assert sp.simplify(result_reverse - expected_reverse).is_zero

--- a/tests/performance/reference.yml
+++ b/tests/performance/reference.yml
@@ -1,11 +1,11 @@
 # Reference wall times (seconds) with some buffer
 create_sdist: 16
 install_sdist: 150
-petab_import: 2100
-install_model: 120
+petab_import: 720
+install_model: 60
 install_model_O0: 40
-install_model_O1: 90
-install_model_O2: 120
+install_model_O1: 45
+install_model_O2: 60
 forward_simulation: 2
 forward_sensitivities: 2
 adjoint_sensitivities: 2.5


### PR DESCRIPTION
Unfortunately, https://github.com/AMICI-dev/AMICI/pull/3030 doubled the import time for our performance test model, but the check there was too lax to catch it.

Sometimes, `smart_subs_dict` is applied to individual expressions, sometimes to complete matrices. If it's only applied to individual expressions or small matrices, avoid the overhead of flattening the substitutions first.

Update the time limits for the performance tests to catch such regressions earlier.

Fixes #3048.