### PR TITLE
Replace min/max disguised as piecewise

### DIFF
--- a/python/sdist/amici/importers/sbml/__init__.py
+++ b/python/sdist/amici/importers/sbml/__init__.py
@@ -66,6 +66,7 @@ from amici.importers.utils import (
 from amici.logging import get_logger, log_execution_time, set_log_level
 from amici.sympy_utils import (
     _monkeypatch_sympy,
+    _piecewise_to_minmax,
     smart_is_zero_matrix,
     smart_multiply,
 )
@@ -2882,6 +2883,7 @@ class SbmlImporter:
         # piecewise to heavisides
         if piecewise_to_heaviside:
             try:
+                expr = expr.replace(sp.Piecewise, _piecewise_to_minmax)
                 expr = expr.replace(
                     sp.Piecewise,
                     lambda *args: _parse_piecewise_to_heaviside(args),

--- a/python/sdist/amici/sympy_utils.py
+++ b/python/sdist/amici/sympy_utils.py
@@ -216,3 +216,19 @@ def _parallel_applyfunc(obj: sp.Matrix, func: Callable) -> sp.Matrix:
                 "to a module-level function or disable parallelization by "
                 "setting `AMICI_IMPORT_NPROCS=1`."
             ) from e
+
+
+def _piecewise_to_minmax(
+    *expr_cond_pairs: tuple[tuple[sp.Basic, sp.Basic], ...],
+) -> sp.Basic:
+    """Replace min/max defined via Piecewise with plain Min/Max.
+
+    To be used in ``expr = expr.replace(sp.Piecewise, pw_to_minmax)``.
+    """
+    if len(expr_cond_pairs) == 2 and expr_cond_pairs[-1][1] == sp.true:
+        (expr1, cond1), (expr2, cond2) = expr_cond_pairs
+        if cond1.args == (expr1, expr2) and cond1.func in (sp.Lt, sp.Le):
+            return sp.Min(expr1, expr2)
+        elif cond1.args == (expr1, expr2) and cond1.func in (sp.Gt, sp.Ge):
+            return sp.Max(expr1, expr2)
+    return sp.Piecewise(*expr_cond_pairs)


### PR DESCRIPTION
During model import, simplify piecewise functions that can be expressed as min()/max().

So far, all piecewise constructs are treated as discontinuous (see also #2049). For min/max, only the derivative is discontinuous, which currently does not receive any special treatment in amici (see also https://amici.readthedocs.io/en/latest/implementation_discontinuities.html).

So this change prevents root tracking for some unnecessary piecewises. Addresses some aspects of https://github.com/AMICI-dev/AMICI/issues/2049.