### PR TITLE
Remove auto-generated `flux_r0` expression in models without reactions

### DIFF
--- a/models/model_calvetti_py/dwdw.cpp
+++ b/models/model_calvetti_py/dwdw.cpp
@@ -7,8 +7,8 @@
 namespace amici {
 namespace model_model_calvetti_py {
 
-static constexpr std::array<sunindextype, 18> dwdw_colptrs_model_calvetti_py_ = {
-    0, 1, 2, 3, 4, 5, 6, 6, 6, 7, 9, 12, 16, 16, 16, 16, 16, 16
+static constexpr std::array<sunindextype, 17> dwdw_colptrs_model_calvetti_py_ = {
+    0, 1, 2, 3, 4, 5, 6, 6, 6, 7, 9, 12, 16, 16, 16, 16, 16
 };
 
 void dwdw_colptrs_model_calvetti_py(SUNMatrixWrapper &dwdw){

--- a/models/model_calvetti_py/dxdotdw.cpp
+++ b/models/model_calvetti_py/dxdotdw.cpp
@@ -7,8 +7,8 @@
 namespace amici {
 namespace model_model_calvetti_py {
 
-static constexpr std::array<sunindextype, 18> dxdotdw_colptrs_model_calvetti_py_ = {
-    0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 3, 5, 7, 7
+static constexpr std::array<sunindextype, 17> dxdotdw_colptrs_model_calvetti_py_ = {
+    0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 3, 5, 7
 };
 
 void dxdotdw_colptrs_model_calvetti_py(SUNMatrixWrapper &dxdotdw){

--- a/models/model_calvetti_py/model_calvetti_py.cpp
+++ b/models/model_calvetti_py/model_calvetti_py.cpp
@@ -45,7 +45,7 @@ ObservableScaling::lin, // y[4]
 ObservableScaling::lin, // y[5]
 };
 
-std::array<const char*, 17> expression_names = {
+std::array<const char*, 16> expression_names = {
     "C1ss", // w[0]
 "C2ss", // w[1]
 "C3ss", // w[2]
@@ -62,7 +62,6 @@ std::array<const char*, 17> expression_names = {
 "rate_of_V1", // w[13]
 "rate_of_V2", // w[14]
 "rate_of_V3", // w[15]
-"flux_r0", // w[16]
 };
 
 std::array<const char*, 0> free_parameter_ids = {
@@ -96,7 +95,7 @@ std::array<const char*, 6> observable_ids = {
 "obs_f2", // y[5]
 };
 
-std::array<const char*, 17> expression_ids = {
+std::array<const char*, 16> expression_ids = {
     "C1ss", // w[0]
 "C2ss", // w[1]
 "C3ss", // w[2]
@@ -113,7 +112,6 @@ std::array<const char*, 17> expression_ids = {
 "rate_of_V1", // w[13]
 "rate_of_V2", // w[14]
 "rate_of_V3", // w[15]
-"flux_r0", // w[16]
 };
 
 std::array<int, 6> state_idxs_solver = {

--- a/models/model_calvetti_py/model_calvetti_py.h
+++ b/models/model_calvetti_py/model_calvetti_py.h
@@ -19,12 +19,12 @@ extern std::array<const char*, 6> fixed_parameter_names;
 extern std::array<const char*, 6> state_names;
 extern std::array<const char*, 6> observable_names;
 extern std::array<const ObservableScaling, 6> observable_scalings;
-extern std::array<const char*, 17> expression_names;
+extern std::array<const char*, 16> expression_names;
 extern std::array<const char*, 0> free_parameter_ids;
 extern std::array<const char*, 6> fixed_parameter_ids;
 extern std::array<const char*, 6> state_ids;
 extern std::array<const char*, 6> observable_ids;
-extern std::array<const char*, 17> expression_ids;
+extern std::array<const char*, 16> expression_ids;
 extern std::array<int, 6> state_idxs_solver;
 
 extern void Jy_model_calvetti_py(realtype *Jy, const int iy, const realtype *p, const realtype *k, const realtype *y, const realtype *sigmay, const realtype *my);
@@ -125,7 +125,7 @@ class Model_model_calvetti_py : public amici::Model_DAE {
                   .ne = 4,
                   .ne_solver = 0,
                   .nspl = 0,
-                  .nw = 17,
+                  .nw = 16,
                   .ndwdx = 15,
                   .ndwdp = 0,
                   .ndwdw = 16,
@@ -557,7 +557,7 @@ class Model_model_calvetti_py : public amici::Model_DAE {
      * @return AMICI git commit hash
      */
     std::string get_amici_commit() const override {
-        return "63f2e78a186ee722a79b0da2797e0c116ec81065";
+        return "c4a395b6462dc1f26ad1472e6b2fa71fe0d54382";
     }
 
     bool has_quadratic_llh() const override {

--- a/models/model_calvetti_py/w.h
+++ b/models/model_calvetti_py/w.h
@@ -14,4 +14,3 @@
 #define rate_of_V1 w[13]
 #define rate_of_V2 w[14]
 #define rate_of_V3 w[15]
-#define flux_r0 w[16]

--- a/models/model_dirac_py/CMakeLists.txt
+++ b/models/model_dirac_py/CMakeLists.txt
@@ -88,7 +88,6 @@ sigmay.h
 stau.cpp 
 stau.h 
 sx.h 
-w.h 
 wrapfunctions.cpp 
 wrapfunctions.h 
 x.h 

--- a/models/model_dirac_py/deltaqB.cpp
+++ b/models/model_dirac_py/deltaqB.cpp
@@ -5,7 +5,6 @@
 #include "x.h"
 #include "p.h"
 #include "h.h"
-#include "w.h"
 #include "xdot.h"
 #include "xdot_old.h"
 #include "x_old.h"

--- a/models/model_dirac_py/dxdotdp_explicit.cpp
+++ b/models/model_dirac_py/dxdotdp_explicit.cpp
@@ -48,7 +48,6 @@ void dxdotdp_explicit_rowvals_model_dirac_py(SUNMatrixWrapper &dxdotdp_explicit)
 #include "x.h"
 #include "p.h"
 #include "h.h"
-#include "w.h"
 #include "dxdotdp_explicit.h"
 
 namespace amici {

--- a/models/model_dirac_py/dxdotdx_explicit.cpp
+++ b/models/model_dirac_py/dxdotdx_explicit.cpp
@@ -48,7 +48,6 @@ void dxdotdx_explicit_rowvals_model_dirac_py(SUNMatrixWrapper &dxdotdx_explicit)
 #include "x.h"
 #include "p.h"
 #include "h.h"
-#include "w.h"
 #include "dxdotdx_explicit.h"
 
 namespace amici {

--- a/models/model_dirac_py/model_dirac_py.cpp
+++ b/models/model_dirac_py/model_dirac_py.cpp
@@ -29,8 +29,8 @@ std::array<const ObservableScaling, 1> observable_scalings = {
     ObservableScaling::lin, // y[0]
 };
 
-std::array<const char*, 1> expression_names = {
-    "flux_r0", // w[0]
+std::array<const char*, 0> expression_names = {
+    
 };
 
 std::array<const char*, 4> free_parameter_ids = {
@@ -53,8 +53,8 @@ std::array<const char*, 1> observable_ids = {
     "obs_x2", // y[0]
 };
 
-std::array<const char*, 1> expression_ids = {
-    "flux_r0", // w[0]
+std::array<const char*, 0> expression_ids = {
+    
 };
 
 std::array<int, 2> state_idxs_solver = {

--- a/models/model_dirac_py/model_dirac_py.h
+++ b/models/model_dirac_py/model_dirac_py.h
@@ -19,12 +19,12 @@ extern std::array<const char*, 0> fixed_parameter_names;
 extern std::array<const char*, 2> state_names;
 extern std::array<const char*, 1> observable_names;
 extern std::array<const ObservableScaling, 1> observable_scalings;
-extern std::array<const char*, 1> expression_names;
+extern std::array<const char*, 0> expression_names;
 extern std::array<const char*, 4> free_parameter_ids;
 extern std::array<const char*, 0> fixed_parameter_ids;
 extern std::array<const char*, 2> state_ids;
 extern std::array<const char*, 1> observable_ids;
-extern std::array<const char*, 1> expression_ids;
+extern std::array<const char*, 0> expression_ids;
 extern std::array<int, 2> state_idxs_solver;
 
 extern void Jy_model_dirac_py(realtype *Jy, const int iy, const realtype *p, const realtype *k, const realtype *y, const realtype *sigmay, const realtype *my);
@@ -125,7 +125,7 @@ class Model_model_dirac_py : public amici::Model_ODE {
                   .ne = 1,
                   .ne_solver = 0,
                   .nspl = 0,
-                  .nw = 1,
+                  .nw = 0,
                   .ndwdx = 0,
                   .ndwdp = 0,
                   .ndwdw = 0,
@@ -544,7 +544,7 @@ class Model_model_dirac_py : public amici::Model_ODE {
      * @return AMICI git commit hash
      */
     std::string get_amici_commit() const override {
-        return "63f2e78a186ee722a79b0da2797e0c116ec81065";
+        return "c4a395b6462dc1f26ad1472e6b2fa71fe0d54382";
     }
 
     bool has_quadratic_llh() const override {

--- a/models/model_dirac_py/w.h
+++ b/models/model_dirac_py/w.h
@@ -1,1 +1,0 @@
-#define flux_r0 w[0]

--- a/models/model_dirac_py/xdot.cpp
+++ b/models/model_dirac_py/xdot.cpp
@@ -5,7 +5,6 @@
 #include "x.h"
 #include "p.h"
 #include "h.h"
-#include "w.h"
 #include "xdot.h"
 
 namespace amici {

--- a/models/model_events_py/CMakeLists.txt
+++ b/models/model_events_py/CMakeLists.txt
@@ -104,7 +104,6 @@ stau.cpp
 stau.h 
 sx.h 
 sx0_fixedParameters.cpp 
-w.h 
 wrapfunctions.cpp 
 wrapfunctions.h 
 x.h 

--- a/models/model_events_py/deltaqB.cpp
+++ b/models/model_events_py/deltaqB.cpp
@@ -6,7 +6,6 @@
 #include "p.h"
 #include "k.h"
 #include "h.h"
-#include "w.h"
 #include "xdot.h"
 #include "xdot_old.h"
 #include "x_old.h"

--- a/models/model_events_py/deltaxB.cpp
+++ b/models/model_events_py/deltaxB.cpp
@@ -6,7 +6,6 @@
 #include "p.h"
 #include "k.h"
 #include "h.h"
-#include "w.h"
 #include "xdot.h"
 #include "xdot_old.h"
 #include "x_old.h"

--- a/models/model_events_py/dxdotdp_explicit.cpp
+++ b/models/model_events_py/dxdotdp_explicit.cpp
@@ -49,7 +49,6 @@ void dxdotdp_explicit_rowvals_model_events_py(SUNMatrixWrapper &dxdotdp_explicit
 #include "p.h"
 #include "k.h"
 #include "h.h"
-#include "w.h"
 #include "dxdotdp_explicit.h"
 
 namespace amici {

--- a/models/model_events_py/dxdotdx_explicit.cpp
+++ b/models/model_events_py/dxdotdx_explicit.cpp
@@ -49,7 +49,6 @@ void dxdotdx_explicit_rowvals_model_events_py(SUNMatrixWrapper &dxdotdx_explicit
 #include "p.h"
 #include "k.h"
 #include "h.h"
-#include "w.h"
 #include "dxdotdx_explicit.h"
 
 namespace amici {

--- a/models/model_events_py/model_events_py.cpp
+++ b/models/model_events_py/model_events_py.cpp
@@ -33,8 +33,8 @@ std::array<const ObservableScaling, 1> observable_scalings = {
     ObservableScaling::lin, // y[0]
 };
 
-std::array<const char*, 1> expression_names = {
-    "flux_r0", // w[0]
+std::array<const char*, 0> expression_names = {
+    
 };
 
 std::array<const char*, 4> free_parameter_ids = {
@@ -61,8 +61,8 @@ std::array<const char*, 1> observable_ids = {
     "y1", // y[0]
 };
 
-std::array<const char*, 1> expression_ids = {
-    "flux_r0", // w[0]
+std::array<const char*, 0> expression_ids = {
+    
 };
 
 std::array<int, 3> state_idxs_solver = {

--- a/models/model_events_py/model_events_py.h
+++ b/models/model_events_py/model_events_py.h
@@ -19,12 +19,12 @@ extern std::array<const char*, 4> fixed_parameter_names;
 extern std::array<const char*, 3> state_names;
 extern std::array<const char*, 1> observable_names;
 extern std::array<const ObservableScaling, 1> observable_scalings;
-extern std::array<const char*, 1> expression_names;
+extern std::array<const char*, 0> expression_names;
 extern std::array<const char*, 4> free_parameter_ids;
 extern std::array<const char*, 4> fixed_parameter_ids;
 extern std::array<const char*, 3> state_ids;
 extern std::array<const char*, 1> observable_ids;
-extern std::array<const char*, 1> expression_ids;
+extern std::array<const char*, 0> expression_ids;
 extern std::array<int, 3> state_idxs_solver;
 
 extern void Jy_model_events_py(realtype *Jy, const int iy, const realtype *p, const realtype *k, const realtype *y, const realtype *sigmay, const realtype *my);
@@ -125,7 +125,7 @@ class Model_model_events_py : public amici::Model_ODE {
                   .ne = 6,
                   .ne_solver = 2,
                   .nspl = 0,
-                  .nw = 1,
+                  .nw = 0,
                   .ndwdx = 0,
                   .ndwdp = 0,
                   .ndwdw = 0,
@@ -579,7 +579,7 @@ class Model_model_events_py : public amici::Model_ODE {
      * @return AMICI git commit hash
      */
     std::string get_amici_commit() const override {
-        return "63f2e78a186ee722a79b0da2797e0c116ec81065";
+        return "c4a395b6462dc1f26ad1472e6b2fa71fe0d54382";
     }
 
     bool has_quadratic_llh() const override {

--- a/models/model_events_py/w.h
+++ b/models/model_events_py/w.h
@@ -1,1 +1,0 @@
-#define flux_r0 w[0]

--- a/models/model_events_py/xdot.cpp
+++ b/models/model_events_py/xdot.cpp
@@ -6,7 +6,6 @@
 #include "p.h"
 #include "k.h"
 #include "h.h"
-#include "w.h"
 #include "xdot.h"
 
 namespace amici {

--- a/models/model_jakstat_adjoint_py/dxdotdw.cpp
+++ b/models/model_jakstat_adjoint_py/dxdotdw.cpp
@@ -7,8 +7,8 @@
 namespace amici {
 namespace model_model_jakstat_adjoint_py {
 
-static constexpr std::array<sunindextype, 3> dxdotdw_colptrs_model_jakstat_adjoint_py_ = {
-    0, 2, 2
+static constexpr std::array<sunindextype, 2> dxdotdw_colptrs_model_jakstat_adjoint_py_ = {
+    0, 2
 };
 
 void dxdotdw_colptrs_model_jakstat_adjoint_py(SUNMatrixWrapper &dxdotdw){

--- a/models/model_jakstat_adjoint_py/model_jakstat_adjoint_py.cpp
+++ b/models/model_jakstat_adjoint_py/model_jakstat_adjoint_py.cpp
@@ -54,9 +54,8 @@ ObservableScaling::lin, // y[1]
 ObservableScaling::lin, // y[2]
 };
 
-std::array<const char*, 2> expression_names = {
+std::array<const char*, 1> expression_names = {
     "u", // w[0]
-"flux_r0", // w[1]
 };
 
 std::array<const char*, 17> free_parameter_ids = {
@@ -102,9 +101,8 @@ std::array<const char*, 3> observable_ids = {
 "obs_spline", // y[2]
 };
 
-std::array<const char*, 2> expression_ids = {
+std::array<const char*, 1> expression_ids = {
     "u", // w[0]
-"flux_r0", // w[1]
 };
 
 std::array<int, 9> state_idxs_solver = {

--- a/models/model_jakstat_adjoint_py/model_jakstat_adjoint_py.h
+++ b/models/model_jakstat_adjoint_py/model_jakstat_adjoint_py.h
@@ -19,12 +19,12 @@ extern std::array<const char*, 2> fixed_parameter_names;
 extern std::array<const char*, 9> state_names;
 extern std::array<const char*, 3> observable_names;
 extern std::array<const ObservableScaling, 3> observable_scalings;
-extern std::array<const char*, 2> expression_names;
+extern std::array<const char*, 1> expression_names;
 extern std::array<const char*, 17> free_parameter_ids;
 extern std::array<const char*, 2> fixed_parameter_ids;
 extern std::array<const char*, 9> state_ids;
 extern std::array<const char*, 3> observable_ids;
-extern std::array<const char*, 2> expression_ids;
+extern std::array<const char*, 1> expression_ids;
 extern std::array<int, 9> state_idxs_solver;
 
 extern void Jy_model_jakstat_adjoint_py(realtype *Jy, const int iy, const realtype *p, const realtype *k, const realtype *y, const realtype *sigmay, const realtype *my);
@@ -125,7 +125,7 @@ class Model_model_jakstat_adjoint_py : public amici::Model_ODE {
                   .ne = 0,
                   .ne_solver = 0,
                   .nspl = 1,
-                  .nw = 2,
+                  .nw = 1,
                   .ndwdx = 0,
                   .ndwdp = 5,
                   .ndwdw = 0,
@@ -552,7 +552,7 @@ class Model_model_jakstat_adjoint_py : public amici::Model_ODE {
      * @return AMICI git commit hash
      */
     std::string get_amici_commit() const override {
-        return "63f2e78a186ee722a79b0da2797e0c116ec81065";
+        return "c4a395b6462dc1f26ad1472e6b2fa71fe0d54382";
     }
 
     bool has_quadratic_llh() const override {

--- a/models/model_jakstat_adjoint_py/w.h
+++ b/models/model_jakstat_adjoint_py/w.h
@@ -1,2 +1,1 @@
 #define u w[0]
-#define flux_r0 w[1]

--- a/models/model_nested_events_py/CMakeLists.txt
+++ b/models/model_nested_events_py/CMakeLists.txt
@@ -90,7 +90,6 @@ stau.cpp
 stau.h 
 sx.h 
 sx0.cpp 
-w.h 
 wrapfunctions.cpp 
 wrapfunctions.h 
 x.h 

--- a/models/model_nested_events_py/deltaqB.cpp
+++ b/models/model_nested_events_py/deltaqB.cpp
@@ -5,7 +5,6 @@
 #include "x.h"
 #include "p.h"
 #include "h.h"
-#include "w.h"
 #include "xdot.h"
 #include "xdot_old.h"
 #include "x_old.h"

--- a/models/model_nested_events_py/deltaxB.cpp
+++ b/models/model_nested_events_py/deltaxB.cpp
@@ -5,7 +5,6 @@
 #include "x.h"
 #include "p.h"
 #include "h.h"
-#include "w.h"
 #include "xdot.h"
 #include "xdot_old.h"
 #include "x_old.h"

--- a/models/model_nested_events_py/dxdotdp_explicit.cpp
+++ b/models/model_nested_events_py/dxdotdp_explicit.cpp
@@ -48,7 +48,6 @@ void dxdotdp_explicit_rowvals_model_nested_events_py(SUNMatrixWrapper &dxdotdp_e
 #include "x.h"
 #include "p.h"
 #include "h.h"
-#include "w.h"
 #include "dxdotdp_explicit.h"
 
 namespace amici {

--- a/models/model_nested_events_py/dxdotdx_explicit.cpp
+++ b/models/model_nested_events_py/dxdotdx_explicit.cpp
@@ -48,7 +48,6 @@ void dxdotdx_explicit_rowvals_model_nested_events_py(SUNMatrixWrapper &dxdotdx_e
 #include "x.h"
 #include "p.h"
 #include "h.h"
-#include "w.h"
 #include "dxdotdx_explicit.h"
 
 namespace amici {

--- a/models/model_nested_events_py/model_nested_events_py.cpp
+++ b/models/model_nested_events_py/model_nested_events_py.cpp
@@ -29,8 +29,8 @@ std::array<const ObservableScaling, 1> observable_scalings = {
     ObservableScaling::lin, // y[0]
 };
 
-std::array<const char*, 1> expression_names = {
-    "flux_r0", // w[0]
+std::array<const char*, 0> expression_names = {
+    
 };
 
 std::array<const char*, 5> free_parameter_ids = {
@@ -53,8 +53,8 @@ std::array<const char*, 1> observable_ids = {
     "obs_Virus", // y[0]
 };
 
-std::array<const char*, 1> expression_ids = {
-    "flux_r0", // w[0]
+std::array<const char*, 0> expression_ids = {
+    
 };
 
 std::array<int, 1> state_idxs_solver = {

--- a/models/model_nested_events_py/model_nested_events_py.h
+++ b/models/model_nested_events_py/model_nested_events_py.h
@@ -19,12 +19,12 @@ extern std::array<const char*, 0> fixed_parameter_names;
 extern std::array<const char*, 1> state_names;
 extern std::array<const char*, 1> observable_names;
 extern std::array<const ObservableScaling, 1> observable_scalings;
-extern std::array<const char*, 1> expression_names;
+extern std::array<const char*, 0> expression_names;
 extern std::array<const char*, 5> free_parameter_ids;
 extern std::array<const char*, 0> fixed_parameter_ids;
 extern std::array<const char*, 1> state_ids;
 extern std::array<const char*, 1> observable_ids;
-extern std::array<const char*, 1> expression_ids;
+extern std::array<const char*, 0> expression_ids;
 extern std::array<int, 1> state_idxs_solver;
 
 extern void Jy_model_nested_events_py(realtype *Jy, const int iy, const realtype *p, const realtype *k, const realtype *y, const realtype *sigmay, const realtype *my);
@@ -125,7 +125,7 @@ class Model_model_nested_events_py : public amici::Model_ODE {
                   .ne = 3,
                   .ne_solver = 2,
                   .nspl = 0,
-                  .nw = 1,
+                  .nw = 0,
                   .ndwdx = 0,
                   .ndwdp = 0,
                   .ndwdw = 0,
@@ -552,7 +552,7 @@ class Model_model_nested_events_py : public amici::Model_ODE {
      * @return AMICI git commit hash
      */
     std::string get_amici_commit() const override {
-        return "63f2e78a186ee722a79b0da2797e0c116ec81065";
+        return "c4a395b6462dc1f26ad1472e6b2fa71fe0d54382";
     }
 
     bool has_quadratic_llh() const override {

--- a/models/model_nested_events_py/w.h
+++ b/models/model_nested_events_py/w.h
@@ -1,1 +1,0 @@
-#define flux_r0 w[0]

--- a/models/model_nested_events_py/xdot.cpp
+++ b/models/model_nested_events_py/xdot.cpp
@@ -5,7 +5,6 @@
 #include "x.h"
 #include "p.h"
 #include "h.h"
-#include "w.h"
 #include "xdot.h"
 
 namespace amici {

--- a/models/model_neuron_py/CMakeLists.txt
+++ b/models/model_neuron_py/CMakeLists.txt
@@ -104,7 +104,6 @@ stau.h
 sx.h 
 sx0.cpp 
 sx0_fixedParameters.cpp 
-w.h 
 wrapfunctions.cpp 
 wrapfunctions.h 
 x.h 

--- a/models/model_neuron_py/deltaqB.cpp
+++ b/models/model_neuron_py/deltaqB.cpp
@@ -6,7 +6,6 @@
 #include "p.h"
 #include "k.h"
 #include "h.h"
-#include "w.h"
 #include "xdot.h"
 #include "xdot_old.h"
 #include "x_old.h"

--- a/models/model_neuron_py/deltaxB.cpp
+++ b/models/model_neuron_py/deltaxB.cpp
@@ -6,7 +6,6 @@
 #include "p.h"
 #include "k.h"
 #include "h.h"
-#include "w.h"
 #include "xdot.h"
 #include "xdot_old.h"
 #include "x_old.h"

--- a/models/model_neuron_py/dxdotdp_explicit.cpp
+++ b/models/model_neuron_py/dxdotdp_explicit.cpp
@@ -49,7 +49,6 @@ void dxdotdp_explicit_rowvals_model_neuron_py(SUNMatrixWrapper &dxdotdp_explicit
 #include "p.h"
 #include "k.h"
 #include "h.h"
-#include "w.h"
 #include "dxdotdp_explicit.h"
 
 namespace amici {

--- a/models/model_neuron_py/dxdotdx_explicit.cpp
+++ b/models/model_neuron_py/dxdotdx_explicit.cpp
@@ -49,7 +49,6 @@ void dxdotdx_explicit_rowvals_model_neuron_py(SUNMatrixWrapper &dxdotdx_explicit
 #include "p.h"
 #include "k.h"
 #include "h.h"
-#include "w.h"
 #include "dxdotdx_explicit.h"
 
 namespace amici {

--- a/models/model_neuron_py/model_neuron_py.cpp
+++ b/models/model_neuron_py/model_neuron_py.cpp
@@ -30,8 +30,8 @@ std::array<const ObservableScaling, 1> observable_scalings = {
     ObservableScaling::lin, // y[0]
 };
 
-std::array<const char*, 1> expression_names = {
-    "flux_r0", // w[0]
+std::array<const char*, 0> expression_names = {
+    
 };
 
 std::array<const char*, 4> free_parameter_ids = {
@@ -55,8 +55,8 @@ std::array<const char*, 1> observable_ids = {
     "y1", // y[0]
 };
 
-std::array<const char*, 1> expression_ids = {
-    "flux_r0", // w[0]
+std::array<const char*, 0> expression_ids = {
+    
 };
 
 std::array<int, 2> state_idxs_solver = {

--- a/models/model_neuron_py/model_neuron_py.h
+++ b/models/model_neuron_py/model_neuron_py.h
@@ -19,12 +19,12 @@ extern std::array<const char*, 2> fixed_parameter_names;
 extern std::array<const char*, 2> state_names;
 extern std::array<const char*, 1> observable_names;
 extern std::array<const ObservableScaling, 1> observable_scalings;
-extern std::array<const char*, 1> expression_names;
+extern std::array<const char*, 0> expression_names;
 extern std::array<const char*, 4> free_parameter_ids;
 extern std::array<const char*, 2> fixed_parameter_ids;
 extern std::array<const char*, 2> state_ids;
 extern std::array<const char*, 1> observable_ids;
-extern std::array<const char*, 1> expression_ids;
+extern std::array<const char*, 0> expression_ids;
 extern std::array<int, 2> state_idxs_solver;
 
 extern void Jy_model_neuron_py(realtype *Jy, const int iy, const realtype *p, const realtype *k, const realtype *y, const realtype *sigmay, const realtype *my);
@@ -125,7 +125,7 @@ class Model_model_neuron_py : public amici::Model_ODE {
                   .ne = 1,
                   .ne_solver = 1,
                   .nspl = 0,
-                  .nw = 1,
+                  .nw = 0,
                   .ndwdx = 0,
                   .ndwdp = 0,
                   .ndwdw = 0,
@@ -574,7 +574,7 @@ class Model_model_neuron_py : public amici::Model_ODE {
      * @return AMICI git commit hash
      */
     std::string get_amici_commit() const override {
-        return "63f2e78a186ee722a79b0da2797e0c116ec81065";
+        return "c4a395b6462dc1f26ad1472e6b2fa71fe0d54382";
     }
 
     bool has_quadratic_llh() const override {

--- a/models/model_neuron_py/w.h
+++ b/models/model_neuron_py/w.h
@@ -1,1 +1,0 @@
-#define flux_r0 w[0]

--- a/models/model_neuron_py/xdot.cpp
+++ b/models/model_neuron_py/xdot.cpp
@@ -6,7 +6,6 @@
 #include "p.h"
 #include "k.h"
 #include "h.h"
-#include "w.h"
 #include "xdot.h"
 
 namespace amici {

--- a/models/model_robertson_py/CMakeLists.txt
+++ b/models/model_robertson_py/CMakeLists.txt
@@ -82,7 +82,6 @@ p.h
 sigmay.cpp 
 sigmay.h 
 sx0_fixedParameters.cpp 
-w.h 
 wrapfunctions.cpp 
 wrapfunctions.h 
 x.h 

--- a/models/model_robertson_py/dxdotdp_explicit.cpp
+++ b/models/model_robertson_py/dxdotdp_explicit.cpp
@@ -49,7 +49,6 @@ void dxdotdp_explicit_rowvals_model_robertson_py(SUNMatrixWrapper &dxdotdp_expli
 #include "p.h"
 #include "k.h"
 #include "dx.h"
-#include "w.h"
 #include "dxdotdp_explicit.h"
 
 namespace amici {

--- a/models/model_robertson_py/dxdotdx_explicit.cpp
+++ b/models/model_robertson_py/dxdotdx_explicit.cpp
@@ -49,7 +49,6 @@ void dxdotdx_explicit_rowvals_model_robertson_py(SUNMatrixWrapper &dxdotdx_expli
 #include "p.h"
 #include "k.h"
 #include "dx.h"
-#include "w.h"
 #include "dxdotdx_explicit.h"
 
 namespace amici {

--- a/models/model_robertson_py/model_robertson_py.cpp
+++ b/models/model_robertson_py/model_robertson_py.cpp
@@ -33,8 +33,8 @@ ObservableScaling::lin, // y[1]
 ObservableScaling::lin, // y[2]
 };
 
-std::array<const char*, 1> expression_names = {
-    "flux_r0", // w[0]
+std::array<const char*, 0> expression_names = {
+    
 };
 
 std::array<const char*, 3> free_parameter_ids = {
@@ -59,8 +59,8 @@ std::array<const char*, 3> observable_ids = {
 "obs_x3", // y[2]
 };
 
-std::array<const char*, 1> expression_ids = {
-    "flux_r0", // w[0]
+std::array<const char*, 0> expression_ids = {
+    
 };
 
 std::array<int, 3> state_idxs_solver = {

--- a/models/model_robertson_py/model_robertson_py.h
+++ b/models/model_robertson_py/model_robertson_py.h
@@ -19,12 +19,12 @@ extern std::array<const char*, 1> fixed_parameter_names;
 extern std::array<const char*, 3> state_names;
 extern std::array<const char*, 3> observable_names;
 extern std::array<const ObservableScaling, 3> observable_scalings;
-extern std::array<const char*, 1> expression_names;
+extern std::array<const char*, 0> expression_names;
 extern std::array<const char*, 3> free_parameter_ids;
 extern std::array<const char*, 1> fixed_parameter_ids;
 extern std::array<const char*, 3> state_ids;
 extern std::array<const char*, 3> observable_ids;
-extern std::array<const char*, 1> expression_ids;
+extern std::array<const char*, 0> expression_ids;
 extern std::array<int, 3> state_idxs_solver;
 
 extern void Jy_model_robertson_py(realtype *Jy, const int iy, const realtype *p, const realtype *k, const realtype *y, const realtype *sigmay, const realtype *my);
@@ -125,7 +125,7 @@ class Model_model_robertson_py : public amici::Model_DAE {
                   .ne = 0,
                   .ne_solver = 0,
                   .nspl = 0,
-                  .nw = 1,
+                  .nw = 0,
                   .ndwdx = 0,
                   .ndwdp = 0,
                   .ndwdw = 0,
@@ -536,7 +536,7 @@ class Model_model_robertson_py : public amici::Model_DAE {
      * @return AMICI git commit hash
      */
     std::string get_amici_commit() const override {
-        return "63f2e78a186ee722a79b0da2797e0c116ec81065";
+        return "c4a395b6462dc1f26ad1472e6b2fa71fe0d54382";
     }
 
     bool has_quadratic_llh() const override {

--- a/models/model_robertson_py/w.h
+++ b/models/model_robertson_py/w.h
@@ -1,1 +1,0 @@
-#define flux_r0 w[0]

--- a/models/model_robertson_py/xdot.cpp
+++ b/models/model_robertson_py/xdot.cpp
@@ -6,7 +6,6 @@
 #include "p.h"
 #include "k.h"
 #include "dx.h"
-#include "w.h"
 #include "xdot.h"
 
 namespace amici {

--- a/models/model_steadystate_py/CMakeLists.txt
+++ b/models/model_steadystate_py/CMakeLists.txt
@@ -81,7 +81,6 @@ p.h
 sigmay.cpp 
 sigmay.h 
 sx0_fixedParameters.cpp 
-w.h 
 wrapfunctions.cpp 
 wrapfunctions.h 
 x.h 

--- a/models/model_steadystate_py/dxdotdp_explicit.cpp
+++ b/models/model_steadystate_py/dxdotdp_explicit.cpp
@@ -48,7 +48,6 @@ void dxdotdp_explicit_rowvals_model_steadystate_py(SUNMatrixWrapper &dxdotdp_exp
 #include "x.h"
 #include "p.h"
 #include "k.h"
-#include "w.h"
 #include "dxdotdp_explicit.h"
 
 namespace amici {

--- a/models/model_steadystate_py/dxdotdx_explicit.cpp
+++ b/models/model_steadystate_py/dxdotdx_explicit.cpp
@@ -48,7 +48,6 @@ void dxdotdx_explicit_rowvals_model_steadystate_py(SUNMatrixWrapper &dxdotdx_exp
 #include "x.h"
 #include "p.h"
 #include "k.h"
-#include "w.h"
 #include "dxdotdx_explicit.h"
 
 namespace amici {

--- a/models/model_steadystate_py/model_steadystate_py.cpp
+++ b/models/model_steadystate_py/model_steadystate_py.cpp
@@ -38,8 +38,8 @@ ObservableScaling::lin, // y[1]
 ObservableScaling::lin, // y[2]
 };
 
-std::array<const char*, 1> expression_names = {
-    "flux_r0", // w[0]
+std::array<const char*, 0> expression_names = {
+    
 };
 
 std::array<const char*, 5> free_parameter_ids = {
@@ -69,8 +69,8 @@ std::array<const char*, 3> observable_ids = {
 "obs_x3", // y[2]
 };
 
-std::array<const char*, 1> expression_ids = {
-    "flux_r0", // w[0]
+std::array<const char*, 0> expression_ids = {
+    
 };
 
 std::array<int, 3> state_idxs_solver = {

--- a/models/model_steadystate_py/model_steadystate_py.h
+++ b/models/model_steadystate_py/model_steadystate_py.h
@@ -19,12 +19,12 @@ extern std::array<const char*, 4> fixed_parameter_names;
 extern std::array<const char*, 3> state_names;
 extern std::array<const char*, 3> observable_names;
 extern std::array<const ObservableScaling, 3> observable_scalings;
-extern std::array<const char*, 1> expression_names;
+extern std::array<const char*, 0> expression_names;
 extern std::array<const char*, 5> free_parameter_ids;
 extern std::array<const char*, 4> fixed_parameter_ids;
 extern std::array<const char*, 3> state_ids;
 extern std::array<const char*, 3> observable_ids;
-extern std::array<const char*, 1> expression_ids;
+extern std::array<const char*, 0> expression_ids;
 extern std::array<int, 3> state_idxs_solver;
 
 extern void Jy_model_steadystate_py(realtype *Jy, const int iy, const realtype *p, const realtype *k, const realtype *y, const realtype *sigmay, const realtype *my);
@@ -125,7 +125,7 @@ class Model_model_steadystate_py : public amici::Model_ODE {
                   .ne = 0,
                   .ne_solver = 0,
                   .nspl = 0,
-                  .nw = 1,
+                  .nw = 0,
                   .ndwdx = 0,
                   .ndwdp = 0,
                   .ndwdw = 0,
@@ -536,7 +536,7 @@ class Model_model_steadystate_py : public amici::Model_ODE {
      * @return AMICI git commit hash
      */
     std::string get_amici_commit() const override {
-        return "63f2e78a186ee722a79b0da2797e0c116ec81065";
+        return "c4a395b6462dc1f26ad1472e6b2fa71fe0d54382";
     }
 
     bool has_quadratic_llh() const override {

--- a/models/model_steadystate_py/w.h
+++ b/models/model_steadystate_py/w.h
@@ -1,1 +1,0 @@
-#define flux_r0 w[0]

--- a/models/model_steadystate_py/xdot.cpp
+++ b/models/model_steadystate_py/xdot.cpp
@@ -5,7 +5,6 @@
 #include "x.h"
 #include "p.h"
 #include "k.h"
-#include "w.h"
 #include "xdot.h"
 
 namespace amici {

--- a/python/sdist/amici/exporters/sundials/de_export.py
+++ b/python/sdist/amici/exporters/sundials/de_export.py
@@ -427,12 +427,13 @@ class DEExporter:
             if sym not in self.model.sym_names():
                 continue
 
+            if len(self.model.sym(sym)) == 0:
+                continue
+
             if sym in sparse_functions:
                 iszero = smart_is_zero_matrix(self.model.sparseeq(sym))
             elif sym in self.functions:
                 iszero = smart_is_zero_matrix(self.model.eq(sym))
-            elif len(self.model.sym(sym)) == 0:
-                continue
             else:
                 iszero = False
 

--- a/tests/cpp/expected_results_py.h5
+++ b/tests/cpp/expected_results_py.h5
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:eae94de78f59eb136564483b1b713199743593f0f9bddbab7dc0bcfa5399d4f9
-size 1847292
+oid sha256:e7c4f4ee6f9a508a2cd7b11947d61c1c53d97f6f4cfcf665e7abfbf5d46ac81b
+size 1808960


### PR DESCRIPTION
This may have been necessary with earlier sympy versions, but I don't think we still need that. Let's not make users wonder where that expression comes from.

Closes #3045.