### PR TITLE
cmake: Replace deprecated swig_link_libraries

### DIFF
--- a/models/model_calvetti_py/model_calvetti_py.h
+++ b/models/model_calvetti_py/model_calvetti_py.h
@@ -557,7 +557,7 @@ class Model_model_calvetti_py : public amici::Model_DAE {
      * @return AMICI git commit hash
      */
     std::string get_amici_commit() const override {
-        return "20b07e9a8c19bdb7bf94a562f61b3d08dc0299d0";
+        return "63f2e78a186ee722a79b0da2797e0c116ec81065";
     }
 
     bool has_quadratic_llh() const override {

--- a/models/model_calvetti_py/swig/CMakeLists.txt
+++ b/models/model_calvetti_py/swig/CMakeLists.txt
@@ -44,8 +44,8 @@ if(NOT "${PY_EXT_SUFFIX}" STREQUAL "")
 endif()
 
 
-swig_link_libraries(${SWIG_LIBRARY_NAME}
-    ${Python3_LIBRARIES}
+target_link_libraries(${SWIG_LIBRARY_NAME}
+    Python3::Module
     model)
 
 install(FILES ${CMAKE_CURRENT_BINARY_DIR}/${PROJECT_NAME}.py

--- a/models/model_dirac_py/model_dirac_py.h
+++ b/models/model_dirac_py/model_dirac_py.h
@@ -544,7 +544,7 @@ class Model_model_dirac_py : public amici::Model_ODE {
      * @return AMICI git commit hash
      */
     std::string get_amici_commit() const override {
-        return "20b07e9a8c19bdb7bf94a562f61b3d08dc0299d0";
+        return "63f2e78a186ee722a79b0da2797e0c116ec81065";
     }
 
     bool has_quadratic_llh() const override {

--- a/models/model_dirac_py/swig/CMakeLists.txt
+++ b/models/model_dirac_py/swig/CMakeLists.txt
@@ -44,8 +44,8 @@ if(NOT "${PY_EXT_SUFFIX}" STREQUAL "")
 endif()
 
 
-swig_link_libraries(${SWIG_LIBRARY_NAME}
-    ${Python3_LIBRARIES}
+target_link_libraries(${SWIG_LIBRARY_NAME}
+    Python3::Module
     model)
 
 install(FILES ${CMAKE_CURRENT_BINARY_DIR}/${PROJECT_NAME}.py

--- a/models/model_events_py/model_events_py.h
+++ b/models/model_events_py/model_events_py.h
@@ -579,7 +579,7 @@ class Model_model_events_py : public amici::Model_ODE {
      * @return AMICI git commit hash
      */
     std::string get_amici_commit() const override {
-        return "20b07e9a8c19bdb7bf94a562f61b3d08dc0299d0";
+        return "63f2e78a186ee722a79b0da2797e0c116ec81065";
     }
 
     bool has_quadratic_llh() const override {

--- a/models/model_events_py/swig/CMakeLists.txt
+++ b/models/model_events_py/swig/CMakeLists.txt
@@ -44,8 +44,8 @@ if(NOT "${PY_EXT_SUFFIX}" STREQUAL "")
 endif()
 
 
-swig_link_libraries(${SWIG_LIBRARY_NAME}
-    ${Python3_LIBRARIES}
+target_link_libraries(${SWIG_LIBRARY_NAME}
+    Python3::Module
     model)
 
 install(FILES ${CMAKE_CURRENT_BINARY_DIR}/${PROJECT_NAME}.py

--- a/models/model_jakstat_adjoint_py/model_jakstat_adjoint_py.h
+++ b/models/model_jakstat_adjoint_py/model_jakstat_adjoint_py.h
@@ -552,7 +552,7 @@ class Model_model_jakstat_adjoint_py : public amici::Model_ODE {
      * @return AMICI git commit hash
      */
     std::string get_amici_commit() const override {
-        return "20b07e9a8c19bdb7bf94a562f61b3d08dc0299d0";
+        return "63f2e78a186ee722a79b0da2797e0c116ec81065";
     }
 
     bool has_quadratic_llh() const override {

--- a/models/model_jakstat_adjoint_py/swig/CMakeLists.txt
+++ b/models/model_jakstat_adjoint_py/swig/CMakeLists.txt
@@ -44,8 +44,8 @@ if(NOT "${PY_EXT_SUFFIX}" STREQUAL "")
 endif()
 
 
-swig_link_libraries(${SWIG_LIBRARY_NAME}
-    ${Python3_LIBRARIES}
+target_link_libraries(${SWIG_LIBRARY_NAME}
+    Python3::Module
     model)
 
 install(FILES ${CMAKE_CURRENT_BINARY_DIR}/${PROJECT_NAME}.py

--- a/models/model_nested_events_py/model_nested_events_py.h
+++ b/models/model_nested_events_py/model_nested_events_py.h
@@ -552,7 +552,7 @@ class Model_model_nested_events_py : public amici::Model_ODE {
      * @return AMICI git commit hash
      */
     std::string get_amici_commit() const override {
-        return "20b07e9a8c19bdb7bf94a562f61b3d08dc0299d0";
+        return "63f2e78a186ee722a79b0da2797e0c116ec81065";
     }
 
     bool has_quadratic_llh() const override {

--- a/models/model_nested_events_py/swig/CMakeLists.txt
+++ b/models/model_nested_events_py/swig/CMakeLists.txt
@@ -44,8 +44,8 @@ if(NOT "${PY_EXT_SUFFIX}" STREQUAL "")
 endif()
 
 
-swig_link_libraries(${SWIG_LIBRARY_NAME}
-    ${Python3_LIBRARIES}
+target_link_libraries(${SWIG_LIBRARY_NAME}
+    Python3::Module
     model)
 
 install(FILES ${CMAKE_CURRENT_BINARY_DIR}/${PROJECT_NAME}.py

--- a/models/model_neuron_py/model_neuron_py.h
+++ b/models/model_neuron_py/model_neuron_py.h
@@ -574,7 +574,7 @@ class Model_model_neuron_py : public amici::Model_ODE {
      * @return AMICI git commit hash
      */
     std::string get_amici_commit() const override {
-        return "20b07e9a8c19bdb7bf94a562f61b3d08dc0299d0";
+        return "63f2e78a186ee722a79b0da2797e0c116ec81065";
     }
 
     bool has_quadratic_llh() const override {

--- a/models/model_neuron_py/swig/CMakeLists.txt
+++ b/models/model_neuron_py/swig/CMakeLists.txt
@@ -44,8 +44,8 @@ if(NOT "${PY_EXT_SUFFIX}" STREQUAL "")
 endif()
 
 
-swig_link_libraries(${SWIG_LIBRARY_NAME}
-    ${Python3_LIBRARIES}
+target_link_libraries(${SWIG_LIBRARY_NAME}
+    Python3::Module
     model)
 
 install(FILES ${CMAKE_CURRENT_BINARY_DIR}/${PROJECT_NAME}.py

--- a/models/model_robertson_py/model_robertson_py.h
+++ b/models/model_robertson_py/model_robertson_py.h
@@ -536,7 +536,7 @@ class Model_model_robertson_py : public amici::Model_DAE {
      * @return AMICI git commit hash
      */
     std::string get_amici_commit() const override {
-        return "20b07e9a8c19bdb7bf94a562f61b3d08dc0299d0";
+        return "63f2e78a186ee722a79b0da2797e0c116ec81065";
     }
 
     bool has_quadratic_llh() const override {

--- a/models/model_robertson_py/swig/CMakeLists.txt
+++ b/models/model_robertson_py/swig/CMakeLists.txt
@@ -44,8 +44,8 @@ if(NOT "${PY_EXT_SUFFIX}" STREQUAL "")
 endif()
 
 
-swig_link_libraries(${SWIG_LIBRARY_NAME}
-    ${Python3_LIBRARIES}
+target_link_libraries(${SWIG_LIBRARY_NAME}
+    Python3::Module
     model)
 
 install(FILES ${CMAKE_CURRENT_BINARY_DIR}/${PROJECT_NAME}.py

--- a/models/model_steadystate_py/model_steadystate_py.h
+++ b/models/model_steadystate_py/model_steadystate_py.h
@@ -536,7 +536,7 @@ class Model_model_steadystate_py : public amici::Model_ODE {
      * @return AMICI git commit hash
      */
     std::string get_amici_commit() const override {
-        return "20b07e9a8c19bdb7bf94a562f61b3d08dc0299d0";
+        return "63f2e78a186ee722a79b0da2797e0c116ec81065";
     }
 
     bool has_quadratic_llh() const override {

--- a/models/model_steadystate_py/swig/CMakeLists.txt
+++ b/models/model_steadystate_py/swig/CMakeLists.txt
@@ -44,8 +44,8 @@ if(NOT "${PY_EXT_SUFFIX}" STREQUAL "")
 endif()
 
 
-swig_link_libraries(${SWIG_LIBRARY_NAME}
-    ${Python3_LIBRARIES}
+target_link_libraries(${SWIG_LIBRARY_NAME}
+    Python3::Module
     model)
 
 install(FILES ${CMAKE_CURRENT_BINARY_DIR}/${PROJECT_NAME}.py

--- a/python/sdist/amici/exporters/sundials/templates/CMakeLists_model.cmake
+++ b/python/sdist/amici/exporters/sundials/templates/CMakeLists_model.cmake
@@ -44,8 +44,8 @@ if(NOT "${PY_EXT_SUFFIX}" STREQUAL "")
 endif()
 
 
-swig_link_libraries(${SWIG_LIBRARY_NAME}
-    ${Python3_LIBRARIES}
+target_link_libraries(${SWIG_LIBRARY_NAME}
+    Python3::Module
     model)
 
 install(FILES ${CMAKE_CURRENT_BINARY_DIR}/${PROJECT_NAME}.py


### PR DESCRIPTION
And link against `Python3::Module` instead of `${Python3_LIBRARIES}`. It might be worth revisiting #3028 after that.