### PR TITLE
Fix version.txt paths

### DIFF
--- a/python/sdist/MANIFEST.in
+++ b/python/sdist/MANIFEST.in
@@ -7,10 +7,10 @@ recursive-include amici/_installation/src *
 recursive-include amici/_installation/swig *
 recursive-include amici/exporters/sundials/templates *
 include amici/*
-include version.txt
-include LICENSE.md
+include amici/_installation/version.txt
 exclude amici/_installation/*.so
 exclude amici/_installation/*.dll
+include LICENSE.md
 prune **/build
 prune **/install
 prune amici/_installation/share

--- a/python/sdist/version.txt
+++ b/python/sdist/version.txt
@@ -1,1 +1,0 @@
-../../version.txt


### PR DESCRIPTION
Fix version.txt paths and MANIFEST.in after rearranging files (#3060).

Fixes installation failures from sdist (https://github.com/AMICI-dev/AMICI/actions/runs/19534015315/job/55923610379).