### PR TITLE
Fix missing CMakeLists.txt in MANIFEST.in

### DIFF
--- a/python/sdist/MANIFEST.in
+++ b/python/sdist/MANIFEST.in
@@ -8,11 +8,13 @@ recursive-include amici/_installation/swig *
 recursive-include amici/exporters/sundials/templates *
 include amici/*
 include amici/_installation/version.txt
+include amici/_installation/CMakeLists.txt
 exclude amici/_installation/*.so
 exclude amici/_installation/*.dll
 include LICENSE.md
 prune **/build
 prune **/install
+prune dist
 prune amici/_installation/share
 prune amici/_installation/lib
 prune amici/_installation/ThirdParty/SuiteSparse/lib


### PR DESCRIPTION
Still puzzled why it was working in https://github.com/AMICI-dev/AMICI/actions/runs/19541908207/job/55950260921 but failed in https://github.com/AMICI-dev/AMICI/actions/runs/19543628281/job/55957118080.