### PR TITLE
PySB import: Replace all PySB objects by plain sympy objects when cre…

### DIFF
--- a/python/sdist/amici/_symbolic/de_model.py
+++ b/python/sdist/amici/_symbolic/de_model.py
@@ -78,9 +78,20 @@ __all__ = [
 class DEModel:
     """
     Defines a Differential Equation as set of ModelQuantities.
+
     This class provides general purpose interfaces to compute arbitrary
     symbolic derivatives that are necessary for model simulation or
     sensitivity computation.
+
+    All occurrences of a symbolic variable with a given name must use the same
+    assumptions (e.g. real, positive, etc.) throughout the model. Mixing
+    different assumptions for the same variable name will result in incorrect
+    derivatives and potentially other errors.
+
+    All symbols in the model are expected to be of type sympy.Symbol. If any
+    subtypes are used, they must behave identically to sympy.Symbol in all
+    relevant aspects (e.g. hashing, equality testing, etc.). In particular,
+    `str(symbol)` is expected to return the same value as `symbol.name`.
 
     :ivar _differential_states:
         differential state variables

--- a/python/sdist/amici/importers/utils.py
+++ b/python/sdist/amici/importers/utils.py
@@ -1014,3 +1014,17 @@ def contains_periodic_subexpression(expr: sp.Expr, symbol: sp.Symbol) -> bool:
         if sp.periodicity(subexpr, symbol) is not None:
             return True
     return False
+
+
+def _expr_to_amici(expr: sp.Basic | sp.MatrixBase):
+    """Convert the given sympy expression to an AMICI-compatible expression.
+
+    Replaces all symbols by plain sympy symbols with the expected assumptions.
+
+    :param expr: The sympy expression to convert.
+    :return: The AMICI-compatible sympy expression.
+    """
+    replacements = {
+        s: symbol_with_assumptions(s.name) for s in expr.free_symbols
+    }
+    return expr.xreplace(replacements)

--- a/python/tests/test_pysb.py
+++ b/python/tests/test_pysb.py
@@ -19,7 +19,7 @@ import sympy as sp
 from amici import MeasurementChannel, import_model_module
 from amici._symbolic.de_model_components import Event
 from amici.importers.pysb import pysb2amici
-from amici.importers.utils import amici_time_symbol
+from amici.importers.utils import amici_time_symbol, symbol_with_assumptions
 from amici.sim.sundials import (
     ExpData,
     ParameterScaling,
@@ -417,10 +417,15 @@ def test_pysb_event(tempdir):
     events = [
         Event(
             # note that unlike for SBML import, we must omit the real=True here
-            symbol=sp.Symbol("event1"),
+            symbol=symbol_with_assumptions("event1"),
             name="Event1",
             value=amici_time_symbol - 5,
-            assignments={sp.Symbol("__s0"): sp.Symbol("__s0") + 1000},
+            assignments={
+                symbol_with_assumptions("__s0"): symbol_with_assumptions(
+                    "__s0"
+                )
+                + 1000
+            },
             use_values_from_trigger_time=False,
         )
     ]


### PR DESCRIPTION
…ating the DEModel

Ensure that DEModel only contains plain `sympy.Symbol`s, no `pysb.Compmenents`.

Also, consistently use `symbol_with_assumptions`.

Closes #3035.