### PR TITLE
GHA: Fix codecov warning

### DIFF
--- a/.github/workflows/test_petab_sciml.yml
+++ b/.github/workflows/test_petab_sciml.yml
@@ -1,4 +1,4 @@
-name: PEtab
+name: PEtab SciML
 on:
   push:
     branches:
@@ -87,6 +87,6 @@ jobs:
         uses: codecov/codecov-action@v5
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
-          file: coverage_petab_sciml.xml
+          files: coverage_petab_sciml.xml
           flags: petab_sciml
           fail_ci_if_error: true


### PR DESCRIPTION
Fixes
```
Unexpected input(s) 'file', valid inputs are ['base_sha', 'binary', 'codecov_yml_path', 'commit_parent', 'directory', 'disable_file_fixes', 'disable_search', 'disable_safe_directory', 'disable_telem', 'dry_run', 'env_vars', 'exclude', 'fail_ci_if_error', 'files', 'flags', 'force', 'git_service', 'gcov_args', 'gcov_executable', 'gcov_ignore', 'gcov_include', 'handle_no_reports_found', 'job_code', 'name', 'network_filter', 'network_prefix', 'os', 'override_branch', 'override_build', 'override_build_url', 'override_commit', 'override_pr', 'plugins', 'recurse_submodules', 'report_code', 'report_type', 'root_dir', 'run_command', 'skip_validation', 'slug', 'swift_project', 'token', 'url', 'use_legacy_upload_endpoint', 'use_oidc', 'use_pypi', 'verbose', 'version', 'working-directory']
```

Also set a distinct workflow name. There were two "PEtab" workflows - make them distinguishable.