### PR TITLE
Catch time overflow during steady-state simulation

### DIFF
--- a/include/amici/defines.h
+++ b/include/amici/defines.h
@@ -93,6 +93,7 @@ constexpr int AMICI_SINGULAR_JACOBIAN=     -9987;
 constexpr int AMICI_NOT_IMPLEMENTED=        -999;
 constexpr int AMICI_MAX_TIME_EXCEEDED  =   -1000;
 constexpr int AMICI_NOT_RUN=               -1001;
+constexpr int AMICI_T_OVERFLOW=            -1002;
 constexpr int AMICI_SUCCESS=                   0;
 constexpr int AMICI_DATA_RETURN=               1;
 constexpr int AMICI_ROOT_RETURN=               2;

--- a/src/amici.cpp
+++ b/src/amici.cpp
@@ -59,6 +59,7 @@ std::map<int, std::string> simulation_status_to_str_map = {
     {AMICI_UNREC_SRHSFUNC_ERR, "AMICI_UNREC_SRHSFUNC_ERR"},
     {AMICI_RTFUNC_FAIL, "AMICI_RTFUNC_FAIL"},
     {AMICI_LINESEARCH_FAIL, "AMICI_LINESEARCH_FAIL"},
+    {AMICI_T_OVERFLOW, "AMICI_T_OVERFLOW"},
 };
 
 std::unique_ptr<ReturnData> run_simulation(

--- a/src/forwardproblem.cpp
+++ b/src/forwardproblem.cpp
@@ -197,6 +197,12 @@ void EventHandlingSimulator::run_steady_state(
         auto tout = std::isfinite(next_t_event)
                         ? next_t_event
                         : std::max(ws_->sol.t, 1.0) * 10;
+
+        if(!std::isfinite(tout)) {
+            // tout overflowed
+            throw IntegrationFailure(AMICI_T_OVERFLOW, tout);
+        }
+
         auto status = solver_->step(tout);
         solver_->write_solution(ws_->sol);
 
@@ -914,7 +920,7 @@ SteadyStateStatus SteadyStateProblem::find_steady_state_by_simulation(
                     ex.time
                 );
             return SteadyStateStatus::failed_convergence;
-        case AMICI_RHSFUNC_FAIL:
+        case amici::AMICI_T_OVERFLOW:
             if (model_->get_logger())
                 model_->get_logger()->log(
                     LogSeverity::debug, "EQUILIBRATION_FAILURE",

--- a/src/solver.cpp
+++ b/src/solver.cpp
@@ -5,6 +5,7 @@
 #include "amici/model.h"
 
 #include <sundials/sundials_context.h>
+#include <gsl/gsl-lite.hpp>
 
 #include <cstdio>
 #include <filesystem>
@@ -138,6 +139,8 @@ void Solver::apply_max_num_steps_B() const {
 }
 
 int Solver::run(realtype const tout) const {
+    gsl_ExpectsDebug(std::isfinite(tout));
+
     set_stop_time(tout);
     CpuTimer const cpu_timer;
     int status = AMICI_SUCCESS;
@@ -157,6 +160,8 @@ int Solver::run(realtype const tout) const {
 }
 
 int Solver::step(realtype const tout) const {
+    gsl_ExpectsDebug(std::isfinite(tout));
+
     int status = AMICI_SUCCESS;
 
     apply_max_num_steps();
@@ -173,6 +178,8 @@ int Solver::step(realtype const tout) const {
 }
 
 void Solver::run_b(realtype const tout) const {
+    gsl_ExpectsDebug(std::isfinite(tout));
+
     CpuTimer cpu_timer;
 
     apply_max_num_steps_B();

--- a/src/solver_cvodes.cpp
+++ b/src/solver_cvodes.cpp
@@ -1178,14 +1178,6 @@ static int fxdot(realtype t, N_Vector x, N_Vector xdot, void* user_data) {
         return AMICI_MAX_TIME_EXCEEDED;
     }
 
-    if (t > 1e200
-        && !model->check_finite(gsl::make_span(x), ModelQuantity::xdot, t)) {
-        /* when t is large (typically ~1e300), CVODES may pass all NaN x
-           to fxdot from which we typically cannot recover. To save time
-           on normal execution, we do not always want to check finiteness
-           of x, but only do so when t is large and we expect problems. */
-        return AMICI_UNRECOVERABLE_ERROR;
-    }
 
     model->fxdot(t, x, xdot);
     return model->check_finite(gsl::make_span(xdot), ModelQuantity::xdot, t);


### PR DESCRIPTION
* Remove the old and faulty check for finiteness of `x` in `Model::fxdot`. Closes #3076.
* The root cause of those NaNs in `x` was not CVODES. The problem is uncaught integer overflow during steady-state simulations and asking CVODES to integrate until `t=inf`. Catch that.
* Add a dedicated error code
* Add debug-level expectations to all integration functions of `Solver`