### PR TITLE
Clean up `amici.sim.sundials` exports

### DIFF
--- a/swig/amici.i
+++ b/swig/amici.i
@@ -406,7 +406,7 @@ from collections.abc import Sequence
 import numpy as np
 if TYPE_CHECKING:
     import numpy
-    from .numpy import ReturnDataView
+    from amici.sim.sundials import ReturnDataView
 %}
 
 %pythoncode %{


### PR DESCRIPTION
* Re-export `import_model_module`.
* Set `__all__`

The goal should be that after having compiled a model, for most applications, the only required import for loading and simulating that model is `amici.sim.sundials`.