### PR TITLE
Test model import/simulation under conda

### DIFF
--- a/.github/workflows/test_conda_install.yml
+++ b/.github/workflows/test_conda_install.yml
@@ -51,8 +51,6 @@ jobs:
           python -m amici
       - name: Run SBML import test
         shell: bash -l {0}
-        # FIXME
-        continue-on-error: true
         run: |
           cd python/tests
           pytest test_sbml_import.py::test_steadystate_simulation -sv

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -124,7 +124,7 @@ endif()
 include(GNUInstallDirs)
 
 include(AmiciFindBLAS)
-find_package(OpenMP)
+find_package(OpenMP COMPONENTS CXX)
 find_package(Boost COMPONENTS chrono)
 
 if(ENABLE_HDF5)
@@ -284,7 +284,7 @@ target_link_libraries(
          SUNDIALS::cvodes_static
          SUNDIALS::idas_static
          $<$<BOOL:${Boost_CHRONO_FOUND}>:Boost::chrono>
-         $<$<BOOL:${OpenMP_FOUND}>:OpenMP::OpenMP_CXX>
+         $<$<BOOL:${OpenMP_CXX_FOUND}>:OpenMP::OpenMP_CXX>
          ${CMAKE_DL_LIBS}
   PRIVATE
     BLAS::BLAS

--- a/cmake/AmiciConfig.cmake.in
+++ b/cmake/AmiciConfig.cmake.in
@@ -2,8 +2,6 @@
 
 include(CMakeFindDependencyMacro)
 
-find_package(OpenMP)
-
 # Current SUNDIALSConfig.cmake doesn't use KLU's FindKLU, but hardcodes paths,
 # and is not relocatable. This does not work with Python package installation in
 # tmpdirs.
@@ -12,6 +10,31 @@ list(APPEND CMAKE_PREFIX_PATH
 
 set(AMICI_BLAS_USE_SCIPY_OPENBLAS @AMICI_BLAS_USE_SCIPY_OPENBLAS@)
 include("${CMAKE_CURRENT_LIST_DIR}/AmiciFindBLAS.cmake")
+
+if(@OpenMP_CXX_FOUND@)
+  # For unclear reasons, OpenMP is not always found correctly, in particular
+  #  on macOS under conda during model compilation.
+  #  In that case, we fall back to the values found by the main project.
+  #  This is not portable, but we aren't distributing binaries anyway.
+
+  # Try to find OpenMP again, but don't fail if not found
+  find_package(OpenMP COMPONENTS CXX)
+
+  if (NOT OpenMP_CXX_FOUND)
+    # Fall back to what was found by the main project
+    set(OpenMP_CXX_FLAGS @OpenMP_CXX_FLAGS@)
+    set(OpenMP_CXX_LIB_NAMES @OpenMP_CXX_LIB_NAMES@)
+    set(OpenMP_CXX_INCLUDE_DIRS @OpenMP_CXX_INCLUDE_DIRS@)
+    set(OpenMP_CXX_LIBRARIES @OpenMP_CXX_LIBRARIES@)
+    set(OpenMP_CXX_FOUND TRUE)
+    add_library(OpenMP::OpenMP_CXX INTERFACE IMPORTED)
+    set_target_properties(OpenMP::OpenMP_CXX PROPERTIES
+      INTERFACE_COMPILE_OPTIONS "${OpenMP_CXX_FLAGS}"
+      INTERFACE_LINK_LIBRARIES "${OpenMP_CXX_LIBRARIES}"
+      INTERFACE_INCLUDE_DIRECTORIES "${OpenMP_CXX_INCLUDE_DIRS}"
+    )
+  endif()
+endif()
 
 find_dependency(SUNDIALS REQUIRED PATHS
              "@CMAKE_SOURCE_DIR@/ThirdParty/sundials/build/@CMAKE_INSTALL_LIBDIR@/cmake/sundials/")

--- a/python/sdist/amici/exporters/sundials/templates/CMakeLists.template.cmake
+++ b/python/sdist/amici/exporters/sundials/templates/CMakeLists.template.cmake
@@ -2,6 +2,11 @@
 cmake_minimum_required(VERSION 3.22)
 cmake_policy(VERSION 3.22...3.31)
 
+# We aren't using C++20 modules, so disable scanning for them to avoid
+# clang-scan-deps-notfound errors.
+# See also https://discourse.cmake.org/t/cmake-3-28-cmake-cxx-compiler-clang-scan-deps-notfound-not-found/9244/3
+set(CMAKE_CXX_SCAN_FOR_MODULES OFF)
+
 project(TPL_MODELNAME)
 
 message(STATUS "CMAKE_CURRENT_SOURCE_DIR: ${CMAKE_CURRENT_SOURCE_DIR}")


### PR DESCRIPTION
* disable module scanning to work with missing clang-scan-deps under macOS/conda
* store OpenMP config in amici-core CMake configuration file as fallback if FindOpenMP fails
* require model import tests to pass

Closes #3028 