### PR TITLE
doc: Exclude private API

### DIFF
--- a/doc/conf.py
+++ b/doc/conf.py
@@ -18,7 +18,7 @@ try:
     import exhale_multiproject_monkeypatch  # noqa: F401
 except ModuleNotFoundError:
     # for unclear reasons, the import of exhale_multiproject_monkeypatch
-    #  fails on some systems, because the the location of the editable install
+    #  fails on some systems, because the location of the editable install
     #  is not automatically added to sys.path ¯\_(ツ)_/¯
     import json
     from importlib.metadata import Distribution
@@ -206,6 +206,7 @@ autodoc_default_options = {
     "special-members": "__init__",
     "inherited-members": True,
     "undoc-members": True,
+    "ignore-module-all": False,
 }
 
 # sphinx-autodoc-typehints

--- a/doc/python_modules.rst
+++ b/doc/python_modules.rst
@@ -7,27 +7,16 @@ AMICI Python API
    :toctree: generated
 
    amici
-   amici.importers.utils
    amici.importers.sbml
-   amici.importers.sbml.conserved_quantities_demartino
-   amici.importers.sbml.conserved_quantities_rref
-   amici.importers.sbml.utils
    amici.importers.sbml.splines
    amici.importers.pysb
    amici.importers.bngl
    amici.importers.antimony
    amici.importers.petab
    amici.importers.petab.v1
-   amici.importers.petab.v1.import_helpers
-   amici.importers.petab.v1.parameter_mapping
-   amici.importers.petab.v1.petab_import
-   amici.importers.petab.v1.pysb_import
-   amici.importers.petab.v1.sbml_import
    amici.jax
-   amici.exporters.sundials.de_export
    amici.sim.sundials
    amici.sim.sundials.plotting
    amici.sim.sundials.gradient_check
    amici.sim.sundials.petab.v1
-   amici.logging
    amici.adapters.fiddy

--- a/python/sdist/amici/__init__.py
+++ b/python/sdist/amici/__init__.py
@@ -1,7 +1,4 @@
 """
-AMICI
------
-
 The AMICI Python module provides functionality for importing SBML or PySB
 models and turning them into C++ Python extensions.
 """
@@ -17,6 +14,14 @@ from collections.abc import Callable
 from pathlib import Path
 from types import ModuleType
 from typing import Any
+
+__all__ = [
+    "import_model_module",
+    "AmiciVersionError",
+    "get_model_root_dir",
+    "get_model_dir",
+    "__version__",
+]
 
 
 def _get_amici_path():

--- a/python/sdist/amici/adapters/fiddy.py
+++ b/python/sdist/amici/adapters/fiddy.py
@@ -2,7 +2,10 @@
 Adapters for using AMICI with the `fiddy <https://github.com/ICB-DCM/fiddy/>`__
 package for finite difference checks.
 
-NOTE: Like fiddy, this module is experimental and subject to change.
+
+.. note::
+
+    Like fiddy, this module is experimental and subject to change.
 """
 
 from __future__ import annotations

--- a/python/sdist/amici/importers/antimony/__init__.py
+++ b/python/sdist/amici/importers/antimony/__init__.py
@@ -6,6 +6,8 @@ https://tellurium.readthedocs.io/en/latest/antimony.html
 
 from pathlib import Path
 
+__all__ = ["antimony2sbml", "antimony2amici"]
+
 
 def antimony2sbml(ant_model: str | Path) -> str:
     """Convert Antimony model to SBML.

--- a/python/sdist/amici/importers/bngl/__init__.py
+++ b/python/sdist/amici/importers/bngl/__init__.py
@@ -9,6 +9,8 @@ from pysb.importers.bngl import model_from_bngl
 
 from ..pysb import pysb2amici
 
+__all__ = ["bngl2amici"]
+
 
 def bngl2amici(bngl_model: str, *args, **kwargs) -> None:
     r"""

--- a/python/sdist/amici/importers/pysb/__init__.py
+++ b/python/sdist/amici/importers/pysb/__init__.py
@@ -52,6 +52,12 @@ from ..utils import (
     symbol_with_assumptions,
 )
 
+__all__ = [
+    "pysb_model_from_path",
+    "pysb2amici",
+    "pysb2jax",
+]
+
 CL_Prototype = dict[str, dict[str, Any]]
 ConservationLaw = dict[str, dict | str | sp.Basic]
 

--- a/python/sdist/amici/importers/sbml/__init__.py
+++ b/python/sdist/amici/importers/sbml/__init__.py
@@ -73,6 +73,13 @@ from amici.importers.utils import (
 )
 from amici.logging import get_logger, log_execution_time, set_log_level
 
+__all__ = [
+    "SbmlImporter",
+    "SBMLException",
+    "MeasurementChannel",
+    "assignment_rules_to_observables",
+]
+
 SymbolicFormula = dict[sp.Symbol, sp.Expr]
 
 

--- a/python/sdist/amici/importers/sbml/conserved_quantities_demartino.py
+++ b/python/sdist/amici/importers/sbml/conserved_quantities_demartino.py
@@ -6,6 +6,8 @@ from collections.abc import MutableSequence, Sequence
 
 from amici.logging import get_logger
 
+__all__ = ["compute_moiety_conservation_laws"]
+
 logger = get_logger(__name__, logging.ERROR)
 
 # increase recursion limit for recursive quicksort

--- a/python/sdist/amici/importers/sbml/conserved_quantities_rref.py
+++ b/python/sdist/amici/importers/sbml/conserved_quantities_rref.py
@@ -4,6 +4,8 @@ from typing import Literal
 
 import numpy as np
 
+__all__ = ["nullspace_by_rref", "rref"]
+
 
 def rref(
     mat: np.array, round_ndigits: Literal[False] | int | None = None

--- a/python/sdist/amici/importers/sbml/splines.py
+++ b/python/sdist/amici/importers/sbml/splines.py
@@ -53,6 +53,12 @@ from .utils import (
     sbml_mathml,
 )
 
+__all__ = [
+    "UniformGrid",
+    "AbstractSpline",
+    "CubicHermiteSpline",
+]
+
 logger = get_logger(__name__, logging.WARNING)
 
 

--- a/python/sdist/amici/sim/sundials/gradient_check.py
+++ b/python/sdist/amici/sim/sundials/gradient_check.py
@@ -22,6 +22,8 @@ from . import (
     run_simulation,
 )
 
+__all__ = ["check_finite_difference"]
+
 
 def check_finite_difference(
     x0: Sequence[float],


### PR DESCRIPTION
Set `__all__`, and remove some modules from the API doc completely.


Closes #3008.