### PR TITLE
Require jax<0.8.2

### DIFF
--- a/python/sdist/pyproject.toml
+++ b/python/sdist/pyproject.toml
@@ -87,7 +87,7 @@ examples = [
     "scipy",
 ]
 jax = [
-    "jax>=0.7.2",
+    "jax>=0.7.2,<0.8.2",
     "diffrax>=0.7.0",
     "jaxtyping>=0.2.34",
     "equinox>=0.13.2",


### PR DESCRIPTION
See #3113. For now, just require jax<0.8.2 to avoid test failures.