### PR TITLE
Fix flaky test_benchmark_gradient / Weber_BMC2015

### DIFF
--- a/tests/benchmark_models/test_petab_benchmark.py
+++ b/tests/benchmark_models/test_petab_benchmark.py
@@ -238,7 +238,7 @@ settings["Weber_BMC2015"] = GradientCheckSettings(
     rtol_sim=1e-12,
     atol_check=1e-6,
     rtol_check=1e-2,
-    rng_seed=1,
+    rng_seed=2,
 )
 settings["Zheng_PNAS2012"] = GradientCheckSettings(
     rng_seed=1,


### PR DESCRIPTION
Frequent failures specifically with Python3.14. Change RNG seed. Closes #3078.