### PR TITLE
Fix binder configuration

### DIFF
--- a/binder/Dockerfile
+++ b/binder/Dockerfile
@@ -5,7 +5,6 @@ FROM ubuntu:24.04
 RUN apt-get update && apt-get install -y \
     g++ \
     git \
-    libatlas-base-dev \
     libboost-serialization-dev \
     libboost-chrono-dev \
     libhdf5-serial-dev \
@@ -23,10 +22,14 @@ ENV USER ${NB_USER}
 ENV NB_UID ${NB_UID}
 ENV HOME /home/${NB_USER}
 ENV PATH="${PATH}:$HOME/.local/bin"
-RUN adduser --disabled-password \
-    --gecos "Default user" \
-    --uid ${NB_UID} \
-    ${NB_USER}
+# If there is no default 1000 user:
+#RUN adduser --disabled-password \
+#    --gecos "Default user" \
+#    --uid ${NB_UID} \
+#    ${NB_USER}
+# On ubuntu>=24.04 images there is ubuntu(1000)
+#  see https://bugs.launchpad.net/cloud-images/+bug/2005129
+RUN usermod -l ${NB_USER} ubuntu
 USER ${NB_USER}
 RUN python3 -m pip install --upgrade build wheel setuptools pip && \
     python3 -m pip install --no-cache-dir notebook jupyterlab jupyterhub jax[cpu] antimony

--- a/binder/Dockerfile
+++ b/binder/Dockerfile
@@ -52,7 +52,7 @@ WORKDIR ${HOME}
 RUN . ./.profile && ${VENV_PATH}/bin/python3 -m build --sdist python/sdist && \
     ${VENV_PATH}/bin/pip install git+https://github.com/pysb/pysb@master && \
     ${VENV_PATH}/bin/pip install -U sympy && \
-    ${VENV_PATH}/bin/pip install -v $(ls -t python/sdist/dist/amici-*.tar.gz | head -1)[petab,vis] && \
+    ${VENV_PATH}/bin/pip install -v $(ls -t python/sdist/dist/amici-*.tar.gz | head -1)[petab,vis,jax] && \
     ${VENV_PATH}/bin/pip install "git+https://github.com/Benchmarking-Initiative/Benchmark-Models-PEtab.git@master#subdirectory=src/python&egg=benchmark_models_petab" && \
     scripts/buildBNGL.sh
 

--- a/binder/Dockerfile
+++ b/binder/Dockerfile
@@ -30,7 +30,10 @@ ENV PATH="${VENV_PATH}/bin:${PATH}"
 #    ${NB_USER}
 # On ubuntu>=24.04 images there is ubuntu(1000)
 #  see https://bugs.launchpad.net/cloud-images/+bug/2005129
-RUN usermod -l ${NB_USER} ubuntu
+RUN usermod -l ${NB_USER} ubuntu && \
+    mv /home/ubuntu ${HOME} && \
+    usermod -d ${HOME} ${NB_USER} && \
+    chown -R ${NB_UID}:${NB_UID} ${HOME}
 USER ${NB_USER}
 RUN python3 -m venv ${VENV_PATH} && \
     ${VENV_PATH}/bin/pip install --upgrade build wheel setuptools pip && \

--- a/binder/Dockerfile
+++ b/binder/Dockerfile
@@ -21,7 +21,8 @@ ARG NB_UID=1000
 ENV USER ${NB_USER}
 ENV NB_UID ${NB_UID}
 ENV HOME /home/${NB_USER}
-ENV PATH="${PATH}:$HOME/.local/bin"
+ENV VENV_PATH=${HOME}/venv
+ENV PATH="${VENV_PATH}/bin:${PATH}"
 # If there is no default 1000 user:
 #RUN adduser --disabled-password \
 #    --gecos "Default user" \
@@ -31,8 +32,9 @@ ENV PATH="${PATH}:$HOME/.local/bin"
 #  see https://bugs.launchpad.net/cloud-images/+bug/2005129
 RUN usermod -l ${NB_USER} ubuntu
 USER ${NB_USER}
-RUN python3 -m pip install --upgrade build wheel setuptools pip && \
-    python3 -m pip install --no-cache-dir notebook jupyterlab jupyterhub jax[cpu] antimony
+RUN python3 -m venv ${VENV_PATH} && \
+    ${VENV_PATH}/bin/pip install --upgrade build wheel setuptools pip && \
+    ${VENV_PATH}/bin/pip install --no-cache-dir notebook jupyterlab jupyterhub jax[cpu] antimony
 # END BINDER
 
 # BEGIN BINDER
@@ -44,9 +46,8 @@ USER ${NB_USER}
 # END BINDER
 
 WORKDIR ${HOME}
-RUN . ./.profile && python3 -m build --sdist python/sdist && \
-    python3 -m pip install -v $(ls -t python/sdist/dist/amici-*.tar.gz | head -1)[petab,pysb,vis] && \
-    python3 -m pip install "git+https://github.com/Benchmarking-Initiative/Benchmark-Models-PEtab.git@master#subdirectory=src/python&egg=benchmark_models_petab" && \
+RUN . ./.profile && ${VENV_PATH}/bin/pip install -v $(ls -t python/sdist/dist/amici-*.tar.gz | head -1)[petab,pysb,vis] && \
+    ${VENV_PATH}/bin/pip install "git+https://github.com/Benchmarking-Initiative/Benchmark-Models-PEtab.git@master#subdirectory=src/python&egg=benchmark_models_petab" && \
     scripts/buildBNGL.sh
 
 ENV BNGPATH="${HOME}/ThirdParty/BioNetGen-2.7.0"

--- a/binder/Dockerfile
+++ b/binder/Dockerfile
@@ -50,7 +50,9 @@ USER ${NB_USER}
 
 WORKDIR ${HOME}
 RUN . ./.profile && ${VENV_PATH}/bin/python3 -m build --sdist python/sdist && \
-    ${VENV_PATH}/bin/pip install -v $(ls -t python/sdist/dist/amici-*.tar.gz | head -1)[petab,pysb,vis] && \
+    ${VENV_PATH}/bin/pip install git+https://github.com/pysb/pysb@master && \
+    ${VENV_PATH}/bin/pip install -U sympy && \
+    ${VENV_PATH}/bin/pip install -v $(ls -t python/sdist/dist/amici-*.tar.gz | head -1)[petab,vis] && \
     ${VENV_PATH}/bin/pip install "git+https://github.com/Benchmarking-Initiative/Benchmark-Models-PEtab.git@master#subdirectory=src/python&egg=benchmark_models_petab" && \
     scripts/buildBNGL.sh
 

--- a/binder/Dockerfile
+++ b/binder/Dockerfile
@@ -52,7 +52,7 @@ WORKDIR ${HOME}
 RUN . ./.profile && ${VENV_PATH}/bin/python3 -m build --sdist python/sdist && \
     ${VENV_PATH}/bin/pip install git+https://github.com/pysb/pysb@master && \
     ${VENV_PATH}/bin/pip install -U sympy && \
-    ${VENV_PATH}/bin/pip install -v $(ls -t python/sdist/dist/amici-*.tar.gz | head -1)[petab,vis,jax] && \
+    ${VENV_PATH}/bin/pip install -v $(ls -t python/sdist/dist/amici-*.tar.gz | head -1)[petab,vis,jax,sciml] && \
     ${VENV_PATH}/bin/pip install "git+https://github.com/Benchmarking-Initiative/Benchmark-Models-PEtab.git@master#subdirectory=src/python&egg=benchmark_models_petab" && \
     scripts/buildBNGL.sh
 

--- a/binder/Dockerfile
+++ b/binder/Dockerfile
@@ -49,7 +49,8 @@ USER ${NB_USER}
 # END BINDER
 
 WORKDIR ${HOME}
-RUN . ./.profile && ${VENV_PATH}/bin/pip install -v $(ls -t python/sdist/dist/amici-*.tar.gz | head -1)[petab,pysb,vis] && \
+RUN . ./.profile && ${VENV_PATH}/bin/python3 -m build --sdist python/sdist && \
+    ${VENV_PATH}/bin/pip install -v $(ls -t python/sdist/dist/amici-*.tar.gz | head -1)[petab,pysb,vis] && \
     ${VENV_PATH}/bin/pip install "git+https://github.com/Benchmarking-Initiative/Benchmark-Models-PEtab.git@master#subdirectory=src/python&egg=benchmark_models_petab" && \
     scripts/buildBNGL.sh
 

--- a/binder/Dockerfile
+++ b/binder/Dockerfile
@@ -18,9 +18,9 @@ RUN apt-get update && apt-get install -y \
 # BEGIN BINDER
 ARG NB_USER=jovyan
 ARG NB_UID=1000
-ENV USER ${NB_USER}
-ENV NB_UID ${NB_UID}
-ENV HOME /home/${NB_USER}
+ENV USER=${NB_USER}
+ENV NB_UID=${NB_UID}
+ENV HOME=/home/${NB_USER}
 ENV VENV_PATH=${HOME}/venv
 ENV PATH="${VENV_PATH}/bin:${PATH}"
 # If there is no default 1000 user:


### PR DESCRIPTION
* Rename default user instead of attempting to create a new user with pre-existing ID. Fixes #3138
* skip installing libatlas which is not necessary anymore.
* install jax extras
* use venv instead of the system env (no longer supported)
* install correct sympy / pysb versions

:eyes: https://mybinder.org/v2/gh/dweindl/AMICI/25328720e5e0eae1473097c4b917842a2451b5b9?labpath=doc/examples/
