### PR TITLE
Remove interpax dep and jax pin to update lineax

### DIFF
--- a/python/sdist/amici/exporters/jax/jax.template.py
+++ b/python/sdist/amici/exporters/jax/jax.template.py
@@ -5,7 +5,6 @@ import equinox as eqx  # noqa: F401
 import jax.numpy as jnp
 import jax.random as jr  # noqa: F401
 import jaxtyping as jt  # noqa: F401
-from interpax import interp1d  # noqa: F401
 from jax.numpy import inf as oo  # noqa: F401
 from jax.numpy import nan as nan  # noqa: F401
 

--- a/python/sdist/pyproject.toml
+++ b/python/sdist/pyproject.toml
@@ -87,12 +87,11 @@ examples = [
     "scipy",
 ]
 jax = [
-    "jax>=0.7.2,<0.8.2",
+    "jax>=0.7.2",
     "diffrax>=0.7.0",
     "jaxtyping>=0.2.34",
     "equinox>=0.13.2",
     "optimistix>=0.0.9",
-    "interpax>=0.3.9",
 ]
 sciml = [
     "h5py"


### PR DESCRIPTION
Closes #3113 

The issue was caused by a lineax bug, fixed in lineax v0.1.0.  lineax v0.1.0 and interpax are not compatible, but luckily we don't appear to use interpax any more. 