### PR TITLE
petab-import: fix fixed parameter selection with pandas>=3

### DIFF
--- a/.github/workflows/test_petab_test_suite.yml
+++ b/.github/workflows/test_petab_test_suite.yml
@@ -172,7 +172,7 @@ jobs:
           git clone https://github.com/PEtab-dev/petab_test_suite \
             && source ./venv/bin/activate \
             && cd petab_test_suite \
-            && git checkout 9542847fb99bcbdffc236e2ef45ba90580a210fa \
+            && git checkout a1935c4d197c3b72dfaf85b9c28268314f4e6ef2 \
             && pip3 install -e .
 
 # TODO: once there is a PEtab v2 benchmark collection
@@ -186,7 +186,7 @@ jobs:
         run: |
           source ./venv/bin/activate \
             && python3 -m pip uninstall -y petab \
-            && python3 -m pip install git+https://github.com/petab-dev/libpetab-python.git@44c8062ce1b87a74a0ba1bd2551de0cdc2a13ff1 \
+            && python3 -m pip install git+https://github.com/petab-dev/libpetab-python.git@main \
             && python3 -m pip install git+https://github.com/pysb/pysb@master \
             && python3 -m pip install sympy>=1.12.1
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,8 @@ See also our [versioning policy](https://amici.readthedocs.io/en/latest/versioni
 
 * Fixed an issue that resulted in failure to import the `PetabImporter` if
   the jax-dependencies weren't installed.
-
+* Fixed a pandas>=3.0 compatibility issue in the PEtab importer which resulted
+  in incorrect selection of fixed parameters.
 
 ### v1.0.0
 

--- a/python/sdist/amici/importers/petab/v1/_import_helpers.py
+++ b/python/sdist/amici/importers/petab/v1/_import_helpers.py
@@ -225,7 +225,7 @@ def get_fixed_parameters(
             # TODO: could check if the final overriding parameter is estimated
             #  or not, but for now, we skip the parameter if there is any kind
             #  of overriding
-            if condition_df[p].dtype != "O"
+            if not pd.api.types.is_string_dtype(condition_df[p].dtype)
             # p is a parameter
             and not petab_problem.model.is_state_variable(p)
         )

--- a/python/sdist/amici/sim/sundials/petab/v1/_conditions.py
+++ b/python/sdist/amici/sim/sundials/petab/v1/_conditions.py
@@ -351,8 +351,8 @@ def create_edata_for_condition(
     # create an ExpData object
     edata = ExpData(amici_model)
     edata.id = condition[SIMULATION_CONDITION_ID]
-    if condition.get(PREEQUILIBRATION_CONDITION_ID):
-        edata.id += "+" + condition.get(PREEQUILIBRATION_CONDITION_ID)
+    if not pd.isna(preeq_id := condition.get(PREEQUILIBRATION_CONDITION_ID)):
+        edata.id += f"+{preeq_id}"
     ##########################################################################
     # enable initial parameters reinitialization
 
@@ -444,7 +444,11 @@ def create_edatas(
         if PREEQUILIBRATION_CONDITION_ID in condition:
             measurement_index = (
                 condition.get(SIMULATION_CONDITION_ID),
-                condition.get(PREEQUILIBRATION_CONDITION_ID) or "",
+                preeq_id
+                if not pd.isna(
+                    preeq_id := condition.get(PREEQUILIBRATION_CONDITION_ID)
+                )
+                else "",
             )
         else:
             measurement_index = (condition.get(SIMULATION_CONDITION_ID),)


### PR DESCRIPTION
Fixes a pandas>=3.0 compatibility issue in the PEtab importer which resulted in incorrect selection of fixed parameters.