### PR TITLE
CI: pytest>=10 compatibility

### DIFF
--- a/python/tests/test_conserved_quantities_rref.py
+++ b/python/tests/test_conserved_quantities_rref.py
@@ -17,7 +17,7 @@ def random_matrix_generator(min_dim, max_dim, count):
 
 
 @skip_on_valgrind
-@pytest.mark.parametrize("mat", random_matrix_generator(0, 10, 200))
+@pytest.mark.parametrize("mat", tuple(random_matrix_generator(0, 10, 200)))
 def test_rref(mat):
     """Create some random matrices and compare output of ``rref`` and
     ``pivots`` to that of sympy"""
@@ -30,7 +30,7 @@ def test_rref(mat):
 
 
 @skip_on_valgrind
-@pytest.mark.parametrize("mat", random_matrix_generator(0, 50, 50))
+@pytest.mark.parametrize("mat", tuple(random_matrix_generator(0, 50, 50)))
 def test_nullspace_by_rref(mat):
     """Test ``nullspace_by_rref`` on a number of random matrices and compare
     to sympy results"""


### PR DESCRIPTION
Fixes:
```
E   pytest.PytestRemovedIn10Warning: Passing a non-Collection iterable to parametrize is deprecated.
E   Test: python/tests/test_conserved_quantities_rref.py::test_rref, argvalues type: generator
E   Please convert to a list or tuple.
E   See https://docs.pytest.org/en/stable/deprecations.html#parametrize-iterators
```