### PR TITLE
CI: pytest>=10 compatibility (again)

### DIFF
--- a/tests/sbml/conftest.py
+++ b/tests/sbml/conftest.py
@@ -90,7 +90,7 @@ def pytest_generate_tests(metafunc):
             # Run selected tests
             last_id = int(list(get_all_semantic_case_ids())[-1])
             test_numbers = sorted(set(parse_selection(cases, last_id)))
-            test_ids = map(format_test_id, test_numbers)
+            test_ids = list(map(format_test_id, test_numbers))
         else:
             # Run all tests
             test_ids = get_all_semantic_case_ids()


### PR DESCRIPTION
`Passing a non-Collection iterable to parametrize is deprecated.`

https://github.com/AMICI-dev/AMICI/actions/runs/27598583574/job/81594102931