### PR TITLE
CI: fix cppcheck suppressions

### DIFF
--- a/.cppcheck-exitcode-suppressions
+++ b/.cppcheck-exitcode-suppressions
@@ -1,1 +1,1 @@
-alloca:*:*
+alloca:*


### PR DESCRIPTION
Remove unsupported line number wildcard.

Fixes:
`cppcheck: error: invalid line number (converting '*' to integer failed - not an integer (invalid_argument))` 
https://github.com/AMICI-dev/AMICI/actions/runs/27597477933/job/81590697285