### PR TITLE
CI: Fix installation of benchmark_models_petab

### DIFF
--- a/.github/workflows/test_benchmark_collection_models.yml
+++ b/.github/workflows/test_benchmark_collection_models.yml
@@ -58,7 +58,7 @@ jobs:
 
     - name: Download benchmark collection
       run: |
-        pip install git+https://github.com/Benchmarking-Initiative/Benchmark-Models-PEtab.git@master#subdirectory=src/python
+        pip install -e 'git+https://github.com/Benchmarking-Initiative/Benchmark-Models-PEtab.git@master#subdirectory=src/python&egg=benchmark_models_petab'
 
     - name: Run tests
       env:
@@ -136,7 +136,7 @@ jobs:
 
     - name: Download benchmark collection
       run: |
-        pip install git+https://github.com/Benchmarking-Initiative/Benchmark-Models-PEtab.git@master#subdirectory=src/python
+        pip install -e 'git+https://github.com/Benchmarking-Initiative/Benchmark-Models-PEtab.git@master#subdirectory=src/python&egg=benchmark_models_petab'
 
     - name: Run JAX tests
       env:


### PR DESCRIPTION
Building the wheel for benchmark_models_petab [fails](https://github.com/AMICI-dev/AMICI/actions/runs/28006132696/job/82890017835) with current setuptools. Symlink issues. Use editable installation.