### PR TITLE
CI: use Python 3.14 for free threading tests

### DIFF
--- a/.github/workflows/test_python_nogil.yml
+++ b/.github/workflows/test_python_nogil.yml
@@ -15,10 +15,10 @@ jobs:
       AMICI_PARALLEL_COMPILE: ""
     steps:
     - run: echo "AMICI_DIR=$(pwd)" >> $GITHUB_ENV
-    - name: Set up Python 3.13 free-threaded
+    - name: Set up free-threaded Python
       uses: actions/setup-python@v6
       with:
-        python-version: '3.13'
+        python-version: '3.14'
         freethreaded: true
     - uses: actions/checkout@v7
       with:


### PR DESCRIPTION
The latest scipy doesn't provide wheels for [py313t](https://github.com/AMICI-dev/AMICI/actions/runs/28012716502/job/82909527662), so let's use [py314t](https://github.com/dweindl/AMICI/actions/runs/28031602005/job/82973512420).

(Avoids building scipy ourselved or using python-version-specific scipy requirements.)