### PR TITLE
Fix NameError in JAX _known_discs for w-dependent explicit triggers

### DIFF
--- a/python/sdist/amici/exporters/jax/ode_export.py
+++ b/python/sdist/amici/exporters/jax/ode_export.py
@@ -275,13 +275,7 @@ class ODEExporter:
             )
             if self._get_all_p_syms()
             else "_",
-            "ROOTS": _jnp_array_str(
-                {
-                    _print_trigger_root(root)
-                    for e in self.model._events
-                    for root in e.get_trigger_times()
-                }
-            ),
+            "ROOTS": _jnp_array_str(self._get_known_discs()),
             "N_IEVENTS": str(len(self.model.get_implicit_roots())),
             "N_EEVENTS": str(len(self.model.get_explicit_roots())),
             "EVENT_INITIAL_VALUES": _jnp_array_str(
@@ -349,6 +343,38 @@ class ODEExporter:
     def _get_all_p_syms(self) -> list[sp.Symbol]:
         return list(self.model.sym("p")) + list(self.model.sym("k"))
 
+    def _get_known_discs(self) -> set[str]:
+        """Known discontinuity time points for use in ``_known_discs``.
+
+        ``_known_discs`` only has access to ``p`` (and ``k``, unpacked from
+        ``p``), so explicit trigger times may only depend on those symbols.
+        Trigger times that depend on *static* ``w`` expressions (i.e.
+        expressions that do not depend on time, states, or Heaviside
+        variables) are resolved by recursively substituting in their
+        defining formulas. Trigger times that depend on any other
+        (non-static) symbols cannot be expressed in terms of ``p``/``k``
+        alone and are excluded here; they are still handled correctly at
+        runtime via root-finding in ``_root_cond_fn``.
+        """
+        static_syms = self.model._static_symbols(["k", "p", "w"])
+        p_k_syms = set(self.model.sym("p")) | set(self.model.sym("k"))
+        w_subs = dict(
+            zip(self.model.sym("w"), self.model.eq("w"), strict=True)
+        )
+
+        known_discs = set()
+        for e in self.model._events:
+            for root in e.get_trigger_times():
+                if not root.free_symbols.issubset(static_syms):
+                    continue
+                resolved = root
+                for _ in range(len(w_subs) + 1):
+                    if resolved.free_symbols.issubset(p_k_syms):
+                        known_discs.add(self._code_printer.doprint(resolved))
+                        break
+                    resolved = resolved.subs(w_subs)
+        return known_discs
+
     def _generate_nn_code(self) -> None:
         for net_name, net in self.hybridization.items():
             generate_equinox(
@@ -402,14 +428,3 @@ class ODEExporter:
             )
 
         self.model_name = model_name
-
-
-def _print_trigger_root(root: sp.Expr) -> str:
-    """Convert a trigger root expression into a string representation.
-
-    :param root: The trigger root expression.
-    :return: A string representation of the trigger root.
-    """
-    if root.is_number:
-        return float(root)
-    return str(root).replace(" ", "")

--- a/python/sdist/amici/exporters/jax/ode_export.py
+++ b/python/sdist/amici/exporters/jax/ode_export.py
@@ -275,7 +275,7 @@ class ODEExporter:
             )
             if self._get_all_p_syms()
             else "_",
-            "ROOTS": _jnp_array_str(self._get_known_discs()),
+            "ROOTS": _jnp_array_str(sorted(self._get_known_discs())),
             "N_IEVENTS": str(len(self.model.get_implicit_roots())),
             "N_EEVENTS": str(len(self.model.get_explicit_roots())),
             "EVENT_INITIAL_VALUES": _jnp_array_str(


### PR DESCRIPTION
## Summary

- The JAX exporter's generated `_known_discs(self, p)` crashed with a `NameError` whenever an explicit (time-)trigger expression referenced a model expression (`w`) rather than depending only on `p`. Repro: `Fujita_SciSignal2010` from the PEtab benchmark collection, where the EGF pulse-end trigger time (`EGF_end`) is a `w` computed from PEtab experiment-indicator parameters.
- `_known_discs` only has `p` in scope, so `EGF_end` leaked into the generated code unresolved.
- Root cause: `ROOTS` codegen in `ode_export.py` pulled `Event.get_trigger_times()` raw, without restricting to symbols computable from `p` alone. The sundials/C++ backend already handles this correctly (`_get_explicit_roots_body` filters to `p`/`k`/static-`w` and passes `w` in as a runtime argument); the JAX backend had no equivalent.
- Fix: added `ODEExporter._get_known_discs()`, which only keeps trigger-time roots whose free symbols are `p`/`k`/*static* `w` (provably independent of `t`/`x`/`h`), then recursively substitutes those static `w` symbols with their defining formulas until only `p`/`k` remain (safe, since static `w`'s formulas can only reference `p`/`k`/other static `w`'s). The resolved expression is printed via the JAX code printer instead of naive `str()`, since a resolved `w` can be a `Piecewise`, which needs to become `jnp.select` rather than un-printable `Piecewise(...)` syntax.
- Triggers that can't be reduced to `p`/`k` alone are excluded from `known_discs`; they're still handled correctly at runtime via root-finding in `_root_cond_fn`.

## Test plan

- [x] Regenerated the `Fujita_SciSignal2010` JAX model — `_known_discs` now returns valid `jnp.select(...)` code instead of the bare undefined `EGF_end` symbol.
- [x] Ran the full `run_simulations` repro from the issue end-to-end — completes successfully with no `NameError`.
- [x] Re-ran the existing JAX discontinuity regression tests (`test_time_dependent_discontinuity`, `test_time_dependent_discontinuity_equilibration`) — both pass.
- [x] Verified a plain numeric/parameter-only explicit trigger still resolves correctly (no regression for the simple case that previously worked).

🤖 Generated with [Claude Code](https://claude.com/claude-code)