### PR TITLE
Avoid JAX recompilation from fresh steady_state_event closures

### DIFF
--- a/python/sdist/amici/sim/jax/petab.py
+++ b/python/sdist/amici/sim/jax/petab.py
@@ -46,6 +46,31 @@ SCALE_TO_INT = {
 logger = get_logger(__name__, logging.WARNING)
 
 
+class SteadyStateEvent(eqx.Module):
+    """Steady-state termination event with value-based equality.
+
+    :func:`diffrax.steady_state_event` returns a fresh closure on every
+    call, which Python compares by identity. Since ``steady_state_event`` is
+    passed as a static argument into :func:`equinox.filter_jit`-compiled
+    functions (:meth:`JAXModel.simulate_condition`,
+    :meth:`JAXModel.preequilibrate_condition`), constructing a new closure
+    with identical settings on every call (e.g. once per iteration of an
+    optimization loop) silently defeats the JIT cache and forces a full
+    recompilation, even though only numeric inputs (parameters) changed.
+    Wrapping the settings in an :class:`equinox.Module` gives value-based
+    ``__eq__``/``__hash__``, so equivalent instances share the compiled
+    executable regardless of how many times they are (re-)constructed.
+    """
+
+    rtol: float | None = None
+    atol: float | None = None
+
+    def __call__(self, *args, **kwargs):
+        return diffrax.steady_state_event(rtol=self.rtol, atol=self.atol)(
+            *args, **kwargs
+        )
+
+
 def jax_unscale(
     parameter: jnp.float_,
     scale_str: str,
@@ -1768,7 +1793,7 @@ def run_simulations(
     ),
     steady_state_event: Callable[
         ..., diffrax._custom_types.BoolScalarLike
-    ] = diffrax.steady_state_event(),
+    ] = SteadyStateEvent(),
     max_steps: int = 2**13,
     ret: ReturnValue | str = ReturnValue.llh,
 ):
@@ -1879,7 +1904,7 @@ def petab_simulate(
     ),
     steady_state_event: Callable[
         ..., diffrax._custom_types.BoolScalarLike
-    ] = diffrax.steady_state_event(),
+    ] = SteadyStateEvent(),
     max_steps: int = 2**13,
 ):
     """

--- a/python/tests/test_jax.py
+++ b/python/tests/test_jax.py
@@ -337,6 +337,131 @@ def test_serialisation(lotka_volterra):  # noqa: F811
 
 
 @skip_on_valgrind
+def test_steady_state_event_no_recompile_across_conditions(
+    tmp_path, monkeypatch
+):
+    """Simulating different conditions/parameters must not force JAX to
+    recompile, as long as only numeric inputs (e.g. parameters) change.
+
+    Regression test: ``diffrax.steady_state_event()`` returns a fresh
+    closure on every call, which Python compares by identity rather than
+    value. Since it is passed as a static argument to the
+    ``eqx.filter_jit``-compiled ``JAXModel.simulate_condition`` and
+    ``JAXModel.preequilibrate_condition``, constructing a fresh instance on
+    every call (e.g. once per condition, or once per optimizer iteration)
+    used to defeat the JIT cache and force a full recompilation every time,
+    even though only numeric parameters differed.
+    :class:`amici.sim.jax.petab.SteadyStateEvent` fixes this by giving the
+    event value-based equality/hashing, so this test also reconstructs the
+    solver/controller/root finder from scratch on every call to make sure
+    those (which already hash by value) don't regress either.
+    """
+    from amici.importers.antimony import antimony2sbml
+    from amici.importers.sbml import SbmlImporter
+    from amici.sim.jax.model import JAXModel
+    from amici.sim.jax.petab import (
+        DEFAULT_CONTROLLER_SETTINGS,
+        DEFAULT_ROOT_FINDER_SETTINGS,
+        SteadyStateEvent,
+    )
+
+    ant_model = """
+    model steady_state_recompile
+        x' = -k * x
+        x = 1
+        k = 1
+    end
+    """
+    sbml = antimony2sbml(ant_model)
+    importer = SbmlImporter(sbml, from_file=False)
+    importer.sbml2jax("steady_state_recompile", output_dir=tmp_path)
+    module = amici._module_from_path(
+        "steady_state_recompile", tmp_path / "__init__.py"
+    )
+    model = module.Model()
+
+    def fresh_solver_kwargs():
+        # construct brand new instances on every call, mimicking e.g. an
+        # optimizer objective that rebuilds solver settings each iteration
+        return dict(
+            solver=diffrax.Kvaerno5(),
+            controller=diffrax.PIDController(**DEFAULT_CONTROLLER_SETTINGS),
+            root_finder=optimistix.Newton(**DEFAULT_ROOT_FINDER_SETTINGS),
+            steady_state_event=SteadyStateEvent(),
+        )
+
+    conditions = [1.0, 2.5, 0.3]  # numeric-only differences between calls
+
+    n_traces = {"n": 0}
+    orig_simulate = JAXModel.simulate_condition_unjitted
+
+    def counting_simulate(self, *args, **kwargs):
+        n_traces["n"] += 1
+        return orig_simulate(self, *args, **kwargs)
+
+    monkeypatch.setattr(
+        JAXModel, "simulate_condition_unjitted", counting_simulate
+    )
+
+    ts = jnp.array([0.0, 1.0, 2.0])
+    my = jnp.zeros_like(ts)
+    iys = jnp.zeros_like(ts, dtype=int)
+    iy_trafos = jnp.zeros_like(ts, dtype=int)
+
+    for k_val in conditions:
+        kwargs = fresh_solver_kwargs()
+        model.simulate_condition(
+            jnp.array([k_val]),
+            ts,
+            jnp.array([]),
+            my,
+            iys,
+            iy_trafos,
+            jnp.zeros((3, 0)),
+            jnp.zeros((3, 0)),
+            kwargs["solver"],
+            kwargs["controller"],
+            kwargs["root_finder"],
+            diffrax.RecursiveCheckpointAdjoint(),
+            kwargs["steady_state_event"],
+            1000,
+        )
+
+    assert n_traces["n"] == 1, (
+        "simulate_condition was retraced across conditions with only "
+        f"numeric differences ({n_traces['n']} traces instead of 1)"
+    )
+
+    n_traces["n"] = 0
+    orig_handle_t0_event = JAXModel._handle_t0_event
+
+    def counting_handle_t0_event(self, *args, **kwargs):
+        n_traces["n"] += 1
+        return orig_handle_t0_event(self, *args, **kwargs)
+
+    monkeypatch.setattr(JAXModel, "_handle_t0_event", counting_handle_t0_event)
+
+    for k_val in conditions:
+        kwargs = fresh_solver_kwargs()
+        model.preequilibrate_condition(
+            jnp.array([k_val]),
+            jnp.array([]),
+            jnp.array([]),
+            jnp.array([]),
+            kwargs["solver"],
+            kwargs["controller"],
+            kwargs["root_finder"],
+            kwargs["steady_state_event"],
+            1000,
+        )
+
+    assert n_traces["n"] == 1, (
+        "preequilibrate_condition was retraced across conditions with only "
+        f"numeric differences ({n_traces['n']} traces instead of 1)"
+    )
+
+
+@skip_on_valgrind
 def test_time_dependent_discontinuity(tmp_path):
     """Models with time dependent discontinuities are handled."""
 

--- a/python/tests/test_jax.py
+++ b/python/tests/test_jax.py
@@ -356,6 +356,7 @@ def test_steady_state_event_no_recompile_across_conditions(
     solver/controller/root finder from scratch on every call to make sure
     those (which already hash by value) don't regress either.
     """
+    import equinox as eqx
     from amici.importers.antimony import antimony2sbml
     from amici.importers.sbml import SbmlImporter
     from amici.sim.jax.model import JAXModel
@@ -392,22 +393,29 @@ def test_steady_state_event_no_recompile_across_conditions(
 
     conditions = [1.0, 2.5, 0.3]  # numeric-only differences between calls
 
-    n_traces = {"n": 0}
-    orig_simulate = JAXModel.simulate_condition_unjitted
+    def patch_trace_counter(target, name):
+        # eqx.debug.assert_max_traces/get_num_traces track calls to a plain
+        # callable; since it isn't itself a descriptor, dispatch to it
+        # manually so `self` is still bound correctly when called as
+        # `self.<name>(...)`.
+        wrapped = eqx.debug.assert_max_traces(
+            getattr(target, name), max_traces=1
+        )
 
-    def counting_simulate(self, *args, **kwargs):
-        n_traces["n"] += 1
-        return orig_simulate(self, *args, **kwargs)
+        def dispatch(self, *args, **kwargs):
+            return wrapped(self, *args, **kwargs)
 
-    monkeypatch.setattr(
-        JAXModel, "simulate_condition_unjitted", counting_simulate
-    )
+        monkeypatch.setattr(target, name, dispatch)
+        return wrapped
 
     ts = jnp.array([0.0, 1.0, 2.0])
     my = jnp.zeros_like(ts)
     iys = jnp.zeros_like(ts, dtype=int)
     iy_trafos = jnp.zeros_like(ts, dtype=int)
 
+    simulate_traces = patch_trace_counter(
+        JAXModel, "simulate_condition_unjitted"
+    )
     for k_val in conditions:
         kwargs = fresh_solver_kwargs()
         model.simulate_condition(
@@ -427,20 +435,12 @@ def test_steady_state_event_no_recompile_across_conditions(
             1000,
         )
 
-    assert n_traces["n"] == 1, (
+    assert eqx.debug.get_num_traces(simulate_traces) == 1, (
         "simulate_condition was retraced across conditions with only "
-        f"numeric differences ({n_traces['n']} traces instead of 1)"
+        "numeric differences"
     )
 
-    n_traces["n"] = 0
-    orig_handle_t0_event = JAXModel._handle_t0_event
-
-    def counting_handle_t0_event(self, *args, **kwargs):
-        n_traces["n"] += 1
-        return orig_handle_t0_event(self, *args, **kwargs)
-
-    monkeypatch.setattr(JAXModel, "_handle_t0_event", counting_handle_t0_event)
-
+    preeq_traces = patch_trace_counter(JAXModel, "_handle_t0_event")
     for k_val in conditions:
         kwargs = fresh_solver_kwargs()
         model.preequilibrate_condition(
@@ -455,9 +455,9 @@ def test_steady_state_event_no_recompile_across_conditions(
             1000,
         )
 
-    assert n_traces["n"] == 1, (
+    assert eqx.debug.get_num_traces(preeq_traces) == 1, (
         "preequilibrate_condition was retraced across conditions with only "
-        f"numeric differences ({n_traces['n']} traces instead of 1)"
+        "numeric differences"
     )
 
 

--- a/python/tests/test_jax.py
+++ b/python/tests/test_jax.py
@@ -342,19 +342,6 @@ def test_steady_state_event_no_recompile_across_conditions(
 ):
     """Simulating different conditions/parameters must not force JAX to
     recompile, as long as only numeric inputs (e.g. parameters) change.
-
-    Regression test: ``diffrax.steady_state_event()`` returns a fresh
-    closure on every call, which Python compares by identity rather than
-    value. Since it is passed as a static argument to the
-    ``eqx.filter_jit``-compiled ``JAXModel.simulate_condition`` and
-    ``JAXModel.preequilibrate_condition``, constructing a fresh instance on
-    every call (e.g. once per condition, or once per optimizer iteration)
-    used to defeat the JIT cache and force a full recompilation every time,
-    even though only numeric parameters differed.
-    :class:`amici.sim.jax.petab.SteadyStateEvent` fixes this by giving the
-    event value-based equality/hashing, so this test also reconstructs the
-    solver/controller/root finder from scratch on every call to make sure
-    those (which already hash by value) don't regress either.
     """
     import equinox as eqx
     from amici.importers.antimony import antimony2sbml

--- a/python/tests/test_jax.py
+++ b/python/tests/test_jax.py
@@ -393,6 +393,9 @@ def test_steady_state_event_no_recompile_across_conditions(
 
     conditions = [1.0, 2.5, 0.3]  # numeric-only differences between calls
 
+    # Avoid order-dependent failures if prior tests already compiled these methods.
+    jax.clear_caches()
+
     def patch_trace_counter(target, name):
         # eqx.debug.assert_max_traces/get_num_traces track calls to a plain
         # callable; since it isn't itself a descriptor, dispatch to it


### PR DESCRIPTION
## Summary
- `diffrax.steady_state_event()` returns a new closure on every call, and Python compares closures by identity, not value. Since it's passed as a static argument into the `eqx.filter_jit`-compiled `JAXModel.simulate_condition` / `JAXModel.preequilibrate_condition`, constructing a fresh instance with identical settings on every call (e.g. once per iteration of an optimization loop) silently defeats the JIT cache and forces a full recompilation, even though only numeric parameters changed.
- Adds `SteadyStateEvent`, an `equinox.Module` wrapping the same `rtol`/`atol` settings with value-based `__eq__`/`__hash__`, and uses it as the default in `run_simulations`/`petab_simulate` so equivalent instances share the compiled executable regardless of how many times they're constructed.
- Adds a regression test using `equinox.debug.assert_max_traces`/`get_num_traces` that verifies `simulate_condition` and `preequilibrate_condition` are traced exactly once across repeated calls with only numeric differences, even when solver/controller/root-finder/event objects are freshly reconstructed each call.

## Test plan
- [x] `python/tests/test_jax.py::test_steady_state_event_no_recompile_across_conditions` passes with the fix
- [x] Same test fails against the pre-fix code (import error / would show >1 trace with a bare `diffrax.steady_state_event()`)
- [x] Full non-PySB-dependent subset of `python/tests/test_jax.py` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)