### PR TITLE
Fix AttributeError during model import

### DIFF
--- a/python/sdist/amici/exporters/sundials/templates/modelname.template.i
+++ b/python/sdist/amici/exporters/sundials/templates/modelname.template.i
@@ -1,6 +1,7 @@
 %define MODULEIMPORT
 "
 import amici
+import amici.sim.sundials
 import datetime
 import importlib.util
 import os


### PR DESCRIPTION
Previously, importing a model module would result in an `AttributeError`if no other objects were imported from `amici.sim.sundials` beforehand.