### PR TITLE
CI: Revert: Skip llh test for Isensee_JCB2018

### DIFF
--- a/tests/benchmark_models/test_petab_benchmark.py
+++ b/tests/benchmark_models/test_petab_benchmark.py
@@ -131,9 +131,7 @@ problems_for_llh_check = [
     "Elowitz_Nature2000",
     "Fiedler_BMCSystBiol2016",
     "Fujita_SciSignal2010",
-    # Excluded until https://github.com/Benchmarking-Initiative/Benchmark-Models-PEtab/pull/253
-    #  is sorted out
-    # "Isensee_JCB2018",
+    "Isensee_JCB2018",
     "Lucarelli_CellSystems2018",
     "Schwen_PONE2014",
     "Smith_BMCSystBiol2013",


### PR DESCRIPTION
Revert skipping Isensee_JCB2018 (#2621).
See https://github.com/Benchmarking-Initiative/Benchmark-Models-PEtab/pull/253