### PR TITLE
Fix spurious conservation-law assertion for condition-dependent compartments

### DIFF
--- a/python/sdist/amici/_symbolic/de_model.py
+++ b/python/sdist/amici/_symbolic/de_model.py
@@ -1833,9 +1833,8 @@ class DEModel:
             # compartment sizes, where the coefficients contain a product of
             # `Piecewise` factors that cancels to 1 in `w` but is retained in
             # `get_x_rdata`.
-            if self._simplify is not None:
+            if self._simplify:
                 expected = [self._simplify(expr) for expr in expected]
-                actual = [self._simplify(expr) for expr in actual]
             if expected != actual:
                 raise AssertionError(
                     "Conservation laws are not at the beginning of 'w'. "

--- a/python/sdist/amici/_symbolic/de_model.py
+++ b/python/sdist/amici/_symbolic/de_model.py
@@ -1817,14 +1817,26 @@ class DEModel:
             self._eqs[name] = self.sym(name)
 
         elif name == "dwdx":
-            if (
-                expected := list(
-                    map(
-                        ConservationLaw.get_x_rdata,
-                        reversed(self.conservation_laws()),
-                    )
+            expected = list(
+                map(
+                    ConservationLaw.get_x_rdata,
+                    reversed(self.conservation_laws()),
                 )
-            ) != (actual := self.eq("w")[: self.num_cons_law()]):
+            )
+            actual = self.eq("w")[: self.num_cons_law()]
+            # `self.eq("w")` has been passed through `self._simplify`, whereas
+            # `ConservationLaw.get_x_rdata` returns the unsimplified expression.
+            # Apply the same simplification to the expected `x_rdata`
+            # reconstruction before comparing, so that mathematically
+            # equivalent but structurally different forms do not trigger a
+            # spurious mismatch. This happens, e.g., for condition-dependent
+            # compartment sizes, where the coefficients contain a product of
+            # `Piecewise` factors that cancels to 1 in `w` but is retained in
+            # `get_x_rdata`.
+            if self._simplify is not None:
+                expected = [self._simplify(expr) for expr in expected]
+                actual = [self._simplify(expr) for expr in actual]
+            if expected != actual:
                 raise AssertionError(
                     "Conservation laws are not at the beginning of 'w'. "
                     f"Got {actual}, expected {expected}."


### PR DESCRIPTION
When importing a PEtab problem with condition-dependent compartment sizes,
the conservation-law coefficients contain a product of `Piecewise` factors
that cancels to 1. `self.eq("w")` is passed through `self._simplify`, which
collapses this product, while `ConservationLaw.get_x_rdata` returns the
unsimplified expression. The strict equality check in the `dwdx` computation
then failed on mathematically equivalent but structurally different forms,
raising a spurious AssertionError (e.g. PEtab v2 test suite case 0012).

Apply the same simplification to both sides before comparing.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01U6qHLHHce8fyPNeoT2BxPf