### PR TITLE
Fix JAXProblem.save()/load() round-trip against current petab.v2 API

### DIFF
--- a/python/sdist/amici/importers/petab/v1/_petab_import.py
+++ b/python/sdist/amici/importers/petab/v1/_petab_import.py
@@ -255,6 +255,10 @@ def import_petab_problem(
     )
 
     if jax:
+        import tempfile
+
+        import petab.v2 as petabv2
+
         from amici.sim.jax import JAXProblem
 
         model = model_module.Model()
@@ -263,9 +267,17 @@ def import_petab_problem(
             f"Successfully loaded jax model {model_name} from {output_dir}."
         )
 
+        # JAXProblem requires a PEtab v2 problem; upgrade the v1 problem by
+        # serializing it to a temporary PEtab v1 problem on disk and letting
+        # petab auto-upgrade it (``petab.v2.Problem.from_yaml`` upgrades v1
+        # YAML files via ``petab1to2``).
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            yaml_path = petab_problem.to_files_generic(prefix_path=tmp_dir)
+            petab_problem_v2 = petabv2.Problem.from_yaml(yaml_path)
+
         # Create and return JAXProblem
         logger.info(f"Successfully created JAXProblem for {model_name}.")
-        return JAXProblem(model, petab_problem)
+        return JAXProblem(model, petab_problem_v2)
 
     model = model_module.get_model()
     check_model(amici_model=model, petab_problem=petab_problem)

--- a/python/sdist/amici/sim/jax/petab.py
+++ b/python/sdist/amici/sim/jax/petab.py
@@ -183,15 +183,12 @@ class JAXProblem(eqx.Module):
         :param directory:
             Directory to save the problem to.
         """
-        self._petab_problem.to_files(
-            prefix_path=directory,
-            model_file="model",
-            condition_file="conditions.tsv",
-            measurement_file="measurements.tsv",
-            parameter_file="parameters.tsv",
-            observable_file="observables.tsv",
-            yaml_file="problem.yaml",
-        )
+        if self._petab_problem.config is None:
+            self._petab_problem.config = petabv2.ProblemConfig(
+                format_version="2.0.0"
+            )
+        self._petab_problem.config.filepath = "problem.yaml"
+        self._petab_problem.to_files(base_path=directory)
         shutil.copy(self.model.jax_py_file, directory / "jax_py_file.py")
         with open(directory / "parameters.pkl", "wb") as f:
             eqx.tree_serialise_leaves(f, self)

--- a/python/tests/test_jax.py
+++ b/python/tests/test_jax.py
@@ -313,27 +313,22 @@ def test_serialisation(lotka_volterra):  # noqa: F811
     with TemporaryDirectoryWinSafe(
         prefix=petab_problem.model.model_id
     ) as model_dir:
-        try:
-            jax_problem = import_petab_problem(
-                petab_problem, jax=True, output_dir=model_dir
-            )
-            # change parameters to random values to test serialisation
-            jax_problem.update_parameters(
-                jax_problem.parameters
-                + jr.normal(jr.PRNGKey(0), jax_problem.parameters.shape)
-            )
+        jax_problem = import_petab_problem(
+            petab_problem, jax=True, output_dir=model_dir
+        )
+        # change parameters to random values to test serialisation
+        jax_problem.update_parameters(
+            jax_problem.parameters
+            + jr.normal(jr.PRNGKey(0), jax_problem.parameters.shape)
+        )
 
-            with TemporaryDirectoryWinSafe() as outdir:
-                outdir = Path(outdir)
-                jax_problem.save(outdir)
-                jax_problem_loaded = JAXProblem.load(outdir)
-                assert_allclose(
-                    jax_problem.parameters, jax_problem_loaded.parameters
-                )
-        except (TypeError, NotImplementedError) as err:
-            if "JAXProblem does not support PEtab v1 problems" in str(err):
-                pytest.skip(str(err))
-            raise err
+        with TemporaryDirectoryWinSafe() as outdir:
+            outdir = Path(outdir)
+            jax_problem.save(outdir)
+            jax_problem_loaded = JAXProblem.load(outdir)
+            assert_allclose(
+                jax_problem.parameters, jax_problem_loaded.parameters
+            )
 
 
 @skip_on_valgrind


### PR DESCRIPTION
## Summary

- `JAXProblem.save()` (`python/sdist/amici/sim/jax/petab.py`) called `petab.v2.Problem.to_files()` with a keyword-argument signature (`prefix_path=`, `model_file=`, `condition_file=`, ...) that no longer exists — the current `to_files(self, base_path)` relies on each table/model already having `rel_path`/`base_path` set (normally done by `Problem.from_yaml`). This raised `TypeError: Problem.to_files() got an unexpected keyword argument 'prefix_path'`. Fixed by setting `config.filepath = "problem.yaml"` (so the written YAML has the name `JAXProblem.load()` expects) and calling `to_files(base_path=directory)`. `load()` needed no change.
- Getting the regression test far enough to hit that bug required fixing a prerequisite issue in `import_petab_problem(..., jax=True)` (`python/sdist/amici/importers/petab/v1/_petab_import.py`): it passed the original PEtab v1 problem straight into `JAXProblem()`, which rejects v1 problems outright. Now upgrades v1→v2 via `to_files_generic`/`from_yaml` first, mirroring the conversion already used elsewhere in the codebase.
- Removed the now-unneeded `try/except (TypeError, NotImplementedError): pytest.skip(...)` guard from `test_serialisation` in `python/tests/test_jax.py` so it actually asserts the save/load round trip instead of silently skipping. Left the equivalent guard on `test_preequilibration_failure` alone — that covers a separate, already-known bug in the preequilibration-condition heuristic, out of scope here.

## Test plan

- [x] `pytest python/tests/test_jax.py::test_serialisation` passes (round-trips perturbed parameters through `save()`/`load()` and asserts `assert_allclose`).
- [x] Confirmed the two other pre-existing failures in `test_jax.py` (`test_conversion`, `test_dimerization`) are unrelated environment issues (missing BioNetGen binary), and `test_preequilibration_failure` fails on a separate, already-tracked bug — neither is a regression from this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)