### PR TITLE
Fix condition-name-based preequilibration detection in JAX PEtab backend

### DIFF
--- a/python/sdist/amici/importers/petab/v1/_petab_import.py
+++ b/python/sdist/amici/importers/petab/v1/_petab_import.py
@@ -255,6 +255,10 @@ def import_petab_problem(
     )
 
     if jax:
+        import tempfile
+
+        import petab.v2 as petabv2
+
         from amici.sim.jax import JAXProblem
 
         model = model_module.Model()
@@ -263,9 +267,17 @@ def import_petab_problem(
             f"Successfully loaded jax model {model_name} from {output_dir}."
         )
 
+        # JAXProblem requires a PEtab v2 problem; upgrade the v1 problem by
+        # serializing it to a temporary PEtab v1 problem on disk and letting
+        # petab auto-upgrade it (``petab.v2.Problem.from_yaml`` upgrades v1
+        # YAML files via ``petab1to2``).
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            yaml_path = petab_problem.to_files_generic(prefix_path=tmp_dir)
+            petab_problem_v2 = petabv2.Problem.from_yaml(yaml_path)
+
         # Create and return JAXProblem
         logger.info(f"Successfully created JAXProblem for {model_name}.")
-        return JAXProblem(model, petab_problem)
+        return JAXProblem(model, petab_problem_v2)
 
     model = model_module.get_model()
     check_model(amici_model=model, petab_problem=petab_problem)

--- a/python/sdist/amici/sim/jax/petab.py
+++ b/python/sdist/amici/sim/jax/petab.py
@@ -285,12 +285,6 @@ class JAXProblem(eqx.Module):
                     )
 
         for _, simulation_condition in simulation_conditions.iterrows():
-            if (
-                "preequilibration"
-                in simulation_condition[petabv2.C.CONDITION_ID]
-            ):
-                continue
-
             query = " & ".join(
                 [
                     f"{k} == '{v}'" if isinstance(v, str) else f"{k} == {v}"
@@ -527,9 +521,9 @@ class JAXProblem(eqx.Module):
                 ch.target_id: jnp.asarray(
                     ch.target_value, dtype=self.model.parameters.dtype
                 )
+                for ch in c.changes
             }
             for c in self._petab_problem.conditions
-            for ch in c.changes
         }
 
         hybrid_map = {}
@@ -1325,7 +1319,9 @@ class JAXProblem(eqx.Module):
 
         t_zeros = jnp.stack(
             [
-                exp.periods[0].time if exp.periods[0].time >= 0.0 else 0.0
+                0.0
+                if exp.periods[0].is_preequilibration
+                else exp.periods[0].time
                 for exp in experiments
             ]
         )
@@ -1553,16 +1549,21 @@ class JAXProblem(eqx.Module):
             Output value and condition specific results and statistics. Results and statistics are returned as a dict
             with arrays with the leading dimension corresponding to the simulation conditions.
         """
-        simulation_conditions = [
-            cid
+        # one entry per experiment, aligned with `experiments` (and thus with
+        # `p_array` built from it in `_prepare_experiments`), not a
+        # deduplicated set of condition names.
+        dynamic_conditions = [
+            next(
+                (
+                    cid
+                    for period in exp.periods
+                    if not period.is_preequilibration
+                    for cid in period.condition_ids
+                ),
+                None,
+            )
             for exp in experiments
-            for p in exp.periods
-            for cid in p.condition_ids
         ]
-        dynamic_conditions = list(
-            sc for sc in simulation_conditions if "preequilibration" not in sc
-        )
-        dynamic_conditions = list(dict.fromkeys(dynamic_conditions))
 
         (
             p_array,
@@ -1704,15 +1705,21 @@ class JAXProblem(eqx.Module):
         ],
         max_steps: jnp.int_,
     ):
-        simulation_conditions = [
-            cid
+        # one entry per experiment, aligned with `experiments` (and thus with
+        # `p_array` built from it in `_prepare_experiments`), not a
+        # deduplicated set of condition names.
+        preequilibration_conditions = [
+            next(
+                (
+                    cid
+                    for period in exp.periods
+                    if period.is_preequilibration
+                    for cid in period.condition_ids
+                ),
+                None,
+            )
             for exp in experiments
-            for p in exp.periods
-            for cid in p.condition_ids
         ]
-        preequilibration_conditions = list(
-            {sc for sc in simulation_conditions if "preequilibration" in sc}
-        )
 
         p_array, mask_reinit_array, x_reinit_array, _, _, h_mask, _ = (
             self._prepare_experiments(
@@ -1789,21 +1796,26 @@ def run_simulations(
             if exp.id in simulation_experiments
         ]
 
-    simulation_conditions = [
-        cid
+    # one entry per experiment, aligned with `experiments` (and thus with the
+    # rows of `problem._iys`/`problem._ts_masks` built from it), not a
+    # deduplicated set of condition names.
+    dynamic_conditions = [
+        next(
+            (
+                cid
+                for period in exp.periods
+                if not period.is_preequilibration
+                for cid in period.condition_ids
+            ),
+            None,
+        )
         for exp in experiments
-        for p in exp.periods
-        for cid in p.condition_ids
     ]
-    dynamic_conditions = list(
-        sc for sc in simulation_conditions if "preequilibration" not in sc
-    )
-    dynamic_conditions = list(dict.fromkeys(dynamic_conditions))
     conditions = {
         "dynamic_conditions": dynamic_conditions,
     }
 
-    has_preeq = any(exp.periods[0].time < 0.0 for exp in experiments)
+    has_preeq = any(exp.periods[0].is_preequilibration for exp in experiments)
 
     if has_preeq:
         preeqs, preresults, h_preeqs = problem.run_preequilibrations(
@@ -1993,6 +2005,13 @@ def get_simulation_conditions_v2(petab_problem) -> pd.DataFrame:
             experiment_df[petabv2.C.EXPERIMENT_ID] == exp_id
         ][petabv2.C.CONDITION_ID].unique()
 
+    # drop preequilibration periods, identified by `time == -inf` (per the
+    # PEtab v2 spec, this is the only value that signifies preequilibration)
+    # rather than by condition name, since preequilibration conditions may be
+    # named arbitrarily.
+    experiment_df = experiment_df[
+        experiment_df[petabv2.C.TIME] != petabv2.C.TIME_PREEQUILIBRATION
+    ]
     experiment_df = experiment_df.drop(columns=[petabv2.C.TIME])
     return experiment_df
 

--- a/python/sdist/amici/sim/jax/petab.py
+++ b/python/sdist/amici/sim/jax/petab.py
@@ -117,7 +117,7 @@ def _get_period_condition_id(
         if period.is_preequilibration != is_preequilibration:
             continue
         if period.condition_ids:
-            return period.condition_ids[0]
+            return '+'.join(period.condition_ids)
 
     kind = "preequilibration" if is_preequilibration else "dynamic"
     raise ValueError(

--- a/python/sdist/amici/sim/jax/petab.py
+++ b/python/sdist/amici/sim/jax/petab.py
@@ -95,6 +95,36 @@ def jax_unscale(
     raise ValueError(f"Invalid parameter scaling: {scale_str}")
 
 
+def _get_period_condition_id(
+    exp: petabv2.Experiment, is_preequilibration: bool
+) -> str:
+    """Get the condition id of an experiment's (pre)equilibration period.
+
+    :param exp:
+        PEtab v2 experiment.
+    :param is_preequilibration:
+        If ``True``, look for the preequilibration period
+        (:attr:`petabv2.ExperimentPeriod.is_preequilibration`, i.e.
+        ``time == -inf``). If ``False``, look for the dynamic
+        (non-preequilibration) period.
+    :return:
+        The first condition id of the matching period.
+    :raises ValueError:
+        If ``exp`` has no matching period with a non-empty
+        ``condition_ids``.
+    """
+    for period in exp.periods:
+        if period.is_preequilibration != is_preequilibration:
+            continue
+        if period.condition_ids:
+            return period.condition_ids[0]
+
+    kind = "preequilibration" if is_preequilibration else "dynamic"
+    raise ValueError(
+        f"Experiment {exp.id!r} has no {kind} period with a condition id."
+    )
+
+
 class JAXProblem(eqx.Module):
     """
     PEtab problem wrapper for JAX models.
@@ -1553,15 +1583,7 @@ class JAXProblem(eqx.Module):
         # `p_array` built from it in `_prepare_experiments`), not a
         # deduplicated set of condition names.
         dynamic_conditions = [
-            next(
-                (
-                    cid
-                    for period in exp.periods
-                    if not period.is_preequilibration
-                    for cid in period.condition_ids
-                ),
-                None,
-            )
+            _get_period_condition_id(exp, is_preequilibration=False)
             for exp in experiments
         ]
 
@@ -1709,15 +1731,7 @@ class JAXProblem(eqx.Module):
         # `p_array` built from it in `_prepare_experiments`), not a
         # deduplicated set of condition names.
         preequilibration_conditions = [
-            next(
-                (
-                    cid
-                    for period in exp.periods
-                    if period.is_preequilibration
-                    for cid in period.condition_ids
-                ),
-                None,
-            )
+            _get_period_condition_id(exp, is_preequilibration=True)
             for exp in experiments
         ]
 
@@ -1800,15 +1814,7 @@ def run_simulations(
     # rows of `problem._iys`/`problem._ts_masks` built from it), not a
     # deduplicated set of condition names.
     dynamic_conditions = [
-        next(
-            (
-                cid
-                for period in exp.periods
-                if not period.is_preequilibration
-                for cid in period.condition_ids
-            ),
-            None,
-        )
+        _get_period_condition_id(exp, is_preequilibration=False)
         for exp in experiments
     ]
     conditions = {
@@ -1999,11 +2005,6 @@ def get_simulation_conditions_v2(petab_problem) -> pd.DataFrame:
         A pandas DataFrame mapping experiment_ids to condition ids.
     """
     experiment_df = petab_problem.experiment_df
-    exps = {}
-    for exp_id in experiment_df[petabv2.C.EXPERIMENT_ID].unique():
-        exps[exp_id] = experiment_df[
-            experiment_df[petabv2.C.EXPERIMENT_ID] == exp_id
-        ][petabv2.C.CONDITION_ID].unique()
 
     # drop preequilibration periods, identified by `time == -inf` (per the
     # PEtab v2 spec, this is the only value that signifies preequilibration)

--- a/python/sdist/amici/sim/jax/petab.py
+++ b/python/sdist/amici/sim/jax/petab.py
@@ -2006,10 +2006,7 @@ def get_simulation_conditions_v2(petab_problem) -> pd.DataFrame:
     """
     experiment_df = petab_problem.experiment_df
 
-    # drop preequilibration periods, identified by `time == -inf` (per the
-    # PEtab v2 spec, this is the only value that signifies preequilibration)
-    # rather than by condition name, since preequilibration conditions may be
-    # named arbitrarily.
+    # drop preequilibration periods
     experiment_df = experiment_df[
         experiment_df[petabv2.C.TIME] != petabv2.C.TIME_PREEQUILIBRATION
     ]

--- a/python/sdist/amici/sim/jax/petab.py
+++ b/python/sdist/amici/sim/jax/petab.py
@@ -95,10 +95,16 @@ def jax_unscale(
     raise ValueError(f"Invalid parameter scaling: {scale_str}")
 
 
-def _get_period_condition_id(
+def _get_period_condition_ids(
     exp: petabv2.Experiment, is_preequilibration: bool
-) -> str:
-    """Get the condition id of an experiment's (pre)equilibration period.
+) -> tuple[str, ...]:
+    """Get the condition ids of an experiment's (pre)equilibration period.
+
+    A period may reference multiple condition ids applied simultaneously
+    (PEtab v2 requires their targets to be disjoint); all of them are
+    returned so callers can consider each one, rather than collapsing them
+    into a single id that would not correspond to any row of
+    :attr:`petab.v2.Problem.condition_df`.
 
     :param exp:
         PEtab v2 experiment.
@@ -108,7 +114,7 @@ def _get_period_condition_id(
         ``time == -inf``). If ``False``, look for the dynamic
         (non-preequilibration) period.
     :return:
-        The first condition id of the matching period.
+        The condition ids of the matching period, in period order.
     :raises ValueError:
         If ``exp`` has no matching period with a non-empty
         ``condition_ids``.
@@ -117,7 +123,7 @@ def _get_period_condition_id(
         if period.is_preequilibration != is_preequilibration:
             continue
         if period.condition_ids:
-            return '+'.join(period.condition_ids)
+            return tuple(period.condition_ids)
 
     kind = "preequilibration" if is_preequilibration else "dynamic"
     raise ValueError(
@@ -1153,14 +1159,16 @@ class JAXProblem(eqx.Module):
 
     def _state_needs_reinitialisation(
         self,
-        simulation_condition: str,
+        simulation_conditions: tuple[str, ...],
         state_id: str,
     ) -> bool:
         """
         Check if a state needs reinitialisation for a simulation condition.
 
-        :param simulation_condition:
-            simulation condition to check reinitialisation for
+        :param simulation_conditions:
+            condition ids simultaneously active for the simulation condition
+            to check reinitialisation for (PEtab v2 requires their targets
+            to be disjoint, so at most one of them defines ``state_id``)
         :param state_id:
             state id to check reinitialisation for
         :return:
@@ -1174,24 +1182,26 @@ class JAXProblem(eqx.Module):
 
         if state_id not in self._petab_problem.condition_df:
             return False
-        xval = self._petab_problem.condition_df.loc[
-            simulation_condition, state_id
-        ]
-        if isinstance(xval, Number) and np.isnan(xval):
-            return False
-        return True
+        for condition in simulation_conditions:
+            xval = self._petab_problem.condition_df.loc[condition, state_id]
+            if not (isinstance(xval, Number) and np.isnan(xval)):
+                return True
+        return False
 
     def _state_reinitialisation_value(
         self,
-        simulation_condition: str,
+        simulation_conditions: tuple[str, ...],
         state_id: str,
         p: jt.Float[jt.Array, "np"],
     ) -> jt.Float[jt.Scalar, ""] | float:  # noqa: F722
         """
         Get the reinitialisation value for a state.
 
-        :param simulation_condition:
-            simulation condition to get reinitialisation value for
+        :param simulation_conditions:
+            condition ids simultaneously active for the simulation condition
+            to get the reinitialisation value for (PEtab v2 requires their
+            targets to be disjoint, so at most one of them defines
+            ``state_id``)
         :param state_id:
             state id to get reinitialisation value for
         :param p:
@@ -1200,21 +1210,27 @@ class JAXProblem(eqx.Module):
             reinitialisation value for the state
         """
         if state_id in self.nn_output_ids:
-            return self._eval_nn(state_id, simulation_condition)
+            return self._eval_nn(state_id, simulation_conditions[0])
 
         if state_id in self._parameter_mappings["hybrid_map"]:
             return self._eval_nn(
                 self._parameter_mappings["hybrid_map"][state_id],
-                simulation_condition,
+                simulation_conditions[0],
             )
 
         if state_id not in self._petab_problem.condition_df:
             # no reinitialisation, return dummy value
             return 0.0
-        xval = self._petab_problem.condition_df.loc[
-            simulation_condition, state_id
-        ]
-        if isinstance(xval, Number) and np.isnan(xval):
+
+        xval = None
+        for condition in simulation_conditions:
+            candidate = self._petab_problem.condition_df.loc[
+                condition, state_id
+            ]
+            if not (isinstance(candidate, Number) and np.isnan(candidate)):
+                xval = candidate
+                break
+        if xval is None:
             # no reinitialisation, return dummy value
             return 0.0
         if isinstance(xval, Number):
@@ -1239,19 +1255,23 @@ class JAXProblem(eqx.Module):
 
     def load_reinitialisation(
         self,
-        simulation_condition: str,
+        simulation_conditions: str | tuple[str, ...],
         p: jt.Float[jt.Array, "np"],
     ) -> tuple[jt.Bool[jt.Array, "nx"], jt.Float[jt.Array, "nx"]]:  # noqa: F821
         """
         Load reinitialisation values and mask for the state vector for a simulation condition.
 
-        :param simulation_condition:
-            Simulation condition to load reinitialisation for.
+        :param simulation_conditions:
+            Condition id(s) simultaneously active for the simulation
+            condition to load reinitialisation for.
         :param p:
             Parameters for the simulation condition.
         :return:
             Tuple of reinitialisation masm and value for states.
         """
+        if isinstance(simulation_conditions, str):
+            simulation_conditions = (simulation_conditions,)
+
         if not any(
             x_id in self._petab_problem.condition_df
             or hasattr(self, "nn_output_ids")
@@ -1262,14 +1282,14 @@ class JAXProblem(eqx.Module):
 
         mask = jnp.array(
             [
-                self._state_needs_reinitialisation(simulation_condition, x_id)
+                self._state_needs_reinitialisation(simulation_conditions, x_id)
                 for x_id in self.model.state_ids
             ]
         )
         reinit_x = jnp.array(
             [
                 self._state_reinitialisation_value(
-                    simulation_condition, x_id, p
+                    simulation_conditions, x_id, p
                 )
                 for x_id in self.model.state_ids
             ]
@@ -1580,7 +1600,7 @@ class JAXProblem(eqx.Module):
         # `p_array` built from it in `_prepare_experiments`), not a
         # deduplicated set of condition names.
         dynamic_conditions = [
-            _get_period_condition_id(exp, is_preequilibration=False)
+            _get_period_condition_ids(exp, is_preequilibration=False)
             for exp in experiments
         ]
 
@@ -1728,7 +1748,7 @@ class JAXProblem(eqx.Module):
         # `p_array` built from it in `_prepare_experiments`), not a
         # deduplicated set of condition names.
         preequilibration_conditions = [
-            _get_period_condition_id(exp, is_preequilibration=True)
+            _get_period_condition_ids(exp, is_preequilibration=True)
             for exp in experiments
         ]
 
@@ -1811,7 +1831,7 @@ def run_simulations(
     # rows of `problem._iys`/`problem._ts_masks` built from it), not a
     # deduplicated set of condition names.
     dynamic_conditions = [
-        _get_period_condition_id(exp, is_preequilibration=False)
+        _get_period_condition_ids(exp, is_preequilibration=False)
         for exp in experiments
     ]
     conditions = {

--- a/python/tests/test_jax.py
+++ b/python/tests/test_jax.py
@@ -285,26 +285,21 @@ def test_preequilibration_failure(lotka_volterra):  # noqa: F811
     petab_problem = lotka_volterra
     # oscillating system, preequilibation should fail when interaction is active
 
-    try:
-        with TemporaryDirectoryWinSafe(prefix="normal") as model_dir:
-            jax_problem = import_petab_problem(
-                petab_problem, jax=True, output_dir=model_dir
-            )
-            r = run_simulations(jax_problem)
-            assert not np.isinf(r[0].item())
-        petab_problem.measurement_df[PREEQUILIBRATION_CONDITION_ID] = (
-            petab_problem.measurement_df[SIMULATION_CONDITION_ID]
+    with TemporaryDirectoryWinSafe(prefix="normal") as model_dir:
+        jax_problem = import_petab_problem(
+            petab_problem, jax=True, output_dir=model_dir
         )
-        with TemporaryDirectoryWinSafe(prefix="failure") as model_dir:
-            jax_problem = import_petab_problem(
-                petab_problem, jax=True, output_dir=model_dir
-            )
-            r = run_simulations(jax_problem)
-            assert np.isinf(r[0].item())
-    except (TypeError, NotImplementedError) as err:
-        if "JAXProblem does not support PEtab v1 problems" in str(err):
-            pytest.skip(str(err))
-        raise err
+        r = run_simulations(jax_problem)
+        assert not np.isinf(r[0].item())
+    petab_problem.measurement_df[PREEQUILIBRATION_CONDITION_ID] = (
+        petab_problem.measurement_df[SIMULATION_CONDITION_ID]
+    )
+    with TemporaryDirectoryWinSafe(prefix="failure") as model_dir:
+        jax_problem = import_petab_problem(
+            petab_problem, jax=True, output_dir=model_dir
+        )
+        r = run_simulations(jax_problem)
+        assert np.isinf(r[0].item())
 
 
 @skip_on_valgrind


### PR DESCRIPTION
## Summary

`JAXProblem.run_preequilibrations` (and several sibling call sites in `python/sdist/amici/sim/jax/petab.py`) identified preequilibration periods/conditions with a substring check (`"preequilibration" in condition_id`). This only worked for AMICI's own synthetic condition names (e.g. `_petab_preequilibration_on`/`_petab_preequilibration_off`) and silently produced an empty or misaligned condition list for PEtab problems that use arbitrary, real condition names for preequilibration — e.g. `"no_interaction"` in the `lotka_volterra` test fixture. This crashed downstream with `ValueError: Need at least one array to stack.` or a `vmap` shape mismatch.

Per the [PEtab v2 spec](https://petab.readthedocs.io/en/latest/v2/documentation_data_format.html), only `time == -inf` signifies preequilibration (matching `petab.v2.ExperimentPeriod.is_preequilibration`); ordinary periods can have any numeric `time`, including negative finite values, so a `time < 0.0` check (an earlier draft of this fix) isn't precise enough either.

- Replaced every name/inequality-based check with `period.is_preequilibration` (or the `TIME_PREEQUILIBRATION` constant where operating on a raw DataFrame column in `get_simulation_conditions_v2`).
- Made the derived condition lists (`preequilibration_conditions`, `dynamic_conditions`) one entry per experiment, aligned with `experiments`/`p_array`, instead of a deduplicated global set — required since `_prepare_experiments` later does `zip(conditions, p_array)`.
- Fixed two additional bugs found while getting the fixture end-to-end, which blocked this code path from producing correct results once reachable:
  - `JAXProblem._get_parameter_mappings` built its per-condition `targets_map` with a malformed (flattened, non-nested) dict comprehension that discarded all but the last parameter override per condition.
  - `import_petab_problem(..., jax=True)` for PEtab v1 problems constructed `JAXProblem` directly from the v1 problem, which `JAXProblem` rejects; now upgrades to v2 first, mirroring the conversion already used by `PetabImporter`.
- Restored `test_preequilibration_failure` in `test_jax.py` without the `try/except (TypeError, NotImplementedError): pytest.skip(...)` guard that had been masking the crash — it now passes for real.

## Test plan

- `pytest python/tests/test_jax.py::test_preequilibration_failure` passes.
- `pytest python/tests/test_jax.py` — same pre-existing/unrelated failures as before this change (missing BioNetGen binary for `test_conversion`/`test_dimerization`; a separate, already-tracked `petab.v2 Problem.to_files()` API mismatch in `JAXProblem.save()` for `test_serialisation`).
- Manually verified against the `lotka_volterra` fixture through both repro routes: direct `amici.importers.petab.v1.import_petab_problem(..., jax=True)`, and PEtab v1→v2→`PetabImporter`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)