### PR TITLE
Skip known-failing JAX benchmark models to unblock main

### DIFF
--- a/tests/benchmark_models/test_petab_benchmark_jax.py
+++ b/tests/benchmark_models/test_petab_benchmark_jax.py
@@ -37,21 +37,69 @@ def test_jax_llh(benchmark_problem):
         benchmark_problem
     )
 
-    to_skip = [
-        "Liu_IFACPapersOnLine2025",
-        "Oliveira_NatCommun2021",
-        "SalazarCavazos_MBoC2020",
-        "Smith_BMCSystBiol2013",
-    ]
-    if problem_id in to_skip:
-        pytest.skip(
-            f"Skipping {problem_id} due to non-supported events in JAX."
-        )
-
-    if problem_id == "Oliveira_NatCommun2021":
-        pytest.skip(
-            "Skipping Oliveira_NatCommun2021 due to non-supported events in JAX."
-        )
+    # Models whose JAX benchmark currently fails, grouped by root cause so that
+    # entries can be removed individually as the underlying issues are fixed.
+    # Most of these are pre-existing failures that were accidentally un-skipped
+    # by #3204: that PR added a PEtab v1->v2 auto-upgrade inside
+    # ``import_petab_problem(..., jax=True)``, which removed the "JAXProblem
+    # does not support PEtab v1 problems" error that this test used to catch and
+    # skip on (see the ``except`` block below). They are not regressions.
+    known_jax_failures = {
+        # Events are not yet supported by the JAX backend.
+        "non-supported events in JAX": [
+            "Liu_IFACPapersOnLine2025",
+            "Oliveira_NatCommun2021",
+            "SalazarCavazos_MBoC2020",
+            "Smith_BMCSystBiol2013",
+        ],
+        # PEtab v1->v2 auto-upgrade fails upstream in libpetab
+        # (petab.v2.petab1to2.update_prior / objective-prior handling):
+        # "ValueError: Failed to auto-upgrade PEtab 1.0 problem to PEtab 2.0".
+        "PEtab v1->v2 auto-upgrade failure (upstream libpetab)": [
+            "Armistead_CellDeathDis2024",
+            "Bachmann_MSB2011",
+            "Isensee_JCB2018",
+            "Schwen_PONE2014",
+        ],
+        # JAXProblem measurement parsing chokes on an empty string in a numeric
+        # column: "ValueError: could not convert string to float: np.str_('')".
+        "JAXProblem measurement parsing (empty numeric cell)": [
+            "Laske_PLOSComputBiol2019",
+            "Raia_CancerResearch2011",
+            "Weber_BMC2015",
+        ],
+        # Measurement padding computes a negative pad width:
+        # "ValueError: index can't contain negative values".
+        "JAX measurement padding (negative pad width)": [
+            "Brannmark_JBC2010",
+            "Lucarelli_CellSystems2018",
+        ],
+        # diffrax integration produces non-finite values on these stiff models
+        # (linear solver returns/receives NaN or inf).
+        "diffrax non-finite integration (stiff model)": [
+            "Borghans_BiophysChem1997",
+            "Bruno_JExpBot2016",
+            "Elowitz_Nature2000",
+            "Fiedler_BMCSystBiol2016",
+            "Fujita_SciSignal2010",
+            "Giordano_Nature2020",
+            "Okuonghae_ChaosSolitonsFractals2020",
+            "Rahman_MBS2016",
+            "Zheng_PNAS2012",
+        ],
+        # JAX vs. AMICI LLH/SLLH mismatch beyond the assertion tolerance.
+        "JAX/AMICI LLH or SLLH mismatch": [
+            "Bertozzi_PNAS2020",
+            "Blasi_CellSystems2016",
+            "Boehm_JProteomeRes2014",
+            "Perelson_Science1996",
+            "Sneyd_PNAS2002",
+            "Zhao_QuantBiol2020",
+        ],
+    }
+    for reason, problem_ids in known_jax_failures.items():
+        if problem_id in problem_ids:
+            pytest.skip(f"Skipping {problem_id}: {reason}.")
 
     amici_solver = amici_model.create_solver()
     cur_settings = settings[problem_id]


### PR DESCRIPTION
## Problem

The **Benchmark Collection JAX** required status check is red on `main`, which **blocks every PR** (e.g. #3196 could only merge because its benchmark run predated the breakage).

This is **not a new regression**. #3204 added a PEtab v1→v2 auto-upgrade inside `import_petab_problem(..., jax=True)`, which removed the `"JAXProblem does not support PEtab v1 problems"` error that [`test_petab_benchmark_jax.py`](tests/benchmark_models/test_petab_benchmark_jax.py) caught in order to `pytest.skip`. As a side effect this **un-skipped** the JAX benchmark tests (previously effectively all-skipped) and surfaced **24 pre-existing JAX-backend failures**. The failure set is byte-identical across recent `main` commits.

Latest job: 24 failed / 2 passed / 4 skipped.

## Fix

Restore the pre-#3204 state for the failing models by extending the `pytest.skip` list, **keeping the two models that actually pass** (`Beer_MolBioSystems2014`, `Crauste_CellSystems2017`) running. The old redundant `Oliveira_NatCommun2021` block is folded in.

Skips are grouped by verified root cause (from the CI log's per-model tracebacks) so entries can be deleted as each issue is fixed:

| Root cause | Error signature | # |
|---|---|---|
| PEtab v1→v2 auto-upgrade failure (upstream libpetab) | `Failed to auto-upgrade PEtab 1.0 problem to PEtab 2.0` | 4 |
| JAXProblem measurement parsing (empty numeric cell) | `could not convert string to float: np.str_('')` | 3 |
| JAX measurement padding (negative pad width) | `index can't contain negative values` | 2 |
| diffrax non-finite integration (stiff models) | linear solver returns/receives NaN or inf | 9 |
| JAX/AMICI LLH or SLLH mismatch | `AssertionError` | 6 |

Plus the 4 pre-existing event-unsupported skips. Total skipped: 28; still running: 2.

Only the benchmark test file is touched; no library code changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)