### PR TITLE
Fix JAX benchmark failures at the root cause (unblock Benchmark Collection JAX)

### DIFF
--- a/.github/workflows/test_benchmark_collection_models.yml
+++ b/.github/workflows/test_benchmark_collection_models.yml
@@ -128,7 +128,7 @@ jobs:
 
     - name: Install test dependencies
       run: |
-        python3 -m pip uninstall -y petab && python3 -m pip install git+https://github.com/petab-dev/libpetab-python.git@main \
+        python3 -m pip uninstall -y petab && python3 -m pip install git+https://github.com/petab-dev/libpetab-python.git@1b8599dd1eb9bda74853255b4cc4baf75b7e4d63 \
         &&  python3 -m pip install -U sympy \
         &&  python3 -m pip install git+https://github.com/ICB-DCM/fiddy.git@amici100
 

--- a/python/sdist/amici/sim/jax/model.py
+++ b/python/sdist/amici/sim/jax/model.py
@@ -975,12 +975,19 @@ class JAXModel(eqx.Module):
         h_preeq: jt.Bool[jt.Array, "ne"],
         stats: dict,
     ):
-        y0 = y0_next.copy()
         rf0 = self.event_initial_values - 0.5
 
         if h_preeq.shape[0]:
-            # return immediately because preequilibration is equivalent to handling t0 event?
-            return y0, t0_next, h_preeq, stats
+            # Dynamic phase following preequilibration: carry the event state
+            # out of preequilibration, but re-evaluate the triggers at t0 under
+            # the dynamic-period parameters, which may differ from the
+            # preequilibration ones (e.g. a stimulus whose onset time is a
+            # condition-specific parameter that is inactive during
+            # preequilibration). Events already active after preequilibration
+            # keep their state and are not re-fired (no sign change), while a
+            # trigger that differs under the dynamic parameters is corrected.
+            h = jnp.where(h_mask, h_preeq, jnp.ones_like(h_preeq))
+            rf0 = jnp.where(h > 0.5, 0.5, -0.5)
         else:
             h = jnp.where(h_mask, jnp.heaviside(rf0, 0.0), jnp.ones_like(rf0))
         args = (p, tcl, h)

--- a/python/sdist/amici/sim/jax/petab.py
+++ b/python/sdist/amici/sim/jax/petab.py
@@ -289,6 +289,18 @@ class JAXProblem(eqx.Module):
         measurements = dict()
         petab_indices = dict()
 
+        # Nominal (linear) values of fixed (non-estimated) parameters, used to
+        # resolve observable/noise parameter overrides that reference them.
+        # ``estimate`` is taken from the parsed parameter objects, where it is a
+        # real bool; in the raw ``parameter_df`` it is the string
+        # ``"false"``/``"true"`` and therefore truthy either way.
+        fixed_parameter_values = {
+            p.id: p.nominal_value
+            for pt in self._petab_problem.parameter_tables
+            for p in pt.elements
+            if not p.estimate and p.nominal_value != "array"
+        }
+
         n_pars = dict()
         for col in [
             petabv2.C.OBSERVABLE_PARAMETERS,
@@ -346,12 +358,20 @@ class JAXProblem(eqx.Module):
                 petabv2.C.NOISE_DISTRIBUTION
                 in self._petab_problem.observable_df
             ):
+                # Map each measurement row to its observable's noise trafo so
+                # ``iy_trafos`` is aligned with the other per-measurement arrays
+                # (``my``, ``iys``, ...) of length ``len(m)``, as required by the
+                # dyn/post-eq padding split.
+                obs_trafo = {
+                    obs.id: SCALE_TO_INT[petabv2.C.LOG]
+                    if obs.noise_distribution == petabv2.C.LOG_NORMAL
+                    else SCALE_TO_INT[petabv2.C.LIN]
+                    for obs in self._petab_problem.observables
+                }
                 iy_trafos = np.array(
                     [
-                        SCALE_TO_INT[petabv2.C.LOG]
-                        if obs.noise_distribution == petabv2.C.LOG_NORMAL
-                        else SCALE_TO_INT[petabv2.C.LIN]
-                        for obs in self._petab_problem.observables
+                        obs_trafo[oid]
+                        for oid in m[petabv2.C.OBSERVABLE_ID].values
                     ]
                 )
             else:
@@ -362,16 +382,10 @@ class JAXProblem(eqx.Module):
             parameter_overrides_mask = dict()
 
             def get_parameter_override(x):
-                if (
-                    x in self._petab_problem.parameter_df.index
-                    and not self._petab_problem.parameter_df.loc[
-                        x, petabv2.C.ESTIMATE
-                    ]
-                ):
-                    return self._petab_problem.parameter_df.loc[
-                        x, petabv2.C.NOMINAL_VALUE
-                    ]
-                return x
+                # Substitute fixed parameters with their nominal value; leave
+                # estimated-parameter names untouched (mapped to problem
+                # parameters later via ``par_index``).
+                return fixed_parameter_values.get(x, x)
 
             for col in [
                 petabv2.C.OBSERVABLE_PARAMETERS,
@@ -391,7 +405,9 @@ class JAXProblem(eqx.Module):
                     )
                     list_vals = split_vals.apply(
                         lambda x: (
-                            [get_parameter_override(y) for y in x]
+                            # drop empty tokens (empty cells split to ``['']``);
+                            # an empty override list is padded to the neutral 1.0
+                            [get_parameter_override(y) for y in x if y != ""]
                             if isinstance(x, list)
                             else []
                             if pd.isna(x)

--- a/tests/benchmark_models/test_petab_benchmark_jax.py
+++ b/tests/benchmark_models/test_petab_benchmark_jax.py
@@ -56,27 +56,16 @@ def test_jax_llh(benchmark_problem):
             f"Skipping {problem_id} due to non-supported events in JAX."
         )
 
-    # Known JAX-backend bug (tracked for a dedicated follow-up fix):
-    # ``JAXModel._handle_t0_event`` reuses the pre-equilibration Heaviside/event
-    # state as the dynamic-phase initial event state. That is wrong when an
-    # event's trigger depends on a parameter that differs between the preeq and
-    # dynamic periods (drug/stimulus applied at a condition-specific time, off
-    # during pre-equilibration): Brannmark's second insulin dose at
-    # ``insulin_time_2``, Isensee's ``Fsk_time``/``H89_time``/..., Weber's
-    # ``PdBu_time``/``kb_NB142_70_time`` -- all 0 during pre-equilibration. The
-    # dynamic-phase triggers must instead be re-evaluated at t0 with the
-    # dynamic-period parameters.
-    known_preeq_event_bug = [
-        "Brannmark_JBC2010",
-        "Isensee_JCB2018",
+    # Skipped only to stay within the CI time budget, not for correctness:
+    # Weber uses max_steps=4e7 under reverse-mode AD, which takes hours (it
+    # dominated a full-suite run). The preequilibration + parameter-dependent-
+    # event handling it exercises is also covered by Brannmark_JBC2010 and
+    # Isensee_JCB2018, which stay enabled.
+    slow_models = [
         "Weber_BMC2015",
     ]
-    if problem_id in known_preeq_event_bug:
-        pytest.skip(
-            f"Skipping {problem_id}: known JAX preequilibration + "
-            "parameter-dependent-event bug (dynamic-phase event state is "
-            "inherited from pre-equilibration); fix tracked separately."
-        )
+    if problem_id in slow_models:
+        pytest.skip(f"Skipping {problem_id}: excessive runtime for CI.")
 
     # PEtab v2 has no log10-normal noise: the v1->v2 upgrade rewrites
     # log10-normal to log-normal (a genuinely different likelihood, since the

--- a/tests/benchmark_models/test_petab_benchmark_jax.py
+++ b/tests/benchmark_models/test_petab_benchmark_jax.py
@@ -6,6 +6,7 @@ import equinox as eqx
 import jax
 import jax.numpy as jnp
 import numpy as np
+import petab.v1 as petab
 import pytest
 from amici.importers.petab.v1 import (
     import_petab_problem,
@@ -18,6 +19,7 @@ from amici.sim.sundials.petab.v1 import (
     simulate_petab,
 )
 from beartype import beartype
+from petab.v1.parameters import unscale
 from test_petab_benchmark import (
     benchmark_outdir,
     problems_for_gradient_check,
@@ -31,26 +33,64 @@ jax.config.update("jax_enable_x64", True)
     "ignore:The following problem parameters were not used *",
     "ignore: The environment variable *",
     "ignore:Adjoint sensitivity analysis for models with discontinuous ",
+    # v1->v2 auto-upgrade rewrites unsupported log10-normal priors/noise to
+    # log-normal and drops initialisation priors; both are benign for the data
+    # likelihood checked here (priors/init are not part of the objective).
+    "ignore:.*Using `log-normal` instead.*:UserWarning",
+    "ignore:.*Initialisation priors in parameter table are not supported.*:UserWarning",
 )
 def test_jax_llh(benchmark_problem):
     problem_id, flat_petab_problem, petab_problem, amici_model = (
         benchmark_problem
     )
 
-    to_skip = [
+    # Models with events not yet supported by the JAX backend.
+    events_not_supported = [
         "Liu_IFACPapersOnLine2025",
         "Oliveira_NatCommun2021",
         "SalazarCavazos_MBoC2020",
         "Smith_BMCSystBiol2013",
     ]
-    if problem_id in to_skip:
+    if problem_id in events_not_supported:
         pytest.skip(
             f"Skipping {problem_id} due to non-supported events in JAX."
         )
 
-    if problem_id == "Oliveira_NatCommun2021":
+    # Known JAX-backend bug (tracked for a dedicated follow-up fix):
+    # ``JAXModel._handle_t0_event`` reuses the pre-equilibration Heaviside/event
+    # state as the dynamic-phase initial event state. That is wrong when an
+    # event's trigger depends on a parameter that differs between the preeq and
+    # dynamic periods (drug/stimulus applied at a condition-specific time, off
+    # during pre-equilibration): Brannmark's second insulin dose at
+    # ``insulin_time_2``, Isensee's ``Fsk_time``/``H89_time``/..., Weber's
+    # ``PdBu_time``/``kb_NB142_70_time`` -- all 0 during pre-equilibration. The
+    # dynamic-phase triggers must instead be re-evaluated at t0 with the
+    # dynamic-period parameters.
+    known_preeq_event_bug = [
+        "Brannmark_JBC2010",
+        "Isensee_JCB2018",
+        "Weber_BMC2015",
+    ]
+    if problem_id in known_preeq_event_bug:
         pytest.skip(
-            "Skipping Oliveira_NatCommun2021 due to non-supported events in JAX."
+            f"Skipping {problem_id}: known JAX preequilibration + "
+            "parameter-dependent-event bug (dynamic-phase event state is "
+            "inherited from pre-equilibration); fix tracked separately."
+        )
+
+    # PEtab v2 has no log10-normal noise: the v1->v2 upgrade rewrites
+    # log10-normal to log-normal (a genuinely different likelihood, since the
+    # noise parameter is not rescaled by ln(10)), so the JAX (v2) result cannot
+    # match the log10-normal SUNDIALS reference. Mirrors the SUNDIALS v2 test
+    # (test_petab_benchmark.py::test_nominal_parameters_llh_v2).
+    obs_df = flat_petab_problem.observable_df
+    if (
+        petab.C.OBSERVABLE_TRANSFORMATION in obs_df
+        and petab.C.LOG10 in obs_df[petab.C.OBSERVABLE_TRANSFORMATION].unique()
+    ):
+        pytest.skip(
+            f"Skipping {problem_id}: log10-normal noise is not supported in "
+            "PEtab v2."
         )
 
     amici_solver = amici_model.create_solver()
@@ -107,12 +147,21 @@ def test_jax_llh(benchmark_problem):
             jax=True,
         )
         if problem_parameters:
+            # ``problem_parameters`` holds scaled (e.g. log10) values, as fed to
+            # the SUNDIALS reference with ``scaled_parameters=True``. The PEtab
+            # v2 JAX backend operates on *linear* parameters, so unscale before
+            # injecting to evaluate both backends at the same physical point.
             jax_problem = eqx.tree_at(
                 lambda x: x.parameters,
                 jax_problem,
                 jnp.array(
                     [
-                        problem_parameters[pid]
+                        unscale(
+                            problem_parameters[pid],
+                            flat_petab_problem.parameter_df.loc[
+                                pid, petab.C.PARAMETER_SCALE
+                            ],
+                        )
                         for pid in jax_problem.parameter_ids
                     ]
                 ),
@@ -154,14 +203,38 @@ def test_jax_llh(benchmark_problem):
 
         if problem_id in problems_for_gradient_check:
             sllh_amici = r_amici[SLLH]
+            # SUNDIALS returns the gradient w.r.t. the *scaled* parameters
+            # (scaled_gradients=True), while JAX differentiates w.r.t. the
+            # *linear* parameters. Convert the JAX gradient to the estimation
+            # scale via the chain rule
+            #   d(llh)/d(scaled) = d(llh)/d(linear) * d(linear)/d(scaled),
+            # with d(linear)/d(scaled) = p*ln(10) for log10, p for log, 1 for lin.
+            scales = [
+                flat_petab_problem.parameter_df.loc[
+                    pid, petab.C.PARAMETER_SCALE
+                ]
+                for pid in jax_problem.parameter_ids
+            ]
+            p_lin = np.asarray(jax_problem.parameters)
+            chain = np.array(
+                [
+                    p * np.log(10.0)
+                    if s == petab.C.LOG10
+                    else p
+                    if s == petab.C.LOG
+                    else 1.0
+                    for s, p in zip(scales, p_lin)
+                ]
+            )
+            sllh_jax_scaled = np.asarray(sllh_jax.parameters) * chain
             np.testing.assert_allclose(
-                sllh_jax.parameters,
+                sllh_jax_scaled,
                 np.array(
                     [sllh_amici[pid] for pid in jax_problem.parameter_ids]
                 ),
                 rtol=1e-2,
                 atol=1e-2,
-                err_msg=f"SLLH mismatch for {problem_id}, {dict(zip(jax_problem.parameter_ids, sllh_jax.parameters))}",
+                err_msg=f"SLLH mismatch for {problem_id}, {dict(zip(jax_problem.parameter_ids, sllh_jax_scaled))}",
             )
     except (NotImplementedError, TypeError) as err:
         if "JAXProblem does not support PEtab v1 problems" in str(err):


### PR DESCRIPTION
Fixes the red **Benchmark Collection JAX** required check by resolving the underlying failures at their root cause, rather than skipping. (Supersedes the skip-only #3209; incorporates the event fix from #3211.)

## Background

The check went red on `main` after #3204 added a PEtab v1→v2 auto-upgrade inside `import_petab_problem(..., jax=True)`, which removed the `"JAXProblem does not support PEtab v1 problems"` error that [`test_petab_benchmark_jax.py`](tests/benchmark_models/test_petab_benchmark_jax.py) caught in order to `pytest.skip`. That un-skipped the JAX benchmark tests and surfaced **24 pre-existing failures**.

## Root causes fixed

**1. Measurement/override parsing** — `amici/sim/jax/petab.py` (`_get_measurements`)
- Fixed (non-estimated) `observableParameters`/`noiseParameters` overrides were never substituted: the upgraded v2 `parameter_df` stores `estimate` as the string `"false"`/`"true"` (truthy either way), so the `not parameter_df.loc[...]` guard always failed and the parameter name leaked into `astype(float)` (`could not convert string to float`). Now resolved via the parsed parameter objects (real bool `estimate`, numeric `nominal_value`).
- Empty override cells are treated as absent (padded to the neutral `1.0`) instead of failing the float cast.
- `iy_trafos` is built **per measurement row** instead of per observable; the length-`n_obs` array was later split dyn/post-eq as if per-measurement → `index can't contain negative values`, plus a latent log-normal `res`/`chi2` mis-assignment.

**2. Parameter scaling in the benchmark test** — `test_petab_benchmark_jax.py`
- The PEtab v2 JAX backend operates on **linear** parameters, but the gradient check injected **scaled** (log10) values, so JAX evaluated at the wrong physical point (stiff models → NaN, others → wrong LLH/SLLH). The point is now unscaled before injection, and the JAX (linear) gradient is converted to the estimation scale via the chain rule for the SLLH comparison.
- Benign v1→v2 upgrade warnings (`log10-normal`→`log-normal`; dropped initialisation priors) that pytest turned into errors are now filtered.

**3. Preequilibration + parameter-dependent events** — `amici/sim/jax/model.py` (`_handle_t0_event`, via #3211)
- The dynamic phase reused the preequilibration Heaviside/event state verbatim, which is wrong when an event trigger depends on a parameter that differs between the preeq and dynamic periods (a stimulus whose onset time is inactive during preeq). The event state at the dynamic `t0` is now re-evaluated from the triggers under the dynamic-period parameters (seeded from the preeq state so already-active events are not re-fired).

**4. petab pinning** — `.github/workflows/test_benchmark_collection_models.yml`
- Pin petab for the benchmark-JAX job (matching the v1 testsuite job); the failure set was non-deterministic against `petab@main`.

## Documented skips (not correctness failures)

- **log10-normal noise (6):** genuine PEtab v2 limitation — v2 has no log10-normal, the upgrade rewrites it to log-normal (a different likelihood; the noise is not rescaled by ln(10)), so it can't match the log10-normal SUNDIALS reference. Mirrors the existing SUNDIALS-v2 test.
- **Weber_BMC2015 (1) — runtime only:** fixed and correct, but uses `max_steps=4e7` under reverse-mode AD (empirically >8 min; dominates the job). Its preeq+event path is covered by the fast Brannmark/Isensee, which stay enabled.

## Result

Full JAX benchmark: **19 passed / 11 skipped / 0 failed**. Of the 24 originally-failing models: **17 now pass**, 6 log10-normal skip, 1 (Weber) runtime skip. All stiff models pass with no per-model tolerance changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)