### PR TITLE
Fix SBML import constant-folding parameters out of initial conditions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,11 @@ See also our [versioning policy](https://amici.readthedocs.io/en/latest/versioni
   (e.g., when using network file systems with not synchronized clocks).
   If you encounter this warning, and you are sure that the model was not
   modified since the last import, you can safely ignore it.
+* Fixed SBML import constant-folding a parameter out of the initial conditions
+  when that parameter both carried an `initialAssignment` with a numeric
+  right-hand side and defined a species' initial value. The parameter remained
+  in the free-parameter list, so its (initial-condition) sensitivity was
+  silently reported as zero (e.g. `init_STAT` in `jakstat_adjoint`) (#3214).
 
 ### v1.0.1 (2026-03-13)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,9 @@ See also our [versioning policy](https://amici.readthedocs.io/en/latest/versioni
   when that parameter both carried an `initialAssignment` with a numeric
   right-hand side and defined a species' initial value. The parameter remained
   in the free-parameter list, so its (initial-condition) sensitivity was
-  silently reported as zero (e.g. `init_STAT` in `jakstat_adjoint`) (#3214).
+  silently reported as zero (e.g. `init_STAT` in `jakstat_adjoint`). This also
+  covers the transitive case, where such a parameter is reached through a chain
+  of parameter initial assignments (#3214).
 
 ### v1.0.1 (2026-03-13)
 

--- a/python/sdist/amici/importers/sbml/__init__.py
+++ b/python/sdist/amici/importers/sbml/__init__.py
@@ -2293,15 +2293,34 @@ class SbmlImporter:
         for var in sym_math.free_symbols:
             element_id = str(var)
             if (
-                var in self._symbols[SymbolId.FREE_PARAMETER]
-                or var in self._symbols[SymbolId.FIXED_PARAMETER]
+                var not in self._symbols[SymbolId.SPECIES]
+                and var not in self._symbols[SymbolId.ALGEBRAIC_STATE]
+                and (
+                    var in self._symbols[SymbolId.FREE_PARAMETER]
+                    or var in self._symbols[SymbolId.FIXED_PARAMETER]
+                    or (
+                        (par := self.sbml_model.getParameter(element_id))
+                        is not None
+                        and not self._is_rate_rule_target(par)
+                        and not self._is_assignment_rule_target(par)
+                    )
+                )
             ):
-                # `var` is a parameter that AMICI keeps as a (differentiable)
-                # symbolic parameter. If it carries an initial assignment, its
-                # value has already been captured as the parameter's nominal
-                # value in `_process_parameters`. Substituting that assignment
-                # here would constant-fold the parameter dependence out of the
-                # initial condition (see #3214), so we keep the symbol instead.
+                # `var` is a parameter that AMICI keeps as a symbolic quantity
+                # (a differentiable free/fixed parameter, or an expression),
+                # rather than folding it to a number. Its value / definition is
+                # captured during parameter processing -- as the parameter's
+                # nominal value or as an expression referencing other
+                # parameters. Substituting its initial assignment here would
+                # constant-fold the dependence out of the initial condition,
+                # either directly (a numeric initial assignment, e.g.
+                # `init_STAT`) or transitively (a chain of parameter
+                # assignments). The FREE/FIXED_PARAMETER dicts are not yet
+                # populated while parameters are still being classified in
+                # `_process_parameters`, so also recognize a parameter from the
+                # SBML model directly. Parameters that become states (rate-rule
+                # targets, or parameters converted to species) are excluded
+                # above and handled by the state branches below. See #3214.
                 continue
             # already recursive since _get_element_initial_assignment calls _make_initial
             if (

--- a/python/sdist/amici/importers/sbml/__init__.py
+++ b/python/sdist/amici/importers/sbml/__init__.py
@@ -2292,6 +2292,17 @@ class SbmlImporter:
         # compute all initial values from scratch, recursively
         for var in sym_math.free_symbols:
             element_id = str(var)
+            if (
+                var in self._symbols[SymbolId.FREE_PARAMETER]
+                or var in self._symbols[SymbolId.FIXED_PARAMETER]
+            ):
+                # `var` is a parameter that AMICI keeps as a (differentiable)
+                # symbolic parameter. If it carries an initial assignment, its
+                # value has already been captured as the parameter's nominal
+                # value in `_process_parameters`. Substituting that assignment
+                # here would constant-fold the parameter dependence out of the
+                # initial condition (see #3214), so we keep the symbol instead.
+                continue
             # already recursive since _get_element_initial_assignment calls _make_initial
             if (
                 ia := self._get_element_initial_assignment(element_id)

--- a/python/tests/test_sbml_import.py
+++ b/python/tests/test_sbml_import.py
@@ -1180,6 +1180,43 @@ def test_time_dependent_initial_assignment(compute_conservation_laws: bool):
 
 
 @skip_on_valgrind
+def test_initial_assignment_parameter_not_constant_folded():
+    """Regression test for #3214.
+
+    A parameter that both carries an ``initialAssignment`` with a
+    dependency-free (numeric) right-hand side and defines a species' initial
+    condition must not be constant-folded out of ``x0``. Such a parameter is
+    still offered as a free (differentiable) parameter, so folding its value
+    into ``x0`` would silently return a zero sensitivity for it.
+
+    This is the shape antimony produces for every parameter assignment whose
+    right-hand side is a compound expression (e.g. ``init_STAT = 10^0`` in
+    ``jakstat_adjoint``).
+    """
+    # `X0 = 6 * 1` is a compound expression, so antimony emits it as an
+    # initial assignment on the parameter X0 (a bare literal would not).
+    sbml_str = antimony2sbml("""
+        model test_ia_not_folded
+            species X;
+            X = X0;
+            X0 = 6 * 1;
+            k = 0.33;
+            degradation: X -> ; k * X;
+        end
+    """)
+    sbml_importer = SbmlImporter(sbml_source=sbml_str, from_file=False)
+    de_model = sbml_importer._build_ode_model()
+
+    # X0 is offered as a differentiable free parameter ...
+    assert "X0" in [p.get_id() for p in de_model.free_parameters()]
+    # ... so x0 must retain the symbolic dependence on it rather than folding
+    # in its nominal value.
+    (x0_x,) = de_model.eq("x0")
+    assert x0_x == symbol_with_assumptions("X0")
+    assert sp.diff(x0_x, symbol_with_assumptions("X0")) == 1
+
+
+@skip_on_valgrind
 def test_minmax_piecewise_is_converted_to_minmax():
     """Test that _piecewise_to_minmax is applied during SBML import."""
     sbml_str = antimony2sbml("""

--- a/python/tests/test_sbml_import.py
+++ b/python/tests/test_sbml_import.py
@@ -1259,6 +1259,35 @@ def test_chained_initial_assignment_parameter_not_constant_folded():
 
 
 @skip_on_valgrind
+def test_initial_assignment_fixed_parameter_not_constant_folded():
+    """Regression test for #3214 (fixed-parameter variant).
+
+    The same constant-folding must be avoided for a fixed (constant)
+    parameter: even though it is excluded from sensitivity analysis, its
+    symbol must be retained in ``x0`` so that changing the constant still
+    moves the initial condition, rather than being baked in as a literal.
+    """
+    sbml_str = antimony2sbml("""
+        model test_ia_not_folded_fixed
+            species X;
+            X = X0;
+            X0 = 6 * 1;
+            k = 0.33;
+            degradation: X -> ; k * X;
+        end
+    """)
+    sbml_importer = SbmlImporter(sbml_source=sbml_str, from_file=False)
+    assert sbml_importer.sbml_model.getInitialAssignment("X0") is not None
+
+    de_model = sbml_importer._build_ode_model(fixed_parameters=["X0"])
+
+    assert "X0" in [p.get_id() for p in de_model.fixed_parameters()]
+    assert "X0" not in [p.get_id() for p in de_model.free_parameters()]
+    (x0_x,) = de_model.eq("x0")
+    assert x0_x == symbol_with_assumptions("X0")
+
+
+@skip_on_valgrind
 def test_minmax_piecewise_is_converted_to_minmax():
     """Test that _piecewise_to_minmax is applied during SBML import."""
     sbml_str = antimony2sbml("""

--- a/python/tests/test_sbml_import.py
+++ b/python/tests/test_sbml_import.py
@@ -1205,6 +1205,11 @@ def test_initial_assignment_parameter_not_constant_folded():
         end
     """)
     sbml_importer = SbmlImporter(sbml_source=sbml_str, from_file=False)
+    # The test only exercises the bug if X0 actually carries an initial
+    # assignment; guard against a future antimony/libSBML folding `6 * 1` to a
+    # plain value, which would silently turn this into a false negative.
+    assert sbml_importer.sbml_model.getInitialAssignment("X0") is not None
+
     de_model = sbml_importer._build_ode_model()
 
     # X0 is offered as a differentiable free parameter ...
@@ -1214,6 +1219,43 @@ def test_initial_assignment_parameter_not_constant_folded():
     (x0_x,) = de_model.eq("x0")
     assert x0_x == symbol_with_assumptions("X0")
     assert sp.diff(x0_x, symbol_with_assumptions("X0")) == 1
+
+
+@skip_on_valgrind
+def test_chained_initial_assignment_parameter_not_constant_folded():
+    """Regression test for #3214 (chained-parameter variant).
+
+    ``X0`` is defined via an initial assignment referencing another parameter
+    ``X1`` whose own initial assignment has a dependency-free (numeric)
+    right-hand side. The dependence of the initial condition on ``X1`` must be
+    retained rather than folded into ``X1``'s nominal value while parameters
+    are being classified.
+    """
+    sbml_str = antimony2sbml("""
+        model test_chained_ia_not_folded
+            species X;
+            X = X0;
+            X0 = X1;
+            X1 = 5 * 1;
+            k = 0.33;
+            degradation: X -> ; k * X;
+        end
+    """)
+    sbml_importer = SbmlImporter(sbml_source=sbml_str, from_file=False)
+    assert sbml_importer.sbml_model.getInitialAssignment("X0") is not None
+    assert sbml_importer.sbml_model.getInitialAssignment("X1") is not None
+
+    de_model = sbml_importer._build_ode_model()
+
+    # X1 remains the differentiable free parameter; X0 becomes an expression
+    # for it rather than an independent, constant-folded parameter.
+    free_parameter_ids = [p.get_id() for p in de_model.free_parameters()]
+    assert "X1" in free_parameter_ids
+    assert "X0" not in free_parameter_ids
+
+    (x0_x,) = de_model.eq("x0")
+    assert x0_x == symbol_with_assumptions("X1")
+    assert sp.diff(x0_x, symbol_with_assumptions("X1")) == 1
 
 
 @skip_on_valgrind


### PR DESCRIPTION
## Summary
Fixed a bug in SBML import where parameters with `initialAssignment` elements were being constant-folded out of initial conditions, causing their sensitivities to be silently reported as zero even though they remained in the free-parameter list.

## Key Changes
- **Modified `_make_initial()` in `sbml/__init__.py`**: Added logic to skip substitution of initial assignments for parameters that AMICI keeps as symbolic quantities (free/fixed parameters or expressions). This prevents constant-folding of parameter dependencies into initial conditions.
  - Checks if a variable is a parameter that should remain symbolic rather than being folded
  - Handles both direct parameters and those reached through chains of initial assignments
  - Excludes parameters that become states (rate-rule targets or converted to species)

- **Added regression tests in `test_sbml_import.py`**:
  - `test_initial_assignment_parameter_not_constant_folded()`: Tests the case where a parameter with a compound-expression initial assignment (e.g., `X0 = 6 * 1`) defines a species' initial condition
  - `test_chained_initial_assignment_parameter_not_constant_folded()`: Tests the transitive case where a parameter's initial assignment references another parameter with its own initial assignment

## Implementation Details
The fix recognizes that during parameter classification in `_process_parameters`, certain parameters are intentionally kept as symbolic quantities rather than being folded to numeric values. When processing initial conditions, the code now skips substituting initial assignments for such parameters, preserving the symbolic dependence chain. This ensures that sensitivity analysis correctly reports non-zero derivatives with respect to these parameters.

The solution handles both direct cases (a parameter with a numeric initial assignment) and transitive cases (chains of parameter initial assignments), addressing issue #3214.

https://claude.ai/code/session_012xf5RqvErY7po9N9DNfpKQ