### PR TITLE
Skip redundant compiler-flag checks in CMake configure

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -50,14 +50,12 @@ set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
 # Compiler flags
 include(CheckCXXCompilerFlag)
-set(MY_CXX_FLAGS -Wall)
-foreach(flag ${MY_CXX_FLAGS})
-  unset(CUR_FLAG_SUPPORTED CACHE)
-  check_cxx_compiler_flag(${flag} CUR_FLAG_SUPPORTED)
-  if(${CUR_FLAG_SUPPORTED})
-    string(APPEND CMAKE_CXX_FLAGS " ${flag}")
-  endif()
-endforeach()
+# -Wall is supported by every GCC/Clang version AMICI targets; skip the
+# check_cxx_compiler_flag() try_compile() and just gate on the compiler
+# family.
+if(CMAKE_CXX_COMPILER_ID MATCHES "^(GNU|Clang|AppleClang)$")
+  string(APPEND CMAKE_CXX_FLAGS " -Wall")
+endif()
 
 if(MSVC)
   set(MY_CXX_FLAGS

--- a/python/sdist/amici/exporters/sundials/templates/CMakeLists.template.cmake
+++ b/python/sdist/amici/exporters/sundials/templates/CMakeLists.template.cmake
@@ -19,18 +19,16 @@ set(CMAKE_CXX_STANDARD 20)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 set(CMAKE_POSITION_INDEPENDENT_CODE ON)
 
-include(CheckCXXCompilerFlag)
-set(MY_CXX_FLAGS -Wall -Wno-unused-function -Wno-unused-variable)
-if(CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
-  list(APPEND MY_CXX_FLAGS -Wno-unused-but-set-variable)
-endif()
-foreach(flag ${MY_CXX_FLAGS})
-  unset(CUR_FLAG_SUPPORTED CACHE)
-  check_cxx_compiler_flag(${flag} CUR_FLAG_SUPPORTED)
-  if(${CUR_FLAG_SUPPORTED})
-    string(APPEND CMAKE_CXX_FLAGS " ${flag}")
+# -Wall/-Wno-unused-* are supported by every GCC/Clang version AMICI
+# targets, so skip the check_cxx_compiler_flag() probing (a full
+# try_compile() per flag, on every single model configure) and just gate
+# on the compiler family.
+if(CMAKE_CXX_COMPILER_ID MATCHES "^(GNU|Clang|AppleClang)$")
+  string(APPEND CMAKE_CXX_FLAGS " -Wall -Wno-unused-function -Wno-unused-variable")
+  if(CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
+    string(APPEND CMAKE_CXX_FLAGS " -Wno-unused-but-set-variable")
   endif()
-endforeach()
+endif()
 
 if(DEFINED ENV{AMICI_CXXFLAGS})
   message(STATUS "Appending flags from AMICI_CXXFLAGS: $ENV{AMICI_CXXFLAGS}")


### PR DESCRIPTION
## Summary
- `check_cxx_compiler_flag()` runs a full `try_compile()` per flag. For `-Wall`/`-Wno-unused-function`/`-Wno-unused-variable`/`-Wno-unused-but-set-variable`, this is checked on every single model configure even though these are ancient, universally-supported GCC/Clang flags.
- The MSVC-specific `-wd####` warning disables and the debug-only `-Werror -Wno-error=deprecated-declarations` check are deliberately left untouched: real per-compiler-version support risk exists for MSVC warning codes, and the `-Werror` check only runs in opt-in debug/coverage builds, not on the per-model hot path this change targets.
- Applies the same compiler-ID gate already used for `-Wno-unused-but-set-variable` to the model CMake template (`exporters/sundials/templates/CMakeLists.template.cmake`) and to the equivalent `-Wall` check in the top-level `CMakeLists.txt`, instead of probing at every configure.
- Follow-up to #3220 (HDF5 detection), same class of fix: speeding up importing/building many models in one go (test suite, benchmark collections, PEtab batch imports) without any shared state between model builds, so they stay independent and safe to run in parallel (e.g. under pytest-xdist).

## Test plan
- [x] Measured a fresh, isolated model configure: ~1.0s → ~0.7-0.8s
- [x] Confirmed the actual compiler invocation still receives the identical flags (`-Wall -Wno-unused-function -Wno-unused-variable -Wno-unused-but-set-variable`)
- [x] Rebuilt AMICI core from source with the equivalent `-Wall` change and confirmed a full model build → install → simulate produces correct results
- [x] Ran a subset of `python/tests/test_sbml_import.py` (model-import/build tests) against the rebuilt core: all pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)