### PR TITLE
Add runner-diagnostics step to all CI workflows

### DIFF
--- a/.github/workflows/deploy_branch.yml
+++ b/.github/workflows/deploy_branch.yml
@@ -12,6 +12,8 @@ jobs:
         python-version: ["3.12"]
 
     steps:
+    - uses: dweindl/gha-runner-diagnostics@v1
+
     - name: Set up Python ${{ matrix.python-version }}
       uses: actions/setup-python@v7
       with:

--- a/.github/workflows/deploy_protected.yml
+++ b/.github/workflows/deploy_protected.yml
@@ -16,6 +16,8 @@ jobs:
     outputs:
       secrets-defined: ${{ steps.secret-check.outputs.defined }}
     steps:
+      - uses: dweindl/gha-runner-diagnostics@v1
+
       - name: Check for Secret availability
         id: secret-check
         shell: bash
@@ -37,6 +39,8 @@ jobs:
         python-version: ["3.12"]
 
     steps:
+    - uses: dweindl/gha-runner-diagnostics@v1
+
     - name: Set up Python ${{ matrix.python-version }}
       uses: actions/setup-python@v7
       with:

--- a/.github/workflows/deploy_release.yml
+++ b/.github/workflows/deploy_release.yml
@@ -22,6 +22,8 @@ jobs:
       id-token: write
 
     steps:
+    - uses: dweindl/gha-runner-diagnostics@v1
+
     - name: Set up Python ${{ matrix.python-version }}
       uses: actions/setup-python@v7
       with:
@@ -55,6 +57,8 @@ jobs:
       GH_ISSUE_USERNAME: ${{ secrets.BIOSIMULATORS_USERNAME }}
       GH_ISSUE_TOKEN: ${{ secrets.BIOSIMULATORS_TOKEN }}
     steps:
+      - uses: dweindl/gha-runner-diagnostics@v1
+
       - name: Trigger GitHub action that will build and release the downstream command-line interface and Docker image
         run: |
           PACKAGE_VERSION="${GITHUB_REF/refs\/tags\/v/}"
@@ -72,6 +76,8 @@ jobs:
     runs-on: ubuntu-24.04
 
     steps:
+    - uses: dweindl/gha-runner-diagnostics@v1
+
     - name: Set up Python
       uses: actions/setup-python@v7
       with:

--- a/.github/workflows/test_benchmark_collection_models.yml
+++ b/.github/workflows/test_benchmark_collection_models.yml
@@ -26,6 +26,8 @@ jobs:
     env:
       AMICI_EXTRACT_CSE: ${{ matrix.extract_subexpressions }}
     steps:
+    - uses: dweindl/gha-runner-diagnostics@v1
+
     - name: Set up Python ${{ matrix.python-version }}
       uses: actions/setup-python@v7
       with:
@@ -103,6 +105,8 @@ jobs:
     env:
       AMICI_EXTRACT_CSE: ${{ matrix.extract_subexpressions }}
     steps:
+    - uses: dweindl/gha-runner-diagnostics@v1
+
     - name: Set up Python ${{ matrix.python-version }}
       uses: actions/setup-python@v7
       with:

--- a/.github/workflows/test_conda_install.yml
+++ b/.github/workflows/test_conda_install.yml
@@ -17,6 +17,8 @@ jobs:
         python-version: ['3.12', '3.13', '3.14']
     runs-on: ${{ matrix.os }}
     steps:
+      - uses: dweindl/gha-runner-diagnostics@v1
+
       - uses: actions/checkout@v7
       - name: Set up Miniconda
         uses: conda-incubator/setup-miniconda@v4

--- a/.github/workflows/test_doc.yml
+++ b/.github/workflows/test_doc.yml
@@ -22,6 +22,8 @@ jobs:
         python-version: ["3.12"]
 
     steps:
+    - uses: dweindl/gha-runner-diagnostics@v1
+
     - name: Set up Python ${{ matrix.python-version }}
       uses: actions/setup-python@v7
       with:
@@ -45,6 +47,8 @@ jobs:
         python-version: [ "3.12" ]
 
     steps:
+      - uses: dweindl/gha-runner-diagnostics@v1
+
       - name: Set up Python ${{ matrix.python-version }}
         uses: actions/setup-python@v7
         with:

--- a/.github/workflows/test_install.yml
+++ b/.github/workflows/test_install.yml
@@ -14,6 +14,8 @@ jobs:
         python-version: ["3.12"]
 
     steps:
+    - uses: dweindl/gha-runner-diagnostics@v1
+
     - name: Set up Python ${{ matrix.python-version }}
       uses: actions/setup-python@v7
       with:
@@ -55,6 +57,8 @@ jobs:
         python-version: ["3.12"]
 
     steps:
+    - uses: dweindl/gha-runner-diagnostics@v1
+
     - name: Set up Python ${{ matrix.python-version }}
       uses: actions/setup-python@v7
       with:
@@ -88,6 +92,8 @@ jobs:
         python-version: ["3.12"]
 
     steps:
+    - uses: dweindl/gha-runner-diagnostics@v1
+
     - name: Set up Python ${{ matrix.python-version }}
       uses: actions/setup-python@v7
       with:

--- a/.github/workflows/test_jax_performance.yml
+++ b/.github/workflows/test_jax_performance.yml
@@ -19,6 +19,8 @@ jobs:
         python-version: ["3.12"]
 
     steps:
+      - uses: dweindl/gha-runner-diagnostics@v1
+
       - uses: actions/checkout@v7
         with:
           fetch-depth: 1

--- a/.github/workflows/test_performance.yml
+++ b/.github/workflows/test_performance.yml
@@ -17,17 +17,8 @@ jobs:
         python-version: ["3.12"]
 
     steps:
-    - name: "Debug: runner and hardware info"
-      run: |
-        echo "== Runner =="
-        echo "name=${RUNNER_NAME} os=${RUNNER_OS} arch=${RUNNER_ARCH} environment=${RUNNER_ENVIRONMENT}"
-        uname -a
-        echo "== CPU =="
-        lscpu
-        echo "== Memory =="
-        free -h
-        echo "== Disk =="
-        df -h
+    - uses: dweindl/gha-runner-diagnostics@v1
+
     - name: Set up Python ${{ matrix.python-version }}
       uses: actions/setup-python@v7
       with:

--- a/.github/workflows/test_petab_sciml.yml
+++ b/.github/workflows/test_petab_sciml.yml
@@ -24,6 +24,8 @@ jobs:
         python-version: ["3.13"]
 
     steps:
+      - uses: dweindl/gha-runner-diagnostics@v1
+
       - name: Set up Python ${{ matrix.python-version }}
         uses: actions/setup-python@v7
         with:

--- a/.github/workflows/test_petab_sciml_benchmarks.yml
+++ b/.github/workflows/test_petab_sciml_benchmarks.yml
@@ -24,6 +24,8 @@ jobs:
         python-version: ["3.13"]
 
     steps:
+      - uses: dweindl/gha-runner-diagnostics@v1
+
       - name: Set up Python ${{ matrix.python-version }}
         uses: actions/setup-python@v7
         with:

--- a/.github/workflows/test_petab_test_suite.yml
+++ b/.github/workflows/test_petab_test_suite.yml
@@ -24,6 +24,8 @@ jobs:
         python-version: ["3.14"]
 
     steps:
+      - uses: dweindl/gha-runner-diagnostics@v1
+
       - name: Set up Python ${{ matrix.python-version }}
         uses: actions/setup-python@v7
         with:
@@ -131,6 +133,8 @@ jobs:
         python-version: ["3.12"]
 
     steps:
+      - uses: dweindl/gha-runner-diagnostics@v1
+
       - name: Set up Python ${{ matrix.python-version }}
         uses: actions/setup-python@v7
         with:

--- a/.github/workflows/test_pypi.yml
+++ b/.github/workflows/test_pypi.yml
@@ -17,6 +17,8 @@ jobs:
     runs-on: ${{ matrix.os }}
 
     steps:
+      - uses: dweindl/gha-runner-diagnostics@v1
+
       - name: apt
         run: |
           if [[ ${{ matrix.os }} == ubuntu* ]] ; then \

--- a/.github/workflows/test_python_cplusplus.yml
+++ b/.github/workflows/test_python_cplusplus.yml
@@ -20,6 +20,8 @@ jobs:
         python-version: [ "3.14" ]
 
     steps:
+    - uses: dweindl/gha-runner-diagnostics@v1
+
     - name: Cache
       uses: actions/cache@v6
       with:
@@ -131,6 +133,8 @@ jobs:
         python-version: [ "3.14" ]
 
     steps:
+    - uses: dweindl/gha-runner-diagnostics@v1
+
     - name: Set up Python ${{ matrix.python-version }}
       uses: actions/setup-python@v7
       with:
@@ -216,6 +220,8 @@ jobs:
         python-version: [ "3.12" ]
 
     steps:
+    - uses: dweindl/gha-runner-diagnostics@v1
+
     - name: Set up Python ${{ matrix.python-version }}
       uses: actions/setup-python@v7
       with:
@@ -259,6 +265,8 @@ jobs:
       PYTHONFAULTHANDLER: "1"
 
     steps:
+    - uses: dweindl/gha-runner-diagnostics@v1
+
     - name: Set up Python
       uses: actions/setup-python@v7
       with:
@@ -319,6 +327,8 @@ jobs:
       PYTHONFAULTHANDLER: "1"
 
     steps:
+    - uses: dweindl/gha-runner-diagnostics@v1
+
     - name: Cache
       uses: actions/cache@v6
       with:

--- a/.github/workflows/test_python_nogil.yml
+++ b/.github/workflows/test_python_nogil.yml
@@ -14,6 +14,8 @@ jobs:
       AMICI_SKIP_CMAKE_TESTS: "TRUE"
       AMICI_PARALLEL_COMPILE: ""
     steps:
+    - uses: dweindl/gha-runner-diagnostics@v1
+
     - run: echo "AMICI_DIR=$(pwd)" >> $GITHUB_ENV
     - name: Set up free-threaded Python
       uses: actions/setup-python@v7

--- a/.github/workflows/test_python_ver_matrix.yml
+++ b/.github/workflows/test_python_ver_matrix.yml
@@ -27,6 +27,8 @@ jobs:
             experimental: false
 
     steps:
+    - uses: dweindl/gha-runner-diagnostics@v1
+
     - run: echo "AMICI_DIR=$(pwd)" >> $GITHUB_ENV
     - run: echo "BNGPATH=${AMICI_DIR}/ThirdParty/BioNetGen-2.7.0" >> $GITHUB_ENV
 

--- a/.github/workflows/test_sbml_semantic_test_suite.yml
+++ b/.github/workflows/test_sbml_semantic_test_suite.yml
@@ -31,6 +31,8 @@ jobs:
         python-version: [ "3.14" ]
 
     steps:
+    - uses: dweindl/gha-runner-diagnostics@v1
+
     - name: Set up Python ${{ matrix.python-version }}
       uses: actions/setup-python@v7
       with:
@@ -67,6 +69,8 @@ jobs:
     runs-on: ubuntu-24.04
     needs: build
     steps:
+      - uses: dweindl/gha-runner-diagnostics@v1
+
       - name: Set up Python
         uses: actions/setup-python@v7
         with:

--- a/.github/workflows/test_sbml_semantic_test_suite_jax.yml
+++ b/.github/workflows/test_sbml_semantic_test_suite_jax.yml
@@ -27,6 +27,8 @@ jobs:
         python-version: [ "3.13" ]
 
     steps:
+    - uses: dweindl/gha-runner-diagnostics@v1
+
     - name: Set up Python ${{ matrix.python-version }}
       uses: actions/setup-python@v7
       with:

--- a/.github/workflows/test_valgrind.yml
+++ b/.github/workflows/test_valgrind.yml
@@ -30,6 +30,8 @@ jobs:
       ENABLE_AMICI_DEBUGGING: "TRUE"
 
     steps:
+    - uses: dweindl/gha-runner-diagnostics@v1
+
     - name: Set up Python ${{ matrix.python-version }}
       uses: actions/setup-python@v7
       with:
@@ -84,6 +86,8 @@ jobs:
       ENABLE_AMICI_DEBUGGING: "TRUE"
 
     steps:
+    - uses: dweindl/gha-runner-diagnostics@v1
+
     - name: Set up Python ${{ matrix.python-version }}
       uses: actions/setup-python@v7
       with:

--- a/.github/workflows/test_windows.yml
+++ b/.github/workflows/test_windows.yml
@@ -26,6 +26,8 @@ jobs:
         python-version: [ "3.12" ]
 
     steps:
+    - uses: dweindl/gha-runner-diagnostics@v1
+
     - name: Set up Python ${{ matrix.python-version }}
       uses: actions/setup-python@v7
       with:


### PR DESCRIPTION
## Summary
- Tests have been intermittently flaky, possibly depending on which GitHub-hosted runner a job gets assigned to.
- Adds [`dweindl/gha-runner-diagnostics@v1`](https://github.com/dweindl/gha-runner-diagnostics) as the first step of every job across all workflows: prints runner identity, `ImageOS`/`ImageVersion`, hardware specs, cgroup CPU/memory limits + throttling stats, load average, and ulimits.
- Removes the now-redundant inline "Debug: runner and hardware info" step in `test_performance.yml`, superseded by the action.
- No existing marketplace action fit this narrow need well (checked `kenchan0130/actions-system-info` - too narrow; `catchpoint/workflow-telemetry-action` - too heavy for a one-shot snapshot), so this uses a small standalone action instead of vendoring the logic into every workflow.

## Test plan
- [x] All edited workflow YAML files parse successfully (`yaml.safe_load`)
- [x] Verified every inserted step directly follows its job's `steps:` line (34 jobs across 20 files)
- [x] Confirm the action resolves and runs cleanly once this PR's workflows actually execute (Linux/macOS/Windows)

🤖 Generated with [Claude Code](https://claude.com/claude-code)