### PR TITLE
Resolve original condition ids in reinit

### DIFF
--- a/python/sdist/amici/sim/jax/petab.py
+++ b/python/sdist/amici/sim/jax/petab.py
@@ -1019,10 +1019,27 @@ class JAXProblem(eqx.Module):
             [jax_unscale(pval, scale) for pval, scale in zip(p, scales)]
         )
 
-    def _resolve_original_condition_id(self, condition_id: str) -> str:
-        """Map a converted condition ID back to its original unconverted ID."""
-        if self._unconverted_problem is None:
-            return condition_id
+    def _find_original_period(
+        self, condition_ids: tuple[str, ...]
+    ) -> (
+        tuple[
+            petabv2.Experiment,
+            petabv2.ExperimentPeriod,
+            petabv2.ExperimentPeriod,
+        ]
+        | None
+    ):
+        """Locate the unconverted period the given converted condition ids belong to
+        using the stored _unconverted_problem.
+
+        :return:
+            ``(converted experiment, original period, converted period)``, or
+            ``None`` if the problem was not converted, or if no corresponding
+            original period was found.
+        """
+        if self._unconverted_problem is None or not condition_ids:
+            return None
+        wanted = set(condition_ids)
         for orig_exp, conv_exp in zip(
             self._unconverted_problem.experiments,
             self._petab_problem.experiments,
@@ -1031,11 +1048,90 @@ class JAXProblem(eqx.Module):
                 orig_exp.sorted_periods, conv_exp.sorted_periods
             ):
                 if (
-                    condition_id in conv_period.condition_ids
+                    wanted.issubset(conv_period.condition_ids)
                     and orig_period.condition_ids
                 ):
-                    return orig_period.condition_ids[0]
-        return condition_id
+                    return conv_exp, orig_period, conv_period
+        return None
+
+    def _resolve_original_condition_ids(
+        self, condition_ids: tuple[str, ...]
+    ) -> tuple[str, ...]:
+        """Map converted condition IDs back to their original unconverted IDs.
+
+        Returns ``condition_ids`` unchanged if no original period was found.
+        """
+        match = self._find_original_period(condition_ids)
+        if match is None:
+            return tuple(condition_ids)
+        _, orig_period, _ = match
+        return tuple(orig_period.condition_ids)
+
+    def _resolve_original_condition_id(self, condition_id: str) -> str:
+        """Map a converted condition ID back to its original unconverted ID.
+
+        See :meth:`_resolve_original_condition_ids`; a single id may not
+        identify a period unambiguously, and where the matched period
+        references several simultaneously-active conditions, only the first one
+        is returned.
+        """
+        return self._resolve_original_condition_ids((condition_id,))[0]
+
+    @staticmethod
+    def _period_starts_at_t0(
+        conv_exp: petabv2.Experiment,
+        orig_period: petabv2.ExperimentPeriod,
+        conv_period: petabv2.ExperimentPeriod,
+    ) -> bool:
+        """Whether reinitialising at the phase's ``t0`` implements a period."""
+        if conv_period.is_preequilibration:
+            return True
+        first_period = conv_exp.sorted_periods[0]
+        t_zero = 0.0 if first_period.is_preequilibration else first_period.time
+        return orig_period.time == t_zero
+
+    def _conditions_defining_changes(
+        self, condition_ids: tuple[str, ...]
+    ) -> list[tuple[petabv2.Condition, bool]]:
+        """The condition-table entries holding the changes of ``condition_ids``.
+
+        For a converted SBML problem (see :meth:`_find_original_period`), condition
+        changes are implemented as model events and removed from the conditions table,
+        so the entries of the *unconverted* problem are considered as well for
+        reinitialization.
+
+        :return:
+            One ``(condition, is_original)`` tuple per matching entry, in
+            lookup order, where ``is_original`` flags entries taken from the
+            unconverted problem (whose changes are already encoded in the
+            model).
+        """
+        conditions = [
+            (c, False)
+            for condition_id in condition_ids
+            for c in self._petab_problem.conditions
+            if c.id == condition_id
+        ]
+        match = self._find_original_period(condition_ids)
+        if match is not None and self._period_starts_at_t0(*match):
+            _, orig_period, _ = match
+            conditions += [
+                (c, True)
+                for c in self._unconverted_problem.conditions
+                if c.id in orig_period.condition_ids
+            ]
+        return conditions
+
+    def _can_resolve_condition_target_value(self, target_value) -> bool:
+        """Whether :meth:`_resolve_condition_target_value` can evaluate this
+        condition-table target value.
+        """
+        if target_value.is_number:
+            return True
+        pname = str(target_value)
+        return pname in self.parameter_ids or pname in {
+            param.id for param in self._petab_problem.parameters
+        }
 
     def _eval_nn(self, output_par: str, condition_id: str):
         entity_id = self._petab_problem.mapping_df.loc[
@@ -1286,21 +1382,27 @@ class JAXProblem(eqx.Module):
         ``targets_map`` value cached at construction time, so that gradients
         w.r.t. parameters used as initial values are not silently dropped.
         """
-        for condition in simulation_conditions:
-            for c in self._petab_problem.conditions:
-                if c.id != condition:
+        for c, is_original in self._conditions_defining_changes(
+            simulation_conditions
+        ):
+            for change in c.changes:
+                if change.target_id != state_id:
                     continue
-                for change in c.changes:
-                    if change.target_id != state_id:
-                        continue
-                    # NaN targets (e.g. "use the preequilibration/SBML value")
-                    # are dropped during v1->v2 conversion, but guard anyway
-                    if (
-                        change.target_value.is_number
-                        and change.target_value.is_finite is False
-                    ):
-                        return None
-                    return change.target_value
+                # NaN targets (e.g. "use the preequilibration/SBML value")
+                # are dropped during v1->v2 conversion, but guard anyway
+                if (
+                    change.target_value.is_number
+                    and change.target_value.is_finite is False
+                ):
+                    return None
+                if (
+                    is_original
+                    and not self._can_resolve_condition_target_value(
+                        change.target_value
+                    )
+                ):
+                    return None
+                return change.target_value
         return None
 
     def _state_reinitialisation_value(

--- a/python/sdist/amici/sim/jax/petab.py
+++ b/python/sdist/amici/sim/jax/petab.py
@@ -1019,23 +1019,16 @@ class JAXProblem(eqx.Module):
             [jax_unscale(pval, scale) for pval, scale in zip(p, scales)]
         )
 
-    def _find_original_period(
+    def _find_unconverted_period(
         self, condition_ids: tuple[str, ...]
-    ) -> (
-        tuple[
-            petabv2.Experiment,
-            petabv2.ExperimentPeriod,
-            petabv2.ExperimentPeriod,
-        ]
-        | None
-    ):
+    ) -> petabv2.ExperimentPeriod | None:
         """Locate the unconverted period the given converted condition ids belong to
         using the stored _unconverted_problem.
 
         :return:
-            ``(converted experiment, original period, converted period)``, or
-            ``None`` if the problem was not converted, or if no corresponding
-            original period was found.
+            The corresponding original (unconverted) period, or ``None`` if the
+            problem was not converted, or if no corresponding original period
+            was found.
         """
         if self._unconverted_problem is None or not condition_ids:
             return None
@@ -1051,58 +1044,44 @@ class JAXProblem(eqx.Module):
                     wanted.issubset(conv_period.condition_ids)
                     and orig_period.condition_ids
                 ):
-                    return conv_exp, orig_period, conv_period
+                    return orig_period
         return None
 
-    def _resolve_original_condition_ids(
+    def _resolve_unconverted_condition_ids(
         self, condition_ids: tuple[str, ...]
     ) -> tuple[str, ...]:
         """Map converted condition IDs back to their original unconverted IDs.
 
         Returns ``condition_ids`` unchanged if no original period was found.
         """
-        match = self._find_original_period(condition_ids)
-        if match is None:
+        orig_period = self._find_unconverted_period(condition_ids)
+        if orig_period is None:
             return tuple(condition_ids)
-        _, orig_period, _ = match
         return tuple(orig_period.condition_ids)
 
-    def _resolve_original_condition_id(self, condition_id: str) -> str:
+    def _resolve_unconverted_condition_id(self, condition_id: str) -> str:
         """Map a converted condition ID back to its original unconverted ID.
 
-        See :meth:`_resolve_original_condition_ids`; a single id may not
+        See :meth:`_resolve_unconverted_condition_ids`; a single id may not
         identify a period unambiguously, and where the matched period
         references several simultaneously-active conditions, only the first one
         is returned.
         """
-        return self._resolve_original_condition_ids((condition_id,))[0]
-
-    @staticmethod
-    def _period_starts_at_t0(
-        conv_exp: petabv2.Experiment,
-        orig_period: petabv2.ExperimentPeriod,
-        conv_period: petabv2.ExperimentPeriod,
-    ) -> bool:
-        """Whether reinitialising at the phase's ``t0`` implements a period."""
-        if conv_period.is_preequilibration:
-            return True
-        first_period = conv_exp.sorted_periods[0]
-        t_zero = 0.0 if first_period.is_preequilibration else first_period.time
-        return orig_period.time == t_zero
+        return self._resolve_unconverted_condition_ids((condition_id,))[0]
 
     def _conditions_defining_changes(
         self, condition_ids: tuple[str, ...]
     ) -> list[tuple[petabv2.Condition, bool]]:
         """The condition-table entries holding the changes of ``condition_ids``.
 
-        For a converted SBML problem (see :meth:`_find_original_period`), condition
+        For a converted SBML problem (see :meth:`_find_unconverted_period`), condition
         changes are implemented as model events and removed from the conditions table,
         so the entries of the *unconverted* problem are considered as well for
         reinitialization.
 
         :return:
-            One ``(condition, is_original)`` tuple per matching entry, in
-            lookup order, where ``is_original`` flags entries taken from the
+            One ``(condition, is_unconverted)`` tuple per matching entry, in
+            lookup order, where ``is_unconverted`` flags entries taken from the
             unconverted problem (whose changes are already encoded in the
             model).
         """
@@ -1112,13 +1091,15 @@ class JAXProblem(eqx.Module):
             for c in self._petab_problem.conditions
             if c.id == condition_id
         ]
-        match = self._find_original_period(condition_ids)
-        if match is not None and self._period_starts_at_t0(*match):
-            _, orig_period, _ = match
+        unconverted_period = self._find_unconverted_period(condition_ids)
+        if unconverted_period is not None and (
+            unconverted_period.is_preequilibration
+            or unconverted_period.time == 0.0
+        ):
             conditions += [
                 (c, True)
                 for c in self._unconverted_problem.conditions
-                if c.id in orig_period.condition_ids
+                if c.id in unconverted_period.condition_ids
             ]
         return conditions
 
@@ -1140,7 +1121,7 @@ class JAXProblem(eqx.Module):
         net_id = entity_id.split(".")[0]
         ind = int(re.search(r"\[\d+\]\[(\d+)\]", entity_id).group(1))
         nn = self.model.nns[net_id]
-        original_condition_id = self._resolve_original_condition_id(
+        unconverted_condition_id = self._resolve_unconverted_condition_id(
             condition_id
         )
 
@@ -1191,9 +1172,9 @@ class JAXProblem(eqx.Module):
                 val = condition_input_map[petab_id]
             elif (
                 petab_id in nn_inputs
-                and original_condition_id in nn_inputs[petab_id]
+                and unconverted_condition_id in nn_inputs[petab_id]
             ):
-                val = nn_inputs[petab_id][original_condition_id]
+                val = nn_inputs[petab_id][unconverted_condition_id]
             else:
                 val = nn_inputs[petab_id]["0"]
 

--- a/python/sdist/amici/sim/jax/petab.py
+++ b/python/sdist/amici/sim/jax/petab.py
@@ -165,7 +165,6 @@ class JAXProblem(eqx.Module):
     _petab_measurement_indices: np.ndarray
     _petab_problem: petabv2.Problem
     _unconverted_problem: petabv2.Problem | None
-    _unconverted_period_map: dict[str, petabv2.ExperimentPeriod]
 
     def __init__(
         self,
@@ -192,7 +191,6 @@ class JAXProblem(eqx.Module):
         self.simulation_conditions = scs.conditionId.to_list()
         self._petab_problem = petab_problem
         self._unconverted_problem = unconverted_problem
-        self._unconverted_period_map = self._compute_unconverted_period_map()
         self.parameters, self.model = (
             self._initialize_model_with_nominal_values(model)
         )
@@ -580,31 +578,6 @@ class JAXProblem(eqx.Module):
             if pname in _petab_param_map:
                 return _petab_param_map[pname]
         return jnp.asarray(target_value, dtype=self.model.parameters.dtype)
-
-    def _compute_unconverted_period_map(
-        self,
-    ) -> dict[str, petabv2.ExperimentPeriod]:
-        """
-        Locate the unconverted period the given converted condition ids. Note that this
-        relies on the ordering of experiments being consistent between the converted
-        and unconverted problems.
-        """
-        return (
-            {
-                cid: orig_period
-                for orig_exp, conv_exp in zip(
-                    self._unconverted_problem.experiments,
-                    self._petab_problem.experiments,
-                )
-                for orig_period, conv_period in zip(
-                    orig_exp.sorted_periods, conv_exp.sorted_periods
-                )
-                if orig_period.condition_ids
-                for cid in conv_period.condition_ids
-            }
-            if self._unconverted_problem is not None
-            else {}
-        )
 
     def _get_parameter_mappings(self) -> dict[str, ...]:
         targets_map = {
@@ -1052,21 +1025,29 @@ class JAXProblem(eqx.Module):
         """Locate the unconverted period the given converted condition ids belong to
         using the stored _unconverted_problem.
 
+        Note that this relies on the ordering of experiments being consistent between the converted and unconverted problems.
+
         :return:
             The corresponding original (unconverted) period, or ``None`` if the
             problem was not converted, or if no corresponding original period
             was found.
         """
-        if not condition_ids:
+        if self._unconverted_problem is None or not condition_ids:
             return None
-        return next(
-            (
-                self._unconverted_period_map[cid]
-                for cid in condition_ids
-                if cid in self._unconverted_period_map
-            ),
-            None,
-        )
+        wanted = set(condition_ids)
+        for orig_exp, conv_exp in zip(
+            self._unconverted_problem.experiments,
+            self._petab_problem.experiments,
+        ):
+            for orig_period, conv_period in zip(
+                orig_exp.sorted_periods, conv_exp.sorted_periods
+            ):
+                if (
+                    wanted.issubset(conv_period.condition_ids)
+                    and orig_period.condition_ids
+                ):
+                    return orig_period
+        return None
 
     def _resolve_unconverted_condition_ids(
         self, condition_ids: tuple[str, ...]
@@ -1075,16 +1056,7 @@ class JAXProblem(eqx.Module):
 
         Returns ``condition_ids`` unchanged if no original period was found.
         """
-        if not condition_ids:
-            return condition_ids
-        orig_period = next(
-            (
-                self._unconverted_period_map[cid]
-                for cid in condition_ids
-                if cid in self._unconverted_period_map
-            ),
-            None,
-        )
+        orig_period = self._find_unconverted_period(condition_ids)
         if orig_period is None:
             return tuple(condition_ids)
         return tuple(orig_period.condition_ids)
@@ -1111,14 +1083,7 @@ class JAXProblem(eqx.Module):
             for c in self._petab_problem.conditions
             if c.id == condition_id
         ]
-        unconverted_period = next(
-            (
-                self._unconverted_period_map[cid]
-                for cid in condition_ids
-                if cid in self._unconverted_period_map
-            ),
-            None,
-        )
+        unconverted_period = self._find_unconverted_period(condition_ids)
         if unconverted_period is not None and (
             unconverted_period.is_preequilibration
             or unconverted_period.time == 0.0

--- a/python/sdist/amici/sim/jax/petab.py
+++ b/python/sdist/amici/sim/jax/petab.py
@@ -1059,16 +1059,6 @@ class JAXProblem(eqx.Module):
             return tuple(condition_ids)
         return tuple(orig_period.condition_ids)
 
-    def _resolve_unconverted_condition_id(self, condition_id: str) -> str:
-        """Map a converted condition ID back to its original unconverted ID.
-
-        See :meth:`_resolve_unconverted_condition_ids`; a single id may not
-        identify a period unambiguously, and where the matched period
-        references several simultaneously-active conditions, only the first one
-        is returned.
-        """
-        return self._resolve_unconverted_condition_ids((condition_id,))[0]
-
     def _conditions_defining_changes(
         self, condition_ids: tuple[str, ...]
     ) -> list[tuple[petabv2.Condition, bool]]:
@@ -1121,9 +1111,9 @@ class JAXProblem(eqx.Module):
         net_id = entity_id.split(".")[0]
         ind = int(re.search(r"\[\d+\]\[(\d+)\]", entity_id).group(1))
         nn = self.model.nns[net_id]
-        unconverted_condition_id = self._resolve_unconverted_condition_id(
-            condition_id
-        )
+        unconverted_condition_id = self._resolve_unconverted_condition_ids(
+            (condition_id,)
+        )[0]
 
         def _is_net_input(model_id):
             comps = model_id.split(".")

--- a/python/sdist/amici/sim/jax/petab.py
+++ b/python/sdist/amici/sim/jax/petab.py
@@ -1025,6 +1025,8 @@ class JAXProblem(eqx.Module):
         """Locate the unconverted period the given converted condition ids belong to
         using the stored _unconverted_problem.
 
+        Note that this relies on the ordering of experiments being consistent between the converted and unconverted problems.
+
         :return:
             The corresponding original (unconverted) period, or ``None`` if the
             problem was not converted, or if no corresponding original period

--- a/python/sdist/amici/sim/jax/petab.py
+++ b/python/sdist/amici/sim/jax/petab.py
@@ -165,6 +165,7 @@ class JAXProblem(eqx.Module):
     _petab_measurement_indices: np.ndarray
     _petab_problem: petabv2.Problem
     _unconverted_problem: petabv2.Problem | None
+    _unconverted_period_map: dict[str, petabv2.ExperimentPeriod]
 
     def __init__(
         self,
@@ -191,6 +192,7 @@ class JAXProblem(eqx.Module):
         self.simulation_conditions = scs.conditionId.to_list()
         self._petab_problem = petab_problem
         self._unconverted_problem = unconverted_problem
+        self._unconverted_period_map = self._compute_unconverted_period_map()
         self.parameters, self.model = (
             self._initialize_model_with_nominal_values(model)
         )
@@ -578,6 +580,31 @@ class JAXProblem(eqx.Module):
             if pname in _petab_param_map:
                 return _petab_param_map[pname]
         return jnp.asarray(target_value, dtype=self.model.parameters.dtype)
+
+    def _compute_unconverted_period_map(
+        self,
+    ) -> dict[str, petabv2.ExperimentPeriod]:
+        """
+        Locate the unconverted period the given converted condition ids. Note that this
+        relies on the ordering of experiments being consistent between the converted
+        and unconverted problems.
+        """
+        return (
+            {
+                cid: orig_period
+                for orig_exp, conv_exp in zip(
+                    self._unconverted_problem.experiments,
+                    self._petab_problem.experiments,
+                )
+                for orig_period, conv_period in zip(
+                    orig_exp.sorted_periods, conv_exp.sorted_periods
+                )
+                if orig_period.condition_ids
+                for cid in conv_period.condition_ids
+            }
+            if self._unconverted_problem is not None
+            else {}
+        )
 
     def _get_parameter_mappings(self) -> dict[str, ...]:
         targets_map = {
@@ -1025,29 +1052,21 @@ class JAXProblem(eqx.Module):
         """Locate the unconverted period the given converted condition ids belong to
         using the stored _unconverted_problem.
 
-        Note that this relies on the ordering of experiments being consistent between the converted and unconverted problems.
-
         :return:
             The corresponding original (unconverted) period, or ``None`` if the
             problem was not converted, or if no corresponding original period
             was found.
         """
-        if self._unconverted_problem is None or not condition_ids:
+        if not condition_ids:
             return None
-        wanted = set(condition_ids)
-        for orig_exp, conv_exp in zip(
-            self._unconverted_problem.experiments,
-            self._petab_problem.experiments,
-        ):
-            for orig_period, conv_period in zip(
-                orig_exp.sorted_periods, conv_exp.sorted_periods
-            ):
-                if (
-                    wanted.issubset(conv_period.condition_ids)
-                    and orig_period.condition_ids
-                ):
-                    return orig_period
-        return None
+        return next(
+            (
+                self._unconverted_period_map[cid]
+                for cid in condition_ids
+                if cid in self._unconverted_period_map
+            ),
+            None,
+        )
 
     def _resolve_unconverted_condition_ids(
         self, condition_ids: tuple[str, ...]
@@ -1056,7 +1075,16 @@ class JAXProblem(eqx.Module):
 
         Returns ``condition_ids`` unchanged if no original period was found.
         """
-        orig_period = self._find_unconverted_period(condition_ids)
+        if not condition_ids:
+            return condition_ids
+        orig_period = next(
+            (
+                self._unconverted_period_map[cid]
+                for cid in condition_ids
+                if cid in self._unconverted_period_map
+            ),
+            None,
+        )
         if orig_period is None:
             return tuple(condition_ids)
         return tuple(orig_period.condition_ids)
@@ -1083,7 +1111,14 @@ class JAXProblem(eqx.Module):
             for c in self._petab_problem.conditions
             if c.id == condition_id
         ]
-        unconverted_period = self._find_unconverted_period(condition_ids)
+        unconverted_period = next(
+            (
+                self._unconverted_period_map[cid]
+                for cid in condition_ids
+                if cid in self._unconverted_period_map
+            ),
+            None,
+        )
         if unconverted_period is not None and (
             unconverted_period.is_preequilibration
             or unconverted_period.time == 0.0

--- a/python/tests/test_jax.py
+++ b/python/tests/test_jax.py
@@ -11,8 +11,13 @@ import jax.numpy as jnp
 import jax.random as jr
 import numpy as np
 import optimistix
+import sympy as sp
 from amici import MeasurementChannel as MC
 from amici import import_model_module
+from amici.exporters.jax.jaxcodeprinter import (
+    AmiciJaxCodePrinter,
+    _jnp_array_str,
+)
 from amici.importers.petab.v1 import import_petab_problem
 from amici.importers.pysb import pysb2amici, pysb2jax
 from amici.sim.jax import JAXProblem, ReturnValue, run_simulations
@@ -24,9 +29,8 @@ from amici.sim.sundials import (
 from amici.testing import TemporaryDirectoryWinSafe, skip_on_valgrind
 from beartype import beartype
 from numpy.testing import assert_allclose
-from test_petab_objective import lotka_volterra  # noqa: F401
-
 from petab.v1.C import PREEQUILIBRATION_CONDITION_ID, SIMULATION_CONDITION_ID
+from test_petab_objective import lotka_volterra  # noqa: F401
 
 pysb = pytest.importorskip("pysb")
 
@@ -35,6 +39,31 @@ jax.config.update("jax_enable_x64", True)
 
 ATOL_SIM = 1e-12
 RTOL_SIM = 1e-12
+
+
+@skip_on_valgrind
+def test_code_printer_floats_roundtrip():
+    """Generated code must recover the exact double.
+
+    sympy's string printer emits only 15 significant digits, which perturbs
+    the last bits and breaks exact comparisons in the generated model
+    (SBML test suite case 00958: a parameter with value `pi` must test equal
+    to `pi`).
+    """
+    printer = AmiciJaxCodePrinter()
+    values = [sp.pi.evalf(), sp.Float(0.1), sp.Float(1) / 3, sp.Float(1e-17)]
+
+    for value in values:
+        assert float(printer.doprint(value)) == float(value)
+        # `Max`/`Min` build their argument array themselves
+        assert repr(float(value)) in printer.doprint(
+            sp.Max(value, sp.Symbol("x"))
+        )
+
+    # parameter values are emitted without going through `doprint`
+    assert _jnp_array_str(values) == "jnp.array([{}])".format(
+        ", ".join(repr(float(value)) for value in values)
+    )
 
 
 @skip_on_valgrind
@@ -340,7 +369,6 @@ def test_condition_table_initial_value_is_differentiable(tmp_path):
     ``grad.parameters``.
     """
     import equinox as eqx
-
     import petab.v1 as petab
     from petab.v1.models.sbml_model import SbmlModel
 
@@ -398,7 +426,6 @@ def test_condition_table_parameter_override_is_differentiable(tmp_path):
     mapping path (``JAXProblem._map_experiment_model_parameter_value``).
     """
     import equinox as eqx
-
     import petab.v1 as petab
     from petab.v1.models.sbml_model import SbmlModel
 
@@ -465,7 +492,6 @@ def test_condition_table_initial_value_with_renamed_conditions(tmp_path):
     """
     import equinox as eqx
     from amici.importers.petab import PetabImporter
-
     from petab.v2 import Problem
     from petab.v2.core import ProblemConfig
     from petab.v2.models.sbml_model import SbmlModel
@@ -564,7 +590,6 @@ def test_renamed_conditions_reinitialisation_respects_period_start(tmp_path):
     """
     from amici.importers.petab import PetabImporter
     from amici.sim.jax.petab import _get_period_condition_ids
-
     from petab.v2 import Problem
     from petab.v2.core import ProblemConfig
     from petab.v2.models.sbml_model import SbmlModel
@@ -632,6 +657,66 @@ def test_renamed_conditions_reinitialisation_respects_period_start(tmp_path):
 
 
 @skip_on_valgrind
+def test_prepare_experiments_numeric_overrides_without_parameters(tmp_path):
+    """
+    Regression test: ``_prepare_experiments`` must preserve the shape of numeric override
+    arrays when the problem has no estimated scalar parameters.
+    """
+    import petab.v1 as petab
+    from amici.sim.jax.petab import _get_period_condition_ids
+    from petab.v1.models.sbml_model import SbmlModel
+
+    problem = petab.Problem()
+    problem.model = SbmlModel.from_antimony(
+        "compartment_ = 1;\n"
+        "species A in compartment_, B in compartment_;\n"
+        "A = 1; B = 0;\n"
+        "k1 = 0.8; k2 = 0.6;\n"
+        "fwd: A -> B; k1 * A;\n"
+        "rev: B -> A; k2 * B;\n"
+    )
+    # no estimated parameters -> ``JAXProblem.parameters`` is empty
+    problem.add_parameter(
+        "k2", estimate=False, nominal_value=0.6, scale="lin", lb=0.1, ub=10
+    )
+    # numeric noise-parameter overrides -> ``_np_numeric`` is non-empty while
+    # ``_np_mask`` is all-False (nothing to look up in the parameter vector)
+    problem.add_observable("obs_b", "B", noise_formula="noiseParameter1_obs_b")
+    problem.add_condition("c0", k1=0.8)
+    problem.add_measurement("obs_b", "c0", 1.0, 0.3, noise_parameters=[0.5])
+    problem.add_measurement("obs_b", "c0", 5.0, 0.4, noise_parameters=[0.7])
+
+    jax_problem = import_petab_problem(
+        problem, jax=True, output_dir=str(tmp_path)
+    )
+    assert jax_problem.parameters.size == 0
+    assert jax_problem._np_numeric.size
+
+    experiments = jax_problem._petab_problem.experiments
+    conditions = [
+        _get_period_condition_ids(exp, is_preequilibration=False)
+        for exp in experiments
+    ]
+    ei = jax_problem._experiment_indices(experiments)
+    np_numeric = jax_problem._np_numeric[ei]
+
+    (*_, np_array, _, _) = jax_problem._prepare_experiments(
+        experiments,
+        conditions,
+        False,
+        jax_problem._op_numeric[ei],
+        jax_problem._op_mask[ei],
+        jax_problem._op_indices[ei],
+        np_numeric,
+        jax_problem._np_mask[ei],
+        jax_problem._np_indices[ei],
+    )
+
+    assert np_array.shape == np_numeric.shape
+    assert_allclose(np.asarray(np_array), np.asarray(np_numeric))
+
+
+@skip_on_valgrind
 def test_petab_simulate_ragged_experiments(tmp_path):
     """``petab_simulate`` must handle experiments with different numbers of
     measurement timepoints.
@@ -643,9 +728,8 @@ def test_petab_simulate_ragged_experiments(tmp_path):
     simulation DataFrame raises ``ValueError: arrays must all be same
     length`` (or leaks padded/duplicated indices).
     """
-    from amici.sim.jax import petab_simulate
-
     import petab.v1 as petab
+    from amici.sim.jax import petab_simulate
     from petab.v1.models.sbml_model import SbmlModel
 
     problem = petab.Problem()

--- a/python/tests/test_jax.py
+++ b/python/tests/test_jax.py
@@ -11,13 +11,8 @@ import jax.numpy as jnp
 import jax.random as jr
 import numpy as np
 import optimistix
-import sympy as sp
 from amici import MeasurementChannel as MC
 from amici import import_model_module
-from amici.exporters.jax.jaxcodeprinter import (
-    AmiciJaxCodePrinter,
-    _jnp_array_str,
-)
 from amici.importers.petab.v1 import import_petab_problem
 from amici.importers.pysb import pysb2amici, pysb2jax
 from amici.sim.jax import JAXProblem, ReturnValue, run_simulations
@@ -29,8 +24,9 @@ from amici.sim.sundials import (
 from amici.testing import TemporaryDirectoryWinSafe, skip_on_valgrind
 from beartype import beartype
 from numpy.testing import assert_allclose
-from petab.v1.C import PREEQUILIBRATION_CONDITION_ID, SIMULATION_CONDITION_ID
 from test_petab_objective import lotka_volterra  # noqa: F401
+
+from petab.v1.C import PREEQUILIBRATION_CONDITION_ID, SIMULATION_CONDITION_ID
 
 pysb = pytest.importorskip("pysb")
 
@@ -39,31 +35,6 @@ jax.config.update("jax_enable_x64", True)
 
 ATOL_SIM = 1e-12
 RTOL_SIM = 1e-12
-
-
-@skip_on_valgrind
-def test_code_printer_floats_roundtrip():
-    """Generated code must recover the exact double.
-
-    sympy's string printer emits only 15 significant digits, which perturbs
-    the last bits and breaks exact comparisons in the generated model
-    (SBML test suite case 00958: a parameter with value `pi` must test equal
-    to `pi`).
-    """
-    printer = AmiciJaxCodePrinter()
-    values = [sp.pi.evalf(), sp.Float(0.1), sp.Float(1) / 3, sp.Float(1e-17)]
-
-    for value in values:
-        assert float(printer.doprint(value)) == float(value)
-        # `Max`/`Min` build their argument array themselves
-        assert repr(float(value)) in printer.doprint(
-            sp.Max(value, sp.Symbol("x"))
-        )
-
-    # parameter values are emitted without going through `doprint`
-    assert _jnp_array_str(values) == "jnp.array([{}])".format(
-        ", ".join(repr(float(value)) for value in values)
-    )
 
 
 @skip_on_valgrind
@@ -369,6 +340,7 @@ def test_condition_table_initial_value_is_differentiable(tmp_path):
     ``grad.parameters``.
     """
     import equinox as eqx
+
     import petab.v1 as petab
     from petab.v1.models.sbml_model import SbmlModel
 
@@ -426,6 +398,7 @@ def test_condition_table_parameter_override_is_differentiable(tmp_path):
     mapping path (``JAXProblem._map_experiment_model_parameter_value``).
     """
     import equinox as eqx
+
     import petab.v1 as petab
     from petab.v1.models.sbml_model import SbmlModel
 
@@ -471,63 +444,191 @@ def test_condition_table_parameter_override_is_differentiable(tmp_path):
 
 
 @skip_on_valgrind
-def test_prepare_experiments_numeric_overrides_without_parameters(tmp_path):
-    """
-    Regression test: ``_prepare_experiments`` must preserve the shape of numeric override
-    arrays when the problem has no estimated scalar parameters.
-    """
-    import petab.v1 as petab
-    from amici.sim.jax.petab import _get_period_condition_ids
-    from petab.v1.models.sbml_model import SbmlModel
+def test_condition_table_initial_value_with_renamed_conditions(tmp_path):
+    """A condition-table change of a species must still be found when the
+    conditions have been renamed during import.
 
-    problem = petab.Problem()
+    ``PetabImporter`` converts the PEtab experiments to SBML events
+    (``petab.v2.converters.ExperimentsToSbmlConverter``), which replaces the
+    condition table by ``_petab*`` indicator conditions. The simulation
+    condition ids of the resulting ``JAXProblem`` therefore no longer name the
+    original condition-table entries.
+
+    Regression test for a bug where
+    ``JAXProblem._condition_reinit_target_value`` only looked the (converted)
+    ids up in the converted condition table -- which merely sets the indicator
+    parameters -- so the state was reported as not needing reinitialisation.
+    ``_eval_nn`` already resolved the ids back to the original ones via
+    ``_resolve_original_condition_id``; the reinitialisation lookup must do the
+    same, while still returning the *raw* target value so that the caller can
+    resolve it against the traced ``JAXProblem.parameters``.
+    """
+    import equinox as eqx
+    from amici.importers.petab import PetabImporter
+
+    from petab.v2 import Problem
+    from petab.v2.core import ProblemConfig
+    from petab.v2.models.sbml_model import SbmlModel
+
+    problem = Problem()
+    problem.config = ProblemConfig()
     problem.model = SbmlModel.from_antimony(
         "compartment_ = 1;\n"
         "species A in compartment_, B in compartment_;\n"
-        "A = 1; B = 0;\n"
+        "A = 3; B = 0;\n"
         "k1 = 0.8; k2 = 0.6;\n"
         "fwd: A -> B; k1 * A;\n"
         "rev: B -> A; k2 * B;\n"
     )
-    # no estimated parameters -> ``JAXProblem.parameters`` is empty
+    # `a0` initialises species `A` via the condition table (not in the model)
     problem.add_parameter(
-        "k2", estimate=False, nominal_value=0.6, scale="lin", lb=0.1, ub=10
+        "a0", nominal_value=2.0, estimate=True, lb=0.1, ub=10, scale="lin"
     )
-    # numeric noise-parameter overrides -> ``_np_numeric`` is non-empty while
-    # ``_np_mask`` is all-False (nothing to look up in the parameter vector)
-    problem.add_observable("obs_b", "B", noise_formula="noiseParameter1_obs_b")
-    problem.add_condition("c0", k1=0.8)
-    problem.add_measurement("obs_b", "c0", 1.0, 0.3, noise_parameters=[0.5])
-    problem.add_measurement("obs_b", "c0", 5.0, 0.4, noise_parameters=[0.7])
-
-    jax_problem = import_petab_problem(
-        problem, jax=True, output_dir=str(tmp_path)
+    problem.add_observable("obs_a", formula="A", noise_formula="0.5")
+    problem.add_condition("c0", A="a0")
+    problem.add_experiment("e0", 0, "c0")
+    problem.add_measurement(
+        "obs_a", experiment_id="e0", time=0.0, measurement=0.7
     )
-    assert jax_problem.parameters.size == 0
-    assert jax_problem._np_numeric.size
-
-    experiments = jax_problem._petab_problem.experiments
-    conditions = [
-        _get_period_condition_ids(exp, is_preequilibration=False)
-        for exp in experiments
-    ]
-    ei = jax_problem._experiment_indices(experiments)
-    np_numeric = jax_problem._np_numeric[ei]
-
-    (*_, np_array, _, _) = jax_problem._prepare_experiments(
-        experiments,
-        conditions,
-        False,
-        jax_problem._op_numeric[ei],
-        jax_problem._op_mask[ei],
-        jax_problem._op_indices[ei],
-        np_numeric,
-        jax_problem._np_mask[ei],
-        jax_problem._np_indices[ei],
+    problem.add_measurement(
+        "obs_a", experiment_id="e0", time=10.0, measurement=0.1
     )
 
-    assert np_array.shape == np_numeric.shape
-    assert_allclose(np.asarray(np_array), np.asarray(np_numeric))
+    jax_problem = PetabImporter(
+        problem,
+        jax=True,
+        module_name="test_reinit_renamed_conditions",
+        output_dir=str(tmp_path),
+        verbose=False,
+    ).create_simulator(force_import=True)
+
+    (condition_id,) = jax_problem.simulation_conditions
+    sc = (condition_id,)
+    # The import must actually have renamed the condition, otherwise the
+    # resolution under test is never exercised.
+    assert condition_id != "c0"
+    assert "c0" not in {c.id for c in jax_problem._petab_problem.conditions}
+    assert "c0" in {c.id for c in jax_problem._unconverted_problem.conditions}
+
+    # the raw (unresolved) target value is looked up under the original id
+    assert str(jax_problem._condition_reinit_target_value(sc, "A")) == "a0"
+    assert jax_problem._condition_reinit_target_value(sc, "B") is None
+
+    ix = jax_problem.model.state_ids.index("A")
+    ia = jax_problem.parameter_ids.index("a0")
+
+    mask, reinit_x = jax_problem.load_reinitialisation(sc)
+    assert bool(mask[ix]), "state reinitialisation was not detected"
+    assert not bool(mask[jax_problem.model.state_ids.index("B")])
+    assert_allclose(float(reinit_x[ix]), 2.0)
+
+    # the raw value must be resolved live, so it follows `update_parameters`...
+    p0 = jax_problem.parameters
+    _, reinit_x = jax_problem.update_parameters(
+        p0.at[ia].set(5.0)
+    ).load_reinitialisation(sc)
+    assert_allclose(float(reinit_x[ix]), 5.0)
+
+    # ... and stays differentiable w.r.t. `JAXProblem.parameters`
+    grad = eqx.filter_grad(lambda m: m.load_reinitialisation(sc)[1][ix])(
+        jax_problem
+    )
+    assert_allclose(float(grad.parameters[ia]), 1.0)
+
+    # the reinitialised initial value is reflected in the likelihood
+    def llh(p):
+        return float(run_simulations(jax_problem.update_parameters(p))[0])
+
+    assert abs(llh(p0.at[ia].add(1.0)) - llh(p0)) > 1e-6
+    eps = 1e-6
+    fd = (llh(p0.at[ia].add(eps)) - llh(p0.at[ia].add(-eps))) / (2 * eps)
+    grad = eqx.filter_grad(lambda m: run_simulations(m)[0])(
+        jax_problem.update_parameters(p0)
+    )
+    assert_allclose(float(grad.parameters[ia]), fd, rtol=1e-4, atol=1e-4)
+
+
+@skip_on_valgrind
+def test_renamed_conditions_reinitialisation_respects_period_start(tmp_path):
+    """Resolving renamed conditions must not reinitialise a state for a period
+    that does not start at the simulated ``t0``.
+
+    Reinitialisation is applied at the initial time of the (pre-)equilibration
+    or of the dynamic simulation, which for an experiment with
+    preequilibration is ``t=0`` -- not the start time of the first dynamic
+    period. A change of a later-starting period is applied by the event that
+    ``PetabImporter`` created for it, so resolving the renamed conditions
+    (see ``test_condition_table_initial_value_with_renamed_conditions``) must
+    not additionally reinitialise the state at ``t0``, which would apply the
+    change too early (PEtab test suite cases 0017/0018).
+    """
+    from amici.importers.petab import PetabImporter
+    from amici.sim.jax.petab import _get_period_condition_ids
+
+    from petab.v2 import Problem
+    from petab.v2.core import ProblemConfig
+    from petab.v2.models.sbml_model import SbmlModel
+
+    problem = Problem()
+    problem.config = ProblemConfig()
+    problem.model = SbmlModel.from_antimony(
+        "compartment_ = 1;\n"
+        "species A in compartment_, B in compartment_;\n"
+        "A = 3; B = 0;\n"
+        "k1 = 0.8; k2 = 0.6;\n"
+        "fwd: A -> B; k1 * A;\n"
+        "rev: B -> A; k2 * B;\n"
+    )
+    problem.add_observable("obs_a", formula="A", noise_formula="0.5")
+    problem.add_condition("preeq_c0", A=0.0, B=2.0)
+    problem.add_condition("c0", A=1.0)
+    # the dynamic period starts at t=10, i.e. after the simulation's t0 (=0)
+    problem.add_experiment("e0", "-inf", "preeq_c0", 10.0, "c0")
+    problem.add_measurement(
+        "obs_a", experiment_id="e0", time=10.0, measurement=0.7
+    )
+    problem.add_measurement(
+        "obs_a", experiment_id="e0", time=20.0, measurement=0.1
+    )
+
+    jax_problem = PetabImporter(
+        problem,
+        jax=True,
+        module_name="test_reinit_renamed_conditions_preeq",
+        output_dir=str(tmp_path),
+        verbose=False,
+    ).create_simulator(force_import=True)
+
+    (experiment,) = jax_problem._petab_problem.experiments
+    preeq_conditions = _get_period_condition_ids(
+        experiment, is_preequilibration=True
+    )
+    dyn_conditions = _get_period_condition_ids(
+        experiment, is_preequilibration=False
+    )
+    # both periods carry the same experiment indicator condition, so a single
+    # condition id does not identify the period
+    assert set(preeq_conditions) & set(dyn_conditions)
+
+    # the preequilibration period starts at the preequilibration's t0 ...
+    assert (
+        float(
+            jax_problem._condition_reinit_target_value(preeq_conditions, "B")
+        )
+        == 2.0
+    )
+    mask, reinit_x = jax_problem.load_reinitialisation(preeq_conditions)
+    ib = jax_problem.model.state_ids.index("B")
+    assert bool(mask[ib])
+    assert_allclose(float(reinit_x[ib]), 2.0)
+
+    # ... whereas the dynamic period starts at t=10, so `A = 1` must be left to
+    # the event and not be applied at t0
+    assert (
+        jax_problem._condition_reinit_target_value(dyn_conditions, "A") is None
+    )
+    mask, _ = jax_problem.load_reinitialisation(dyn_conditions)
+    assert not bool(mask[jax_problem.model.state_ids.index("A")])
 
 
 @skip_on_valgrind
@@ -542,8 +643,9 @@ def test_petab_simulate_ragged_experiments(tmp_path):
     simulation DataFrame raises ``ValueError: arrays must all be same
     length`` (or leaks padded/duplicated indices).
     """
-    import petab.v1 as petab
     from amici.sim.jax import petab_simulate
+
+    import petab.v1 as petab
     from petab.v1.models.sbml_model import SbmlModel
 
     problem = petab.Problem()

--- a/tests/sciml/test_sciml.py
+++ b/tests/sciml/test_sciml.py
@@ -15,10 +15,10 @@ import pytest
 from amici.exporters.jax import generate_equinox
 from amici.importers.petab import *
 from amici.sim.jax import petab_simulate, run_simulations
-from petab import v2
 from petab_sciml import NNModelStandard
-from sciml_helpers import _v2_sciml_problem_helper
 from yaml import safe_load
+
+from petab import v2
 
 
 @contextmanager


### PR DESCRIPTION
Updating the function `_condition_reinit_target_value` to resolve conditions ids in the same way as `_eval_nn` does, while preserving gradient tracing. 

The context in which I noticed this bug was a JAXProblem built from a PetabImporter instance. The underlying petab problem contained conditions which modified a model state variable. The PetabImporter changes the names of conditions and condition targets as part of import which is why `_eval_nn` needs to resolve current condition ids to originals, and why `_condition_reinit_target_value` should do the same. 