### PR TITLE
GHA: Add NumPy SIMD dispatch diagnostic for flaky Weber_BMC2015 (#3078)

### DIFF
--- a/.github/workflows/test_benchmark_collection_models.yml
+++ b/.github/workflows/test_benchmark_collection_models.yml
@@ -63,6 +63,28 @@ jobs:
         AMICI_PARALLEL_COMPILE="" pip3 install -v --user \
             $(ls -t python/sdist/dist/amici-*.tar.gz | head -1)[petab,test,vis,jax]
 
+    # Diagnostic for https://github.com/AMICI-dev/AMICI/issues/3078: root
+    # cause was NumPy's own runtime SIMD dispatch for transcendental ufuncs
+    # (np.power/np.exp, used when unscaling log10/log-scaled PEtab
+    # parameters) picking different, non-bit-identical kernels depending on
+    # which instruction-set tiers are available on the runner. This can't be
+    # inferred from generic hardware diagnostics (dweindl/gha-runner-diagnostics@v1,
+    # which runs before Python/NumPy even exist) -- it has to be queried
+    # from NumPy directly, after it's installed.
+    - name: NumPy SIMD dispatch state (#3078)
+      run: |
+        python3 -c "
+        import numpy as np
+        try:
+            from numpy._core import _multiarray_umath as mau
+        except ImportError:
+            from numpy.core import _multiarray_umath as mau
+        print('numpy:', np.__version__)
+        print('baseline:', mau.__cpu_baseline__)
+        print('dispatch (compiled in):', mau.__cpu_dispatch__)
+        print('features (active this run):', [k for k, v in mau.__cpu_features__.items() if v])
+        "
+
     - name: Install test dependencies
       run: |
         python3 -m pip uninstall -y petab && python3 -m pip install git+https://github.com/petab-dev/libpetab-python.git@main \


### PR DESCRIPTION
## Summary

Follow-up to #3078 and #3229. The AVX-512-presence correlation reported
there was real but indirect: the actual root cause is NumPy's own runtime
SIMD dispatch for transcendental ufuncs (`np.power`, `np.exp`), used when
AMICI unscales `log10`/`log`-scaled PEtab parameters back to linear scale.
`Weber_BMC2015` has all 40 of its parameters on `log10` scale, so this path
is exercised heavily. NumPy's optimized kernels at different SIMD widths
(`X86_V3` vs. `X86_V4`/`AVX512_ICL`/`AVX512_SPR`) aren't required to agree
bit-for-bit -- documented, accepted NumPy behavior -- and it silently picks
the widest tier the host CPU supports. AVX-512 presence only predicted the
outcome because it gates *which tier NumPy even has the option to pick*; it
is not a causal pathway through AMICI's own C++ core, SUNDIALS, SuiteSparse,
glibc, or OpenBLAS, all of which were directly tested (via causal probes on
real AVX-512 CI hardware) and refuted. Full writeup:
https://github.com/AMICI-dev/AMICI/issues/3078#issuecomment-5244467220

This PR previously carried the exploratory causal-probe steps
(`GLIBC_TUNABLES`, `OPENBLAS_CORETYPE=HASWELL`, a full state-trajectory
dump) used to reach that conclusion. Now that the mechanism is confirmed,
those are removed, leaving only the one diagnostic that's actually useful
going forward.

## What this adds

A step that prints NumPy's actual runtime SIMD dispatch state
(`numpy._core._multiarray_umath.__cpu_baseline__`/`__cpu_dispatch__`/
`__cpu_features__`) right after NumPy becomes available in the job. Generic
hardware diagnostics (`dweindl/gha-runner-diagnostics@v1`, already present,
merged in #3229) run before Python/NumPy even exist and can only show raw
CPU feature flags -- not which dispatch tier NumPy actually selected. This
shows the real variable directly, rather than requiring it to be inferred
indirectly from CPU flags as this investigation had to do.

## Test plan

- [x] Verified the exact snippet runs correctly and reports the expected
  fields locally.
- [x] YAML validated.
- [ ] Confirm it runs cleanly in CI on both `extract_subexpressions` matrix
  legs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)