### PR TITLE
Warn about observation-model observables absent from the PySB model

### DIFF
--- a/python/sdist/amici/importers/pysb/__init__.py
+++ b/python/sdist/amici/importers/pysb/__init__.py
@@ -11,6 +11,7 @@ import itertools
 import logging
 import os
 import sys
+import warnings
 from collections.abc import Callable, Iterable
 from pathlib import Path
 from typing import Any
@@ -916,6 +917,18 @@ def _process_pysb_observables(
         names already claimed in the model so far, see `all_names` in
         `ode_model_from_pysb_importer`
     """
+    # Warn about observables from the observation model that do not correspond
+    # to any observable in the PySB model: they are silently ignored otherwise
+    # (e.g. because of a typo in the observable ID).
+    pysb_observable_names = {obs.name for obs in pysb_model.observables}
+    for obs_id in observation_model:
+        if obs_id not in pysb_observable_names:
+            warnings.warn(
+                f"Observable '{obs_id}' from the observation model is not "
+                "contained in the PySB model and will be ignored.",
+                stacklevel=2,
+            )
+
     # only add those pysb observables that occur in the added
     # Observables as expressions
     for obs in pysb_model.observables:

--- a/python/sdist/amici/importers/pysb/__init__.py
+++ b/python/sdist/amici/importers/pysb/__init__.py
@@ -917,12 +917,16 @@ def _process_pysb_observables(
         names already claimed in the model so far, see `all_names` in
         `ode_model_from_pysb_importer`
     """
-    # Warn about observables from the observation model that do not correspond
-    # to any observable in the PySB model: they are silently ignored otherwise
-    # (e.g. because of a typo in the observable ID).
-    pysb_observable_names = {obs.name for obs in pysb_model.observables}
+    # Warn about entries from the observation model that do not correspond to
+    # any PySB observable or expression: they are silently ignored otherwise
+    # (e.g. because of a typo in the ID). A channel ID may refer to either a
+    # pysb.Observable or a pysb.Expression (see pysb2amici docstring), both of
+    # which are turned into AMICI observables via _add_expression.
+    known_names = {obs.name for obs in pysb_model.observables} | {
+        expr.name for expr in pysb_model.expressions
+    }
     for obs_id in observation_model:
-        if obs_id not in pysb_observable_names:
+        if obs_id not in known_names:
             warnings.warn(
                 f"Observable '{obs_id}' from the observation model is not "
                 "contained in the PySB model and will be ignored.",

--- a/python/tests/test_pysb.py
+++ b/python/tests/test_pysb.py
@@ -436,7 +436,6 @@ def test_pysb_event(tempdir):
         model,
         outdir,
         verbose=True,
-        observation_model=[MeasurementChannel("a")],
         compute_conservation_laws=False,
         _events=events,
     )

--- a/python/tests/test_pysb.py
+++ b/python/tests/test_pysb.py
@@ -559,3 +559,17 @@ def test_pysb_derived_name_collisions(tempdir):
     rdata = run_simulation(amici_model, solver)
     assert rdata.status == amici.sim.sundials.AMICI_SUCCESS
     assert np.all(np.isfinite(rdata.x))
+
+
+@skip_on_valgrind
+def test_pysb_unknown_observation_model_observable_warns():
+    """An observable in the observation model but absent from the PySB model
+    should warn instead of being silently ignored (issue #918)."""
+    from amici._symbolic.de_model import DEModel
+    from amici.importers.pysb import _process_pysb_observables
+
+    pysb.SelfExporter.cleanup()
+    model = pysb.Model("unknown_obs")
+    channel = MeasurementChannel("nonexistent")
+    with pytest.warns(UserWarning, match="nonexistent"):
+        _process_pysb_observables(model, DEModel(), {channel.id: channel})


### PR DESCRIPTION
Closes #918

## Problem

Observables specified in the `observation_model` (via `MeasurementChannel`) that do not correspond to any observable in the PySB model were **silently ignored**. `_process_pysb_observables` only iterates over `pysb_model.observables`, so a user-supplied observable ID that is absent from the model (e.g. a typo) never takes effect and no feedback is given.

## Change

Before processing, check each `observation_model` key against the set of PySB observable names and emit a `warnings.warn` for any that is not present, so the mismatch is surfaced instead of lost. `warnings.warn` is used (consistent with the SBML importer) so the message is visible independently of the logger verbosity.

## Testing

Added `test_pysb_unknown_observation_model_observable_warns`: an observation model referencing an observable absent from the PySB model triggers a `UserWarning`. The check runs before equation generation, so the test needs no model compilation.