### PR TITLE
Bump BioNetGen to 2.9.2

### DIFF
--- a/.github/actions/install-macos-dependencies/action.yml
+++ b/.github/actions/install-macos-dependencies/action.yml
@@ -13,7 +13,7 @@ runs:
       shell: bash
 
     # BioNetGen path
-    - run: echo "BNGPATH=${AMICI_DIR}/ThirdParty/BioNetGen-2.9.3" >> $GITHUB_ENV
+    - run: echo "BNGPATH=${AMICI_DIR}/ThirdParty/BioNetGen-2.9.2" >> $GITHUB_ENV
       shell: bash
 
     # CMake hints

--- a/.github/actions/install-macos-dependencies/action.yml
+++ b/.github/actions/install-macos-dependencies/action.yml
@@ -13,7 +13,7 @@ runs:
       shell: bash
 
     # BioNetGen path
-    - run: echo "BNGPATH=${AMICI_DIR}/ThirdParty/BioNetGen-2.7.0" >> $GITHUB_ENV
+    - run: echo "BNGPATH=${AMICI_DIR}/ThirdParty/BioNetGen-2.9.3" >> $GITHUB_ENV
       shell: bash
 
     # CMake hints

--- a/.github/actions/setup-amici-cpp/action.yml
+++ b/.github/actions/setup-amici-cpp/action.yml
@@ -7,7 +7,7 @@ runs:
   using: "composite"
   steps:
     # BioNetGen Path
-    - run: echo "BNGPATH=${GITHUB_WORKSPACE}/ThirdParty/BioNetGen-2.9.3" >> $GITHUB_ENV
+    - run: echo "BNGPATH=${GITHUB_WORKSPACE}/ThirdParty/BioNetGen-2.9.2" >> $GITHUB_ENV
       shell: bash
 
     # use all available cores

--- a/.github/actions/setup-amici-cpp/action.yml
+++ b/.github/actions/setup-amici-cpp/action.yml
@@ -7,7 +7,7 @@ runs:
   using: "composite"
   steps:
     # BioNetGen Path
-    - run: echo "BNGPATH=${GITHUB_WORKSPACE}/ThirdParty/BioNetGen-2.7.0" >> $GITHUB_ENV
+    - run: echo "BNGPATH=${GITHUB_WORKSPACE}/ThirdParty/BioNetGen-2.9.3" >> $GITHUB_ENV
       shell: bash
 
     # use all available cores

--- a/.github/workflows/test_petab_test_suite.yml
+++ b/.github/workflows/test_petab_test_suite.yml
@@ -50,7 +50,7 @@ jobs:
       - run: |
           echo "${HOME}/.local/bin/" >> $GITHUB_PATH
           echo "${GITHUB_WORKSPACE}/tests/performance/" >> $GITHUB_PATH
-          echo "BNGPATH=${GITHUB_WORKSPACE}/ThirdParty/BioNetGen-2.7.0" >> $GITHUB_ENV
+          echo "BNGPATH=${GITHUB_WORKSPACE}/ThirdParty/BioNetGen-2.9.3" >> $GITHUB_ENV
 
       # install AMICI
       - name: Install python package
@@ -159,7 +159,7 @@ jobs:
       - run: |
           echo "${HOME}/.local/bin/" >> $GITHUB_PATH
           echo "${GITHUB_WORKSPACE}/tests/performance/" >> $GITHUB_PATH
-          echo "BNGPATH=${GITHUB_WORKSPACE}/ThirdParty/BioNetGen-2.7.0" >> $GITHUB_ENV
+          echo "BNGPATH=${GITHUB_WORKSPACE}/ThirdParty/BioNetGen-2.9.3" >> $GITHUB_ENV
 
       # install AMICI
       - name: Install python package

--- a/.github/workflows/test_petab_test_suite.yml
+++ b/.github/workflows/test_petab_test_suite.yml
@@ -50,7 +50,7 @@ jobs:
       - run: |
           echo "${HOME}/.local/bin/" >> $GITHUB_PATH
           echo "${GITHUB_WORKSPACE}/tests/performance/" >> $GITHUB_PATH
-          echo "BNGPATH=${GITHUB_WORKSPACE}/ThirdParty/BioNetGen-2.9.3" >> $GITHUB_ENV
+          echo "BNGPATH=${GITHUB_WORKSPACE}/ThirdParty/BioNetGen-2.9.2" >> $GITHUB_ENV
 
       # install AMICI
       - name: Install python package
@@ -159,7 +159,7 @@ jobs:
       - run: |
           echo "${HOME}/.local/bin/" >> $GITHUB_PATH
           echo "${GITHUB_WORKSPACE}/tests/performance/" >> $GITHUB_PATH
-          echo "BNGPATH=${GITHUB_WORKSPACE}/ThirdParty/BioNetGen-2.9.3" >> $GITHUB_ENV
+          echo "BNGPATH=${GITHUB_WORKSPACE}/ThirdParty/BioNetGen-2.9.2" >> $GITHUB_ENV
 
       # install AMICI
       - name: Install python package

--- a/.github/workflows/test_python_ver_matrix.yml
+++ b/.github/workflows/test_python_ver_matrix.yml
@@ -30,7 +30,7 @@ jobs:
     - uses: dweindl/gha-runner-diagnostics@v1
 
     - run: echo "AMICI_DIR=$(pwd)" >> $GITHUB_ENV
-    - run: echo "BNGPATH=${AMICI_DIR}/ThirdParty/BioNetGen-2.7.0" >> $GITHUB_ENV
+    - run: echo "BNGPATH=${AMICI_DIR}/ThirdParty/BioNetGen-2.9.3" >> $GITHUB_ENV
 
     - name: Set up Python ${{ matrix.python-version }}
       uses: actions/setup-python@v7

--- a/.github/workflows/test_python_ver_matrix.yml
+++ b/.github/workflows/test_python_ver_matrix.yml
@@ -30,7 +30,7 @@ jobs:
     - uses: dweindl/gha-runner-diagnostics@v1
 
     - run: echo "AMICI_DIR=$(pwd)" >> $GITHUB_ENV
-    - run: echo "BNGPATH=${AMICI_DIR}/ThirdParty/BioNetGen-2.9.3" >> $GITHUB_ENV
+    - run: echo "BNGPATH=${AMICI_DIR}/ThirdParty/BioNetGen-2.9.2" >> $GITHUB_ENV
 
     - name: Set up Python ${{ matrix.python-version }}
       uses: actions/setup-python@v7

--- a/binder/Dockerfile
+++ b/binder/Dockerfile
@@ -56,4 +56,4 @@ RUN . ./.profile && ${VENV_PATH}/bin/python3 -m build --sdist python/sdist && \
     ${VENV_PATH}/bin/pip install "git+https://github.com/Benchmarking-Initiative/Benchmark-Models-PEtab.git@master#subdirectory=src/python&egg=benchmark_models_petab" && \
     scripts/buildBNGL.sh
 
-ENV BNGPATH="${HOME}/ThirdParty/BioNetGen-2.7.0"
+ENV BNGPATH="${HOME}/ThirdParty/BioNetGen-2.9.3"

--- a/binder/Dockerfile
+++ b/binder/Dockerfile
@@ -56,4 +56,4 @@ RUN . ./.profile && ${VENV_PATH}/bin/python3 -m build --sdist python/sdist && \
     ${VENV_PATH}/bin/pip install "git+https://github.com/Benchmarking-Initiative/Benchmark-Models-PEtab.git@master#subdirectory=src/python&egg=benchmark_models_petab" && \
     scripts/buildBNGL.sh
 
-ENV BNGPATH="${HOME}/ThirdParty/BioNetGen-2.9.3"
+ENV BNGPATH="${HOME}/ThirdParty/BioNetGen-2.9.2"

--- a/python/tests/test_bngl.py
+++ b/python/tests/test_bngl.py
@@ -58,7 +58,7 @@ def test_compare_to_pysb_simulation(example):
         "..",
         "..",
         "ThirdParty",
-        "BioNetGen-2.7.0",
+        "BioNetGen-2.9.3",
         "Validate",
         f"{example}.bngl",
     )

--- a/python/tests/test_bngl.py
+++ b/python/tests/test_bngl.py
@@ -58,7 +58,7 @@ def test_compare_to_pysb_simulation(example):
         "..",
         "..",
         "ThirdParty",
-        "BioNetGen-2.9.3",
+        "BioNetGen-2.9.2",
         "Validate",
         f"{example}.bngl",
     )

--- a/scripts/buildBNGL.sh
+++ b/scripts/buildBNGL.sh
@@ -4,7 +4,7 @@
 #
 set -euo pipefail
 
-BNG_VERSION="2.9.3"
+BNG_VERSION="2.9.2"
 
 script_path=$(dirname "$BASH_SOURCE")
 amici_path=$(cd "$script_path/.." && pwd)

--- a/scripts/buildBNGL.sh
+++ b/scripts/buildBNGL.sh
@@ -2,7 +2,9 @@
 #
 # Build BNGL (required for pysb)
 #
-set -e
+set -euo pipefail
+
+BNG_VERSION="2.9.3"
 
 script_path=$(dirname "$BASH_SOURCE")
 amici_path=$(cd "$script_path/.." && pwd)
@@ -10,13 +12,23 @@ amici_path=$(cd "$script_path/.." && pwd)
 mkdir -p "${amici_path}/ThirdParty"
 cd "${amici_path}/ThirdParty"
 
-if [ ! -d "BioNetGen-2.7.0" ]; then
+if [ ! -d "BioNetGen-${BNG_VERSION}" ]; then
     if [ ! -e "bionetgen.tar.gz" ]; then
         if [[ "$OSTYPE" == "linux-gnu" || "$OSTYPE" == "linux" ]]; then
-            wget -q -O bionetgen.tar.gz https://github.com/RuleWorld/bionetgen/releases/download/BioNetGen-2.7.0/BioNetGen-2.7.0-linux.tgz
+            os="linux"
         elif [[ "$OSTYPE" == "darwin"* ]]; then
-            wget -q -O bionetgen.tar.gz https://github.com/RuleWorld/bionetgen/releases/download/BioNetGen-2.7.0/BioNetGen-2.7.0-mac.tgz
+            os="mac"
+        else
+            echo "Unsupported OSTYPE for BioNetGen download: ${OSTYPE}" >&2
+            exit 1
         fi
+        wget -q -O bionetgen.tar.gz \
+            "https://github.com/RuleWorld/bionetgen/releases/download/BioNetGen-${BNG_VERSION}/BioNetGen-${BNG_VERSION}-${os}.tar.gz"
     fi
     tar -xf bionetgen.tar.gz
+
+    if [ ! -d "BioNetGen-${BNG_VERSION}" ]; then
+        echo "Error: expected directory BioNetGen-${BNG_VERSION} not found after extracting bionetgen.tar.gz" >&2
+        exit 1
+    fi
 fi

--- a/scripts/run-codecov.sh
+++ b/scripts/run-codecov.sh
@@ -8,7 +8,7 @@ source "${amici_path}"/venv/bin/activate
 pip install coverage pytest pytest-cov
 
 if [[ -z "${BNGPATH}" ]]; then
-    export BNGPATH="${amici_path}"/ThirdParty/BioNetGen-2.7.0
+    export BNGPATH="${amici_path}"/ThirdParty/BioNetGen-2.9.3
 fi
 
 pytest \

--- a/scripts/run-codecov.sh
+++ b/scripts/run-codecov.sh
@@ -8,7 +8,7 @@ source "${amici_path}"/venv/bin/activate
 pip install coverage pytest pytest-cov
 
 if [[ -z "${BNGPATH}" ]]; then
-    export BNGPATH="${amici_path}"/ThirdParty/BioNetGen-2.9.3
+    export BNGPATH="${amici_path}"/ThirdParty/BioNetGen-2.9.2
 fi
 
 pytest \

--- a/scripts/run-python-tests.sh
+++ b/scripts/run-python-tests.sh
@@ -8,7 +8,7 @@ amici_path=$(cd "$script_path"/.. && pwd)
 set -e
 
 if [[ -z "${BNGPATH}" ]]; then
-    export BNGPATH=${amici_path}/ThirdParty/BioNetGen-2.7.0
+    export BNGPATH=${amici_path}/ThirdParty/BioNetGen-2.9.3
 fi
 
 cd "${amici_path}"/python/tests

--- a/scripts/run-python-tests.sh
+++ b/scripts/run-python-tests.sh
@@ -8,7 +8,7 @@ amici_path=$(cd "$script_path"/.. && pwd)
 set -e
 
 if [[ -z "${BNGPATH}" ]]; then
-    export BNGPATH=${amici_path}/ThirdParty/BioNetGen-2.9.3
+    export BNGPATH=${amici_path}/ThirdParty/BioNetGen-2.9.2
 fi
 
 cd "${amici_path}"/python/tests

--- a/scripts/run-valgrind-py.sh
+++ b/scripts/run-valgrind-py.sh
@@ -8,7 +8,7 @@ amici_path=$(cd "$script_path"/.. && pwd)
 set -e
 
 if [[ -z "${BNGPATH}" ]]; then
-    export BNGPATH=${amici_path}/ThirdParty/BioNetGen-2.7.0
+    export BNGPATH=${amici_path}/ThirdParty/BioNetGen-2.9.3
 fi
 suppressions="${amici_path}/python/tests/valgrind-python.supp"
 if [ $# -eq 0 ]

--- a/scripts/run-valgrind-py.sh
+++ b/scripts/run-valgrind-py.sh
@@ -8,7 +8,7 @@ amici_path=$(cd "$script_path"/.. && pwd)
 set -e
 
 if [[ -z "${BNGPATH}" ]]; then
-    export BNGPATH=${amici_path}/ThirdParty/BioNetGen-2.9.3
+    export BNGPATH=${amici_path}/ThirdParty/BioNetGen-2.9.2
 fi
 suppressions="${amici_path}/python/tests/valgrind-python.supp"
 if [ $# -eq 0 ]


### PR DESCRIPTION
## Summary
- Bump BioNetGen from 2.7.0 to 2.9.2 (release asset naming changed `.tgz` -> `.tar.gz` back at 2.8.5); version extracted into a variable in `scripts/buildBNGL.sh`
  - Note: 2.9.3 was tried first, but it drops the release-tarball `Validate/` directory (replaced by a different, smaller `Models2/` set), which breaks `test_bngl.py`. 2.9.2 is the last release that still ships all the `.bngl` fixtures the tests need.
- Harden `buildBNGL.sh`: `set -euo pipefail`, explicit error on unsupported OS, verify extraction produced the expected directory
- Update the remaining hardcoded `BioNetGen-2.7.0` references (CI workflows/actions, `binder/Dockerfile`, `scripts/run-*.sh`, `python/tests/test_bngl.py`) to match

## Test plan
- [x] `bash -n scripts/buildBNGL.sh`
- [x] Ran `buildBNGL.sh` locally: downloads `BioNetGen-2.9.2-linux.tar.gz`, extracts to `ThirdParty/BioNetGen-2.9.2/`, idempotent re-run short-circuits correctly; confirmed all `test_bngl.py` fixture files are present under `Validate/`
- [x] `grep -r "BioNetGen-2.7.0"` / `"BioNetGen-2.9.3"` confirm no stale references remain
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)