### PR TITLE
Give PySB import the same reserved-name rename-and-restore as SBML

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,12 @@ See also our [versioning policy](https://amici.readthedocs.io/en/latest/versioni
   source directly, expect different local variable names (#2226, #2461,
   #3237).
 
+* Fixed PySB/BNGL import failing with a `ValueError` when a model quantity
+  was literally named one of AMICI's reserved argument names (`x`, `p`,
+  `k`, `h`, `w`, `y`). These are now renamed internally and the original
+  ID is restored everywhere it's reported, matching existing SBML import
+  behavior.
+
 ### v1.1 (2026-09-03)
 
 **BREAKING CHANGES**

--- a/python/sdist/amici/importers/pysb/__init__.py
+++ b/python/sdist/amici/importers/pysb/__init__.py
@@ -44,6 +44,7 @@ from ..utils import (
     generate_measurement_symbol,
     noise_distribution_to_cost_function,
     noise_distribution_to_observable_transformation,
+    resolve_reserved_symbol_renames,
     symbol_with_assumptions,
 )
 
@@ -385,8 +386,26 @@ def ode_model_from_pysb_importer(
 
     pysb.bng.generate_equations(model, verbose=verbose)
 
-    _process_pysb_species(model, ode)
-    _process_pysb_parameters(model, ode, fixed_parameters)
+    # species/conservation-law/sigma/log-likelihood symbols are all
+    # synthetically prefixed (__s{ix}, tcl_s{ix}, sigma_{name}, llh_{name})
+    # so they can never literally match a reserved name (single letters);
+    # only parameter and expression/observable names need checking
+    all_names = (
+        {par.name for par in model.parameters}
+        | {
+            expr.name
+            for expr in model.expressions_constant(include_derived=True)
+            | model.expressions_dynamic(include_derived=True)
+        }
+        | {obs.name for obs in model.observables}
+    )
+    renames = resolve_reserved_symbol_renames(all_names)
+    ode.reserved_symbol_original_ids = {
+        new_name: old_name for old_name, new_name in renames.items()
+    }
+
+    _process_pysb_species(model, ode, renames)
+    _process_pysb_parameters(model, ode, fixed_parameters, renames)
     if compute_conservation_laws:
         if _events:
             raise NotImplementedError(
@@ -399,12 +418,14 @@ def ode_model_from_pysb_importer(
         ode,
         observation_model,
         pysb_model_has_obs_and_noise,
+        renames,
     )
     _process_pysb_expressions(
         model,
         ode,
         observation_model,
         pysb_model_has_obs_and_noise,
+        renames,
     )
 
     for event in _events or []:
@@ -416,7 +437,7 @@ def ode_model_from_pysb_importer(
         for channel in observation_model.values()
     )
 
-    _process_stoichiometric_matrix(model, ode, fixed_parameters)
+    _process_stoichiometric_matrix(model, ode, fixed_parameters, renames)
 
     ode.generate_basic_variables()
 
@@ -425,7 +446,10 @@ def ode_model_from_pysb_importer(
 
 @log_execution_time("processing PySB stoich. matrix", logger)
 def _process_stoichiometric_matrix(
-    pysb_model: pysb.Model, ode_model: DEModel, fixed_parameters: list[str]
+    pysb_model: pysb.Model,
+    ode_model: DEModel,
+    fixed_parameters: list[str],
+    renames: dict[str, str],
 ) -> None:
     """
     Exploits the PySB stoichiometric matrix to generate xdot derivatives
@@ -438,6 +462,10 @@ def _process_stoichiometric_matrix(
 
     :param fixed_parameters:
         list of model variables excluded from sensitivity analysis
+
+    :param renames:
+        mapping from a PySB-chosen name to a non-colliding replacement, see
+        `resolve_reserved_symbol_renames`
     """
 
     x = ode_model.sym("x")
@@ -479,7 +507,7 @@ def _process_stoichiometric_matrix(
                 values = dflux_dw_dict
 
             values[(ir, idx)] = sp.diff(
-                _expr_to_amici(rxn["rate"]), x_rdata[ix]
+                _expr_to_amici(rxn["rate"], renames), x_rdata[ix]
             )
 
         # typically <= 3 free symbols in rate, we already account for
@@ -502,9 +530,13 @@ def _process_stoichiometric_matrix(
                 continue
 
             idx = get_cached_index(
-                symbol_with_assumptions(fs.name), var, idx_cache
+                symbol_with_assumptions(renames.get(fs.name, fs.name)),
+                var,
+                idx_cache,
             )
-            values[(ir, idx)] = _expr_to_amici(sp.diff(rxn["rate"], fs))
+            values[(ir, idx)] = _expr_to_amici(
+                sp.diff(rxn["rate"], fs), renames
+            )
 
     dflux_dx = sp.ImmutableSparseMatrix(n_r, n_x, dflux_dx_dict)
     dflux_dw = sp.ImmutableSparseMatrix(n_r, n_w, dflux_dw_dict)
@@ -525,7 +557,11 @@ def _process_stoichiometric_matrix(
 
 
 @log_execution_time("processing PySB species", logger)
-def _process_pysb_species(pysb_model: pysb.Model, ode_model: DEModel) -> None:
+def _process_pysb_species(
+    pysb_model: pysb.Model,
+    ode_model: DEModel,
+    renames: dict[str, str],
+) -> None:
     """
     Converts pysb Species into States and adds them to the DEModel instance
 
@@ -534,9 +570,13 @@ def _process_pysb_species(pysb_model: pysb.Model, ode_model: DEModel) -> None:
 
     :param ode_model:
         DEModel instance
+
+    :param renames:
+        mapping from a PySB-chosen name to a non-colliding replacement, see
+        `resolve_reserved_symbol_renames`
     """
     xdot = sp.Matrix(pysb_model.odes)
-    xdot = _expr_to_amici(xdot)
+    xdot = _expr_to_amici(xdot, renames)
 
     for ix, specie in enumerate(pysb_model.species):
         init = sp.sympify("0.0")
@@ -550,7 +590,7 @@ def _process_pysb_species(pysb_model: pysb.Model, ode_model: DEModel) -> None:
                 else:
                     init = ic.value
 
-        init = _expr_to_amici(init)
+        init = _expr_to_amici(init, renames)
         ode_model.add_component(
             DifferentialState(
                 symbol_with_assumptions(f"__s{ix}"),
@@ -567,6 +607,7 @@ def _process_pysb_parameters(
     pysb_model: pysb.Model,
     ode_model: DEModel,
     fixed_parameters: list[str],
+    renames: dict[str, str],
 ) -> None:
     """
     Converts pysb parameters into Parameters or Constants and adds them to
@@ -580,9 +621,14 @@ def _process_pysb_parameters(
 
     :param ode_model:
         DEModel instance
+
+    :param renames:
+        mapping from a PySB-chosen name to a non-colliding replacement, see
+        `resolve_reserved_symbol_renames`
     """
     for par in pysb_model.parameters:
-        args = [symbol_with_assumptions(par.name), par.name]
+        symbol = symbol_with_assumptions(renames.get(par.name, par.name))
+        args = [symbol, par.name]
         if par.name in fixed_parameters:
             comp = FixedParameter
             args.append(par.value)
@@ -599,6 +645,7 @@ def _process_pysb_expressions(
     ode_model: DEModel,
     observation_model: dict[str, MeasurementChannel],
     pysb_model_has_obs_and_noise: bool = False,
+    renames: dict[str, str] | None = None,
 ) -> None:
     r"""
     Converts pysb expressions/observables into Observables (with
@@ -619,6 +666,10 @@ def _process_pysb_expressions(
     :param pysb_model_has_obs_and_noise:
         if set to ``True``, the pysb model is expected to have extra
         observables and noise variables added
+
+    :param renames:
+        mapping from a PySB-chosen name to a non-colliding replacement, see
+        `resolve_reserved_symbol_renames`
     """
     # we no longer expand expressions here. pysb/bng guarantees that
     # they are ordered according to their dependency and we can
@@ -646,6 +697,7 @@ def _process_pysb_expressions(
             ode_model,
             observation_model,
             pysb_model_has_obs_and_noise,
+            renames,
         )
 
 
@@ -656,6 +708,7 @@ def _add_expression(
     ode_model: DEModel,
     observation_model: dict[str, MeasurementChannel],
     pysb_model_has_obs_and_noise: bool = False,
+    renames: dict[str, str] | None = None,
 ):
     """
     Adds expressions to the ODE model given and adds observables/sigmas if
@@ -679,7 +732,15 @@ def _add_expression(
     :param pysb_model_has_obs_and_noise:
         if set to ``True``, the pysb model is expected to have extra
         observables and noise variables added
+
+    :param renames:
+        mapping from a PySB-chosen name to a non-colliding replacement, see
+        `resolve_reserved_symbol_renames`
     """
+    renames = renames or {}
+    # `name` stays the original (used for `observation_model` lookups and
+    # as the human-readable label); only the identifier is renamed
+    sym_name = renames.get(name, name)
     if not pysb_model_has_obs_and_noise or name not in observation_model:
         if any(
             name == str(channel.sigma)
@@ -688,15 +749,15 @@ def _add_expression(
             component = SigmaY
         else:
             component = Expression
-        expr = _parse_special_functions(_expr_to_amici(expr))
+        expr = _parse_special_functions(_expr_to_amici(expr, renames))
         ode_model.add_component(
-            component(symbol_with_assumptions(name), name, expr)
+            component(symbol_with_assumptions(sym_name), name, expr)
         )
 
     if name in observation_model:
         noise_dist = observation_model[name].noise_distribution
 
-        y = symbol_with_assumptions(name)
+        y = symbol_with_assumptions(sym_name)
         trafo = noise_distribution_to_observable_transformation(noise_dist)
         # note that this is a bit iffy since we are potentially using the same
         # _symbolic identifier in expressions (w) and observables (y).
@@ -705,7 +766,7 @@ def _add_expression(
         # If this changes, I would expect symbol redefinition warnings in CPP
         # models and overwriting in JAX models, but as both symbols refer to
         # the same _symbolic entity, this should not be a problem (untested)
-        expr = _parse_special_functions(_expr_to_amici(expr))
+        expr = _parse_special_functions(_expr_to_amici(expr, renames))
         obs = Observable(y, name, expr, transformation=trafo)
         ode_model.add_component(obs)
 
@@ -713,7 +774,7 @@ def _add_expression(
         if isinstance(sigma_name, sp.Symbol):
             sigma_name = sigma_name.name
 
-        sigma = _get_sigma(pysb_model, name, sigma_name)
+        sigma = _get_sigma(pysb_model, name, sigma_name, renames)
         if not pysb_model_has_obs_and_noise:
             ode_model.add_component(
                 SigmaY(sigma, f"sigma_{name}", sp.Float(1.0))
@@ -731,7 +792,7 @@ def _add_expression(
                 )
             ),
         )
-        cost_fun_expr = _expr_to_amici(cost_fun_expr)
+        cost_fun_expr = _expr_to_amici(cost_fun_expr, renames)
         ode_model.add_component(
             LogLikelihoodY(
                 symbol_with_assumptions(f"llh_{name}"),
@@ -742,7 +803,10 @@ def _add_expression(
 
 
 def _get_sigma(
-    pysb_model: pysb.Model, obs_name: str, sigma_name: str | None
+    pysb_model: pysb.Model,
+    obs_name: str,
+    sigma_name: str | None,
+    renames: dict[str, str] | None = None,
 ) -> sp.Symbol:
     """
     Tries to extract standard deviation _symbolic identifier and formula
@@ -759,6 +823,10 @@ def _get_sigma(
         Name of a :class:`pysb.core.Expression` that should be mapped to a
         sigma or ``None``.
 
+    :param renames:
+        mapping from a PySB-chosen name to a non-colliding replacement, see
+        `resolve_reserved_symbol_renames`
+
     :return:
         _symbolic variable representing the standard deviation of the observable
     """
@@ -766,7 +834,7 @@ def _get_sigma(
         return symbol_with_assumptions(f"sigma_{obs_name}")
 
     if sigma_name in pysb_model.expressions.keys():
-        return _expr_to_amici(pysb_model.expressions[sigma_name])
+        return _expr_to_amici(pysb_model.expressions[sigma_name], renames)
 
     raise ValueError(f"value of sigma {obs_name} is not a valid expression.")
 
@@ -777,6 +845,7 @@ def _process_pysb_observables(
     ode_model: DEModel,
     observation_model: dict[str, MeasurementChannel],
     pysb_model_has_obs_and_noise: bool = False,
+    renames: dict[str, str] | None = None,
 ) -> None:
     """
     Converts :class:`pysb.core.Observable` into
@@ -795,6 +864,10 @@ def _process_pysb_observables(
     :param pysb_model_has_obs_and_noise:
         if set to ``True``, the pysb model is expected to have extra
         observables and noise variables added
+
+    :param renames:
+        mapping from a PySB-chosen name to a non-colliding replacement, see
+        `resolve_reserved_symbol_renames`
     """
     # only add those pysb observables that occur in the added
     # Observables as expressions
@@ -806,6 +879,7 @@ def _process_pysb_observables(
             ode_model,
             observation_model,
             pysb_model_has_obs_and_noise,
+            renames,
         )
 
 

--- a/python/sdist/amici/importers/sbml/__init__.py
+++ b/python/sdist/amici/importers/sbml/__init__.py
@@ -49,7 +49,6 @@ from amici.constants import SymbolId
 from amici.importers.sbml.splines import AbstractSpline
 from amici.importers.sbml.utils import SBMLException
 from amici.importers.utils import (
-    RESERVED_SYMBOLS,
     MeasurementChannel,
     _check_unsupported_functions,
     _default_simplify,
@@ -65,6 +64,7 @@ from amici.importers.utils import (
     generate_regularization_symbol,
     noise_distribution_to_cost_function,
     noise_distribution_to_observable_transformation,
+    resolve_reserved_symbol_renames,
     sbml_time_symbol,
     smart_subs,
     smart_subs_dict,
@@ -2825,27 +2825,16 @@ class SbmlImporter:
         The original id is kept so it can be restored for anything reported
         outward (state/parameter ids, PEtab mapping, ...).
         """
-        self._reserved_symbol_original_ids: dict[str, str] = {}
         all_names = {
             s.name for symbols in self._symbols.values() for s in symbols
         }
+        renames = resolve_reserved_symbol_renames(all_names)
+        self._reserved_symbol_original_ids = {
+            new_name: old_name for old_name, new_name in renames.items()
+        }
 
-        for sym in RESERVED_SYMBOLS:
-            old_symbol = symbol_with_assumptions(sym)
-            if not any(
-                old_symbol in symbols for symbols in self._symbols.values()
-            ):
-                continue
-
-            # the model may already define e.g. "amici_t" itself; keep
-            # trying suffixes until we land on a name that's actually free
-            new_name, n = f"amici_{sym}", 2
-            while new_name in all_names:
-                new_name = f"amici_{sym}_{n}"
-                n += 1
-            all_names.add(new_name)
-            self._reserved_symbol_original_ids[new_name] = sym
-
+        for old_name, new_name in renames.items():
+            old_symbol = symbol_with_assumptions(old_name)
             new_symbol = symbol_with_assumptions(new_name)
             self._replace_in_all_expressions(
                 old_symbol, new_symbol, replace_identifiers=True

--- a/python/sdist/amici/importers/utils.py
+++ b/python/sdist/amici/importers/utils.py
@@ -48,6 +48,43 @@ RESERVED_SYMBOLS = [
 ]
 
 
+def resolve_reserved_symbol_renames(all_names: set[str]) -> dict[str, str]:
+    """
+    Decide non-colliding replacement names for any of ``RESERVED_SYMBOLS``
+    that collide with a name already in use in the model.
+
+    Each importer is responsible for actually renaming the corresponding
+    symbol everywhere it's used (before it's embedded in any expression)
+    and for recording the mapping so the original id can be restored for
+    anything reported outward (state/parameter ids, PEtab mapping, ...).
+
+    :param all_names:
+        every symbol name already used in the model. Used both to detect
+        which reserved names actually collide, and to disambiguate the
+        replacement (e.g. if the model already defines "amici_t" itself).
+
+    :return:
+        mapping from a colliding reserved name to a new, guaranteed-free
+        replacement name (``amici_{name}``, or ``amici_{name}_{n}`` if
+        that's already taken too). Only contains entries for names that
+        actually collide with something in ``all_names``.
+    """
+    all_names = set(all_names)  # local copy; we add newly chosen names below
+    renames: dict[str, str] = {}
+    for sym in RESERVED_SYMBOLS:
+        if sym not in all_names:
+            continue
+
+        new_name, n = f"amici_{sym}", 2
+        while new_name in all_names:
+            new_name = f"amici_{sym}_{n}"
+            n += 1
+        all_names.add(new_name)
+        renames[sym] = new_name
+
+    return renames
+
+
 class SBMLException(Exception):
     """Exception for SBML related errors.
 
@@ -1123,15 +1160,24 @@ def contains_periodic_subexpression(expr: sp.Expr, symbol: sp.Symbol) -> bool:
     return False
 
 
-def _expr_to_amici(expr: sp.Basic | sp.MatrixBase):
+def _expr_to_amici(
+    expr: sp.Basic | sp.MatrixBase, renames: dict[str, str] | None = None
+):
     """Convert the given sympy expression to an AMICI-compatible expression.
 
-    Replaces all symbols by plain sympy symbols with the expected assumptions.
+    Replaces all symbols by plain sympy symbols with the expected
+    assumptions.
 
     :param expr: The sympy expression to convert.
+    :param renames:
+        optional mapping from a symbol's current name to a replacement
+        name (e.g. from `resolve_reserved_symbol_renames`), applied while
+        converting.
     :return: The AMICI-compatible sympy expression.
     """
+    renames = renames or {}
     replacements = {
-        s: symbol_with_assumptions(s.name) for s in expr.free_symbols
+        s: symbol_with_assumptions(renames.get(s.name, s.name))
+        for s in expr.free_symbols
     }
     return expr.xreplace(replacements)

--- a/python/tests/test_bngl.py
+++ b/python/tests/test_bngl.py
@@ -87,15 +87,6 @@ def test_compare_to_pysb_simulation(example):
                     compute_conservation_laws=True,
                 )
 
-        if example in ["empty_compartments_block", "motor"]:
-            # these define a model quantity literally named "k"/"w" --
-            # reserved AMICI array-parameter names. Unlike SBML import,
-            # PySB/BNGL import has no automatic rename-and-restore for
-            # reserved names, so this is expected to fail outright.
-            with pytest.raises(ValueError, match="Cannot add"):
-                bngl2amici(model_file, output_dir=outdir, **kwargs)
-            return
-
         bngl2amici(model_file, output_dir=outdir, **kwargs)
 
         amici_model_module = import_model_module(pysb_model.name, outdir)

--- a/python/tests/test_pysb.py
+++ b/python/tests/test_pysb.py
@@ -413,10 +413,7 @@ def test_pysb_event(tempdir):
     model = pysb.Model("pysb_event_test")
     a = pysb.Monomer("A")
     pysb.Initial(a(), pysb.Parameter("a0"))
-    # "k" is reserved (it's one of AMICI's fixed array-parameter names);
-    # unlike SBML import, PySB import has no automatic rename-and-restore
-    # for reserved names, so it must be avoided here
-    pysb.Rule("deg", a() >> None, pysb.Parameter("kk", 1.0))
+    pysb.Rule("deg", a() >> None, pysb.Parameter("k", 1.0))
 
     events = [
         Event(
@@ -454,3 +451,46 @@ def test_pysb_event(tempdir):
     np.testing.assert_allclose(
         amici_model.simulate().x, np.array([[0.0], [0.0], [1000.0]])
     )
+
+
+@skip_on_valgrind
+def test_pysb_reserved_names(tempdir):
+    """Model quantities literally named one of AMICI's reserved
+    array-parameter names (x, p, k, h, w, y) are renamed internally and
+    have their original ids restored everywhere they're reported --
+    mirrors SBML import's handling of the same collision class, see
+    test_reserved_symbols.py."""
+    pysb.SelfExporter.cleanup()  # reset pysb
+    pysb.SelfExporter.do_export = True
+
+    model = pysb.Model("pysb_reserved_names_test")
+    a = pysb.Monomer("A")
+    pysb.Initial(a(), pysb.Parameter("a0", 1.0))
+    pysb.Rule("deg", a() >> None, pysb.Parameter("p", 0.5))
+    # reference "p" here too, so its renamed symbol survives substitution
+    # into another expression
+    pysb.Expression("h", 2 * model.parameters["p"])
+    pysb.Observable("y", a())
+
+    outdir = tempdir
+    pysb2amici(
+        model,
+        outdir,
+        observation_model=[MeasurementChannel("y")],
+        compute_conservation_laws=False,
+    )
+
+    model_module = import_model_module(
+        module_name=model.name, module_path=outdir
+    )
+    amici_model = model_module.get_model()
+
+    assert amici_model.get_observable_ids() == ("y",)
+    assert "p" in amici_model.get_free_parameter_ids()
+    assert "h" in amici_model.get_expression_ids()
+
+    amici_model.set_timepoints([0, 1, 2])
+    solver = amici_model.create_solver()
+    rdata = run_simulation(amici_model, solver)
+    assert rdata.status == amici.sim.sundials.AMICI_SUCCESS
+    assert np.all(np.isfinite(rdata.x))


### PR DESCRIPTION
A model quantity literally named one of AMICI's reserved array-parameter
names (`t, x, p, k, h, w, y`) used to hit a hard `ValueError` on PySB/BNGL
import, since only `SbmlImporter` renamed and restored these names before
embedding them anywhere. This applies the same rename-and-restore at
PySB's own symbol-minting sites (parameters, expressions/observables, and
the stoichiometric matrix's derivative computation), sharing the
disambiguation logic with SBML via a new `resolve_reserved_symbol_renames`
helper.

- Drops the `test_pysb_event` `"kk"` workaround.
- Drops the `empty_compartments_block`/`motor` BNGL expected-failure
  special case -- both now import and simulate successfully.
- Adds a dedicated regression test (`test_pysb_reserved_names`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)