### PR TITLE
CI: Add clang matrix leg to performance test workflow

### DIFF
--- a/.github/workflows/test_performance.yml
+++ b/.github/workflows/test_performance.yml
@@ -8,13 +8,18 @@ on:
 
 jobs:
   build:
-    name: Performance Test
+    name: Performance Test (${{ matrix.compiler }})
 
     runs-on: ubuntu-24.04
 
     strategy:
       matrix:
         python-version: ["3.12"]
+        compiler: [gcc, clang]
+
+    env:
+      CC: ${{ matrix.compiler == 'clang' && 'clang' || 'gcc' }}
+      CXX: ${{ matrix.compiler == 'clang' && 'clang++' || 'g++' }}
 
     steps:
     - uses: dweindl/gha-runner-diagnostics@v1
@@ -30,6 +35,10 @@ jobs:
 
     - name: Install apt dependencies
       uses: ./.github/actions/install-apt-dependencies
+
+    - name: Install clang
+      if: matrix.compiler == 'clang'
+      run: sudo apt-get install -y clang
 
     - run: pip3 install petab shyaml build scipy
 


### PR DESCRIPTION
Run the performance test workflow with both gcc and clang.

:eyes: https://github.com/dweindl/AMICI/actions/runs/33918032303/job/101169658788