### PR TITLE
Substitute spline function calls for proper spl/sspl/dspl symbols

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,14 @@ See also our [versioning policy](https://amici.readthedocs.io/en/latest/versioni
   source directly, expect different local variable names (#2226, #2461,
   #3237).
 
+* Fixed splines being treated as unconditionally time-dependent via
+  fragile string matching, rather than through AMICI's normal symbolic
+  dependency tracking, when determining which expressions need to be
+  recomputed at every simulation step vs. only once. Models combining a
+  spline with an event trigger that depends on it now raise a clear error
+  at import time instead of silently generating incorrect C++, since
+  simulating such models is not yet supported (#3245).
+
 ### v1.1 (2026-09-03)
 
 **BREAKING CHANGES**

--- a/python/sdist/amici/_symbolic/de_model.py
+++ b/python/sdist/amici/_symbolic/de_model.py
@@ -724,17 +724,126 @@ class DEModel:
         Returns (and constructs if necessary) the formulas for a symbolic
         entity.
 
+        Unlike `_eq_raw`, any `AmiciSpline`/`AmiciSplineDerivative`/
+        `AmiciSplineSensitivity` function calls occurring in the formulas are
+        substituted for the corresponding `spl`/`dspl`/`sspl` symbols. This
+        is the accessor that must be used by anything other than the small
+        set of internal call sites that differentiate `w` itself (which need
+        the un-substituted `Function` form intact for sympy to apply the
+        correct chain rule) -- see `_eq_raw`.
+
+        The substituted result is deliberately NOT cached separately from
+        `self._eqs`: some equations (e.g. `dydx`) are computed by mutating
+        `self._eqs[name]` in place across multiple reentrant calls, e.g. via
+        `sym_or_eq`, which may call `self.eq(name)` for the very `name`
+        that's still being computed, to obtain an intermediate partial
+        result. Caching a substituted snapshot from such a reentrant call
+        would freeze a stale, incomplete value under `name` once the
+        computation of `self._eqs[name]` later continues.
+
         :param name:
             name of the symbolic variable
 
         :return:
             matrix of symbolic formulas
         """
+        raw = self._eq_raw(name)
+        if not self._splines or name in ("spl", "sspl", "dspl"):
+            return raw
 
+        substituted = self._substitute_splines(raw)
+        if self._contains_dspl(substituted):
+            raise NotImplementedError(
+                f"Model uses a spline in an expression that depends on "
+                f"its time derivative (encountered while computing "
+                f"'{name}'). This typically means an event trigger "
+                f"depends on a time-varying spline, which is not yet "
+                f"supported."
+            )
+        return substituted
+
+    def _eq_raw(self, name: str) -> sp.Matrix:
+        """
+        Returns (and constructs if necessary) the formulas for a symbolic
+        entity, without substituting spline function calls for symbols.
+
+        This must only be used internally, by code that differentiates `w`
+        (the only named equation whose un-substituted `Function`-call form
+        is required for correct further differentiation) -- see `eq`.
+
+        :param name:
+            name of the symbolic variable
+
+        :return:
+            matrix of symbolic formulas
+        """
         if name not in self._eqs:
             dec = log_execution_time(f"computing {name}", logger)
             dec(self._compute_equation)(name)
         return self._eqs[name]
+
+    def _contains_dspl(self, expr) -> bool:
+        """
+        Returns whether ``expr`` (as returned by `_substitute_splines`)
+        contains any `self.sym("dspl")` entry. ``expr`` may be a plain
+        matrix or, for equations defined per-event, a list of matrices.
+        """
+        if isinstance(expr, list):
+            return any(self._contains_dspl(e) for e in expr)
+        return expr.has(*self.sym("dspl"))
+
+    def _substitute_splines(self, expr: sp.Matrix):
+        """
+        Substitutes ``AmiciSpline``/``AmiciSplineDerivative``/
+        ``AmiciSplineSensitivity`` function calls (see
+        :mod:`amici.importers.sbml.splines`) in ``expr`` for the
+        corresponding ``self.sym("spl")``/``self.sym("dspl")``/
+        ``self.sym("sspl")`` entries.
+
+        Matching is done by function-class name (``e.func.__name__``), not
+        by ``isinstance``/class identity: `AmiciSplineDerivative` and
+        `AmiciSplineSensitivity` are freshly defined nested classes on every
+        ``fdiff()`` call, so no single saved class reference would match all
+        occurrences.
+
+        :param expr:
+            expression (or matrix of expressions) that may contain spline
+            function calls; equations defined per-event are lists of
+            matrices instead of a single matrix, and are handled by
+            recursing over the list
+
+        :return:
+            ``expr`` with all spline function calls replaced by symbols
+        """
+        if isinstance(expr, list):
+            return [self._substitute_splines(e) for e in expr]
+
+        spline_index = {
+            spline.sbml_id: i for i, spline in enumerate(self._splines)
+        }
+        param_index = {sym: i for i, sym in enumerate(self.sym("p"))}
+
+        def repl(e: sp.Function) -> sp.Symbol:
+            idx = spline_index[e.args[0]]
+            if e.func.__name__ == "AmiciSpline":
+                return self.sym("spl")[idx]
+            if e.func.__name__ == "AmiciSplineDerivative":
+                return self.sym("dspl")[idx]
+            # AmiciSplineSensitivity(spline_id, x, param_id, *params)
+            return self.sym("sspl")[idx, param_index[e.args[2]]]
+
+        return expr.replace(
+            lambda e: (
+                isinstance(e, sp.Function)
+                and e.func.__name__
+                in (
+                    "AmiciSpline",
+                    "AmiciSplineDerivative",
+                    "AmiciSplineSensitivity",
+                )
+            ),
+            repl,
+        )
 
     def sparseeq(self, name) -> sp.Matrix:
         """
@@ -859,31 +968,16 @@ class DEModel:
             # to check for other time-dependence, we add a column to the dwdx
             #  matrix
             dynamic_syms = [
-                # FIXME: see spline comment below
-                # *self.sym("spl"),
+                *self.sym("spl"),
                 *self.sym("h"),
                 amici_time_symbol,
             ]
             dynamic_dependency = np.hstack(
                 (
                     dynamic_dependency,
-                    np.array(
-                        [
-                            expr.has(*dynamic_syms)
-                            # FIXME: the current spline implementation is a giant pita
-                            #  currently, the splines occur in the form of sympy functions, e.g.:
-                            #   AmiciSpline(y0, time, y0_3, y0_1)
-                            #   AmiciSplineSensitivity(y0, time, y0_1, y0_3, y0_1)
-                            #  until it uses the proper self.sym("spl") / self.sym("sspl")
-                            #  symbols, which will require quite some refactoring,
-                            #  we just do dumb string checks :|
-                            or (
-                                bool(self._splines)
-                                and "AmiciSpline" in str(expr)
-                            )
-                            for expr in w
-                        ]
-                    )[:, np.newaxis],
+                    np.array([expr.has(*dynamic_syms) for expr in w])[
+                        :, np.newaxis
+                    ],
                 )
             )
 
@@ -918,9 +1012,9 @@ class DEModel:
                 amici_time_symbol,
                 *self.sym("x"),
                 *self.sym("h"),
-                # FIXME see spline comment above
-                # *(self.sym("spl") if name in ("dwdw", "dwdx") else ()),
-                # *(self.sym("sspl") if name == "dwdp" else ()),
+                *(self.sym("spl") if name in ("dwdw", "dwdx") else ()),
+                *(self.sym("sspl") if name == "dwdp" else ()),
+                *self.sym("dspl"),
             ]
             dynamic_syms = sp.Matrix(dynamic_syms)
             rowvals = self.rowvals(name)
@@ -937,26 +1031,15 @@ class DEModel:
                 if row_idx in static_indices_w
                 # constant expressions
                 or expr.is_Number
-                # check for dependencies on non-static entities
-                or (
-                    # FIXME see spline comment above
-                    #  (check str before diff, as diff will fail on spline functions)
-                    (
-                        # splines: non-static
-                        not self._splines or "AmiciSpline" not in str(expr)
-                    )
-                    and (
-                        # If the expression contains dynamic symbols, it might
-                        # still be static. However, checking the derivative
-                        # is currently too expensive, and we rather accept
-                        # false negatives.
-                        not expr.has(*dynamic_syms)
-                        # or all(
-                        #     expr.diff(dyn_sym).is_zero
-                        #     for dyn_sym in dynamic_syms
-                        # )
-                    )
-                )
+                # check for dependencies on non-static entities.
+                # If the expression contains dynamic symbols, it might still
+                # be static. However, checking the derivative is currently
+                # too expensive, and we rather accept false negatives.
+                or not expr.has(*dynamic_syms)
+                # or all(
+                #     expr.diff(dyn_sym).is_zero
+                #     for dyn_sym in dynamic_syms
+                # )
             ]
             return self._static_indices[name]
 
@@ -1129,6 +1212,13 @@ class DEModel:
                 ]
             )
             return
+        elif name == "dspl":
+            # placeholders for spline time derivatives. Need to create
+            # symbols
+            self._syms[name] = sp.Matrix(
+                [[f"dspl_{isp}" for isp in range(len(self._splines))]]
+            )
+            return
         elif name == "ih":
             self._syms[name] = sp.Matrix(
                 [
@@ -1170,7 +1260,7 @@ class DEModel:
             if var not in self._syms:
                 self._generate_symbol(var)
         # symbols for spline values need to be created in addition
-        for var in ["spl", "sspl"]:
+        for var in ["spl", "sspl", "dspl"]:
             self._generate_symbol(var)
 
         self._generate_symbol("x")
@@ -1542,6 +1632,10 @@ class DEModel:
             # force symbols
             self._eqs[name] = self.sym(name)
 
+        elif name == "dspl":
+            # force symbols
+            self._eqs[name] = self.sym(name)
+
         elif name == "spline_values":
             # force symbols
             self._eqs[name] = sp.Matrix(
@@ -1583,7 +1677,9 @@ class DEModel:
             # += drootdw * dwdt_total
             if not smart_is_zero_matrix(drootdw := self.eq("drootdw")):
                 dwdt = self.eq("dwdt")
-                dwdx_explicit = smart_jacobian(self.eq("w"), self.sym("x"))
+                dwdx_explicit = smart_jacobian(
+                    self._eq_raw("w"), self.sym("x")
+                )
                 dwdt_total = dwdt + smart_multiply(dwdx_explicit, xdot)
                 self._eqs[name] += smart_multiply(drootdw, dwdt_total)
 
@@ -1828,8 +1924,8 @@ class DEModel:
                     reversed(self.conservation_laws()),
                 )
             )
-            actual = self.eq("w")[: self.num_cons_law()]
-            # `self.eq("w")` has been passed through `self._simplify`, whereas
+            actual = self._eq_raw("w")[: self.num_cons_law()]
+            # `self._eq_raw("w")` has been passed through `self._simplify`, whereas
             # `ConservationLaw.get_x_rdata` returns the unsimplified expression.
             # Apply the same simplification to the expected `x_rdata`
             # reconstruction before comparing, so that mathematically
@@ -1854,11 +1950,11 @@ class DEModel:
                     for cl in reversed(self._conservation_laws)
                 ]
             ).col_join(
-                smart_jacobian(self.eq("w")[self.num_cons_law() :, :], x)
+                smart_jacobian(self._eq_raw("w")[self.num_cons_law() :, :], x)
             )
 
         elif name == "dwdt":
-            self._eqs[name] = smart_jacobian(self.eq("w"), time_symbol)
+            self._eqs[name] = smart_jacobian(self._eq_raw("w"), time_symbol)
 
         elif name == "iroot":
             self._eqs[name] = sp.Matrix(
@@ -2022,7 +2118,15 @@ class DEModel:
             return
 
         # partial derivative
-        sym_eq = self.eq(eq).transpose() if eq == "Jy" else self.eq(eq)
+        if eq == "w":
+            # differentiating `w` requires the un-substituted spline
+            # `Function`-call form for sympy to apply the correct chain
+            # rule (see `_eq_raw`)
+            sym_eq = self._eq_raw(eq)
+        elif eq == "Jy":
+            sym_eq = self.eq(eq).transpose()
+        else:
+            sym_eq = self.eq(eq)
 
         sym_var = self.sym(var)
 

--- a/python/sdist/amici/exporters/sundials/de_export.py
+++ b/python/sdist/amici/exporters/sundials/de_export.py
@@ -218,16 +218,6 @@ class DEExporter:
         # Signatures and properties of generated model functions (see
         # include/amici/model.h for details)
         self.model: DEModel = de_model
-        self._code_printer.known_functions.update(
-            splines._spline_user_functions(
-                self.model._splines,
-                {
-                    self._code_printer.mangle_identifier(name): index
-                    for name, index in self._get_index("p").items()
-                },
-                self._code_printer.mangle_identifier,
-            )
-        )
 
         # To only generate a subset of functions, apply subselection here
         self.functions: dict[str, _FunctionInfo] = copy.deepcopy(functions)
@@ -304,24 +294,6 @@ class DEExporter:
             CXX_MAIN_TEMPLATE_FILE, os.path.join(self.model_path, "main.cpp")
         )
 
-    def _get_index(self, name: str) -> dict[str, int]:
-        """
-        Compute indices for a symbolic array.
-        :param name:
-            key in self.model._syms for which to obtain the index.
-        :return:
-            a dictionary of symbol/index pairs.
-        """
-        if name in self.model.sym_names():
-            if name in sparse_functions:
-                symbols = self.model.sparsesym(name)
-            else:
-                symbols = self.model.sym(name).T
-        else:
-            raise ValueError(f"Unknown symbolic array: {name}")
-
-        return {symbol.name: index for index, symbol in enumerate(symbols)}
-
     def _get_local_declarations(
         self, name: str, is_used: Callable[[str], bool] | None = None
     ) -> list[str]:
@@ -336,16 +308,13 @@ class DEExporter:
             called with a candidate entry's mangled name; entries for which
             this returns ``False`` are skipped. If ``None``, a declaration
             is generated for every (non-zero) entry. Usage is checked
-            against the printed code rather than the symbolic equations,
-            since some entries (e.g. spline (sensitivity) values) are only
-            ever referenced via a custom print function, never appearing
-            as a plain symbol in the equations themselves.
-
-            TODO: once splines no longer need a custom print function for
-            this (i.e. spline (sensitivity) values are represented as
-            regular symbols in the equations), this can go back to a plain
-            ``equations.free_symbols`` set instead of matching against
-            printed text.
+            against the printed code rather than the symbolic equations:
+            ``"create_splines"``/``"explicit_roots"`` bodies aren't backed
+            by a single symbolic equations matrix at all (they're built
+            directly from ``AbstractSpline``/event objects), so there is no
+            uniform ``equations.free_symbols`` set to check against for
+            every function this is called for -- matching against the
+            printed text works uniformly across all of them.
         """
         if name not in self.model.sym_names():
             raise ValueError(f"Unknown symbolic array: {name}")

--- a/python/sdist/amici/importers/sbml/__init__.py
+++ b/python/sdist/amici/importers/sbml/__init__.py
@@ -2720,6 +2720,18 @@ class SbmlImporter:
                     field, smart_subs(self.__getattribute__(field), old, new)
                 )
 
+        # `self._splines` holds `AbstractSpline` objects, not sympy
+        # expressions living in one of the fields/dicts below, so it needs
+        # its own delegate. In particular, this is what propagates the
+        # sbml-time -> amici-time substitution (from `_process_time`, called
+        # after all rules -- including splines -- have been processed) into
+        # each spline's `evaluate_at`/nodes/values_at_nodes; without it,
+        # `evaluate_at` stays the SBML time symbol -- a distinct object from
+        # `amici_time_symbol` despite printing the same, silently breaking
+        # any differentiation with respect to time.
+        for spline in self._splines:
+            spline._replace_in_all_expressions(old, new)
+
         dictfields = [
             "_compartment_assignment_rules",
             "_parameter_assignment_rules",

--- a/python/sdist/amici/importers/sbml/splines.py
+++ b/python/sdist/amici/importers/sbml/splines.py
@@ -11,7 +11,7 @@ from __future__ import annotations
 from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
-    from collections.abc import Callable, Sequence
+    from collections.abc import Sequence
     from numbers import Real
     from typing import (
         Any,
@@ -1179,7 +1179,7 @@ class AbstractSpline(ABC):
     ) -> None:
         if self.sbml_id == old:
             self._sbml_id = new
-        self._x = self.evaluate_at.subs(old, new)
+        self._evaluate_at = self.evaluate_at.subs(old, new)
         if not isinstance(self.nodes, UniformGrid):
             self._nodes = [x.subs(old, new) for x in self.nodes]
         self._values_at_nodes = [
@@ -1484,49 +1484,6 @@ class AbstractSpline(ABC):
         if ylabel is not None:
             ax.set_ylabel(ylabel)
         return ax
-
-
-def _spline_user_functions(
-    splines: list[AbstractSpline],
-    p_index: dict[sp.Symbol, int],
-    mangle: Callable[[str], str],
-) -> dict[str, list[tuple[Callable[..., bool], Callable[..., str]]]]:
-    """
-    Custom user functions to be used in `ODEExporter`
-    for linking spline expressions to C++ code.
-
-    :param mangle:
-        The code printer's identifier mangling, applied here to match:
-        by the time these lambdas run, `spline_id`/`param_id` have already
-        been printed (i.e. mangled) by the code printer.
-    """
-    spline_ids = [mangle(spline.sbml_id.name) for spline in splines]
-    return {
-        "AmiciSpline": [
-            (
-                lambda *args: True,
-                lambda spline_id, x, *p: mangle(
-                    f"spl_{spline_ids.index(spline_id)}"
-                ),
-            )
-        ],
-        "AmiciSplineDerivative": [
-            (
-                lambda *args: True,
-                lambda spline_id, x, *p: mangle(
-                    f"dspl_{spline_ids.index(spline_id)}"
-                ),
-            )
-        ],
-        "AmiciSplineSensitivity": [
-            (
-                lambda *args: True,
-                lambda spline_id, x, param_id, *p: mangle(
-                    f"sspl_{spline_ids.index(spline_id)}_{p_index[param_id]}"
-                ),
-            )
-        ],
-    }
 
 
 class CubicHermiteSpline(AbstractSpline):

--- a/python/tests/test_de_model.py
+++ b/python/tests/test_de_model.py
@@ -1,8 +1,94 @@
+import libsbml
 import pytest
 import sympy as sp
+from amici import MeasurementChannel, SbmlImporter
 from amici._symbolic.de_model_components import Event, FreeParameter
+from amici.importers.antimony import antimony2sbml
+from amici.importers.sbml.splines import CubicHermiteSpline
 from amici.importers.utils import amici_time_symbol
 from amici.testing import skip_on_valgrind
+
+
+def _build_spline_model(*, with_spline_dependent_event: bool):
+    """Build a minimal `DEModel` with a single state and a single spline,
+    optionally with an event whose trigger depends on the spline's value.
+
+    Kept intentionally tiny and built via `_build_ode_model` directly (no
+    codegen/compilation) so these tests run fast.
+    """
+    event_line = (
+        "e1: at u > 1: x = x + 1;\n" if with_spline_dependent_event else ""
+    )
+    ant_str = rf"""
+    model spline_model
+        p1 = 1;
+        sp1 = 0;
+        sp2 = 2;
+        species x = 1;
+        x' = -p1*x + u;
+        var u = 0;
+        {event_line}
+    end
+    """
+    sbml_str = antimony2sbml(ant_str)
+    sbml_model = libsbml.SBMLReader().readSBMLFromString(sbml_str).getModel()
+
+    spline = CubicHermiteSpline(
+        sbml_id="u",
+        evaluate_at=amici_time_symbol,
+        nodes=[0, 10],
+        values_at_nodes=[sp.Symbol("sp1"), sp.Symbol("sp2")],
+        extrapolate=("constant", "constant"),
+    )
+    spline.add_to_sbml_model(sbml_model, auto_add=False)
+
+    importer = SbmlImporter(sbml_model)
+    model = importer._build_ode_model(
+        observation_model=[MeasurementChannel(id_="obs_x", formula="x")],
+    )
+    model.generate_basic_variables()
+    return model
+
+
+@skip_on_valgrind
+def test_spline_static_indices_and_substitution():
+    """Splines occur in the model as `AmiciSpline`/`AmiciSplineSensitivity`
+    sympy `Function` calls, which must be substituted for `spl`/`sspl`
+    symbols so `static_indices()` can classify spline-dependent rows as
+    dynamic without falling back to string matching (see the FIXMEs this
+    replaces)."""
+    model = _build_spline_model(with_spline_dependent_event=False)
+
+    # the spline's own row in `w` is time-varying and must not be static
+    w = model.eq("w")
+    static_w = set(model.static_indices("w"))
+    spline_row = next(
+        i for i, sym in enumerate(model.sym("w")) if str(sym) == "u"
+    )
+    assert spline_row not in static_w
+
+    # no raw spline Function calls should survive substitution anywhere
+    for name in ("w", "dwdx", "dwdw", "dwdp"):
+        eq = model.eq(name)
+        for entry in eq:
+            assert "AmiciSpline" not in str(entry)
+
+    # dwdp's entry for the spline row references the sensitivity symbols
+    assert set(model.sym("sspl")) & w[spline_row].free_symbols == set()
+    dwdp_spline_row = model.eq("dwdp")[spline_row, :]
+    assert set(model.sym("sspl")) & dwdp_spline_row.free_symbols
+
+
+@skip_on_valgrind
+def test_spline_derivative_in_event_not_supported():
+    """`AmiciSplineDerivative` (a spline's time derivative) has no C++
+    codegen support yet. A model where an event trigger depends on a
+    time-varying spline must fail loudly at import time instead of
+    silently generating C++ that references an undefined `dspl_N`."""
+    model = _build_spline_model(with_spline_dependent_event=True)
+
+    with pytest.raises(NotImplementedError, match="time derivative"):
+        model.eq("drootdt_total")
 
 
 @skip_on_valgrind


### PR DESCRIPTION
- Splines appear in equations as raw `AmiciSpline*`/`AmiciSplineSensitivity` sympy `Function` calls instead of the `spl`/`sspl` placeholder symbols already defined for them, forcing `DEModel.static_indices()` to fall back to matching `"AmiciSpline"` against `str(expr)`.
- Substitute these calls for proper `spl`/`dspl`/`sspl` symbols once `w`'s differentiation is complete (internal differentiation still uses the raw `Function` form via a new `_eq_raw()`, since sympy needs it intact for the chain rule). This lets `static_indices()` use plain `expr.has(...)` and removes the print-time `known_functions` workaround in `de_export.py`/`splines.py`.
- Also fixes a pre-existing bug: a spline's `evaluate_at` time symbol was never reconciled with `amici_time_symbol` after SBML annotation round-tripping, silently zeroing `dwdt` for any model where an event trigger depends on a spline. The substitution is propagated via `SbmlImporter._replace_in_all_expressions`, in lockstep with the rest of the model's sbml-time -> amici-time conversion (an earlier version of this fix applied it too early and broke a species-initial-value spline check that still expects the pre-conversion symbol at that point in the pipeline). Since `AmiciSplineDerivative` (`dspl`) has no C++ codegen support yet, a model hitting this now raises a clear `NotImplementedError` instead of silently generating broken C++.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


