### PR TITLE
Prevent sparse-Jacobian placeholder names from colliding with model entity ids

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,25 +14,27 @@ See also our [versioning policy](https://amici.readthedocs.io/en/latest/versioni
   with a C++ keyword, a standard-library macro (e.g. `NULL`, `EOF`), one
   of AMICI's fixed array-parameter names (`x`, `p`, `k`, `h`, `w`, `y`),
   or an AMICI-internally-derived symbol name (e.g. a reaction's own flux
-  symbol, a conservation-law total, or an observable's measurement/sigma
-  symbol). In particular, single-letter entity names used to be a common
-  source of such failures. All of these are now handled transparently:
-  colliding names are disambiguated or renamed internally, with the
-  original ID restored everywhere it's reported (state/parameter/
-  observable/expression IDs, PEtab mapping, ...) — for some single-letter
-  names, this internal renaming previously used an `amici_` prefix that
-  could itself leak into reported IDs; that prefix is now purely an
-  implementation detail and never visible to users. Generated C++ locals
-  are also never aliased across two different quantities that merely
-  happen to print the same name, and generated C++ files no longer rely
-  on unscoped `#define` macros for entity names either.
+  symbol, a conservation-law total, an observable's measurement/sigma
+  symbol, or a sparse-Jacobian placeholder like the `dwdx`/`dwdp`/
+  `dxdotdx_explicit` entries named `d{row}_d{col}`). In particular,
+  single-letter entity names used to be a common source of such failures.
+  All of these are now handled transparently: colliding names are
+  disambiguated or renamed internally, with the original ID restored
+  everywhere it's reported (state/parameter/observable/expression IDs,
+  PEtab mapping, ...) — for some single-letter names, this internal
+  renaming previously used an `amici_` prefix that could itself leak into
+  reported IDs; that prefix is now purely an implementation detail and
+  never visible to users. Generated C++ locals are also never aliased
+  across two different quantities that merely happen to print the same
+  name, and generated C++ files no longer rely on unscoped `#define`
+  macros for entity names either.
 
   As a side effect, the local variable names used internally in generated
   model code have changed (e.g. `STAT` is now printed as `STAT_`). This
   does not affect the public API — state/parameter/observable IDs are
   unaffected — but if you inspect or post-process AMICI-generated C++
   source directly, expect different local variable names (#2226, #2461,
-  #3237, #3240, #3243).
+  #3237, #3240, #3243, #3246).
 
 * Fixed splines being treated as unconditionally time-dependent via
   fragile string matching, rather than through AMICI's normal symbolic

--- a/python/sdist/amici/_symbolic/de_model.py
+++ b/python/sdist/amici/_symbolic/de_model.py
@@ -1401,6 +1401,16 @@ class DEModel:
             rownames = self.sym(eq)
             colnames = self.sym(var)
 
+        # every name already claimed in the model, so the placeholder names
+        # csc_matrix mints below can never alias an unrelated model entity
+        # that happens to share the same id (#3246); shared and mutated
+        # in-place across all csc_matrix calls below so they also can't
+        # collide with each other
+        taken_names = {
+            c.get_id() if isinstance(c, ModelQuantity) else c.sbml_id.name
+            for c in self._components
+        }
+
         if name == "dJydy":
             # One entry per y-slice
             self._colptrs[name] = []
@@ -1421,6 +1431,7 @@ class DEModel:
                     rownames=rownames,
                     colnames=colnames,
                     identifier=iy,
+                    taken_names=taken_names,
                 )
                 self._colptrs[name].append(symbol_col_ptrs)
                 self._rowvals[name].append(symbol_row_vals)
@@ -1439,6 +1450,7 @@ class DEModel:
                 rownames=rownames,
                 colnames=colnames,
                 pattern_only=name in nobody_functions,
+                taken_names=taken_names,
             )
 
             self._colptrs[name] = symbol_col_ptrs

--- a/python/sdist/amici/exporters/sundials/cxxcodeprinter.py
+++ b/python/sdist/amici/exporters/sundials/cxxcodeprinter.py
@@ -12,7 +12,11 @@ from sympy.printing.cxx import CXX11CodePrinter
 from sympy.utilities.iterables import numbered_symbols
 from toposort import toposort
 
-from amici.importers.utils import amici_time_symbol, symbol_with_assumptions
+from amici.importers.utils import (
+    amici_time_symbol,
+    make_name_unique,
+    symbol_with_assumptions,
+)
 
 
 def _mangle(name: str) -> str:
@@ -447,6 +451,7 @@ def csc_matrix(
     colnames: list[sp.Symbol],
     identifier: int | None = 0,
     pattern_only: bool | None = False,
+    taken_names: set[str] | None = None,
 ) -> tuple[list[int], list[int], sp.Matrix, list[sp.Symbol], sp.Matrix]:
     """
     Generates the sparse symbolic identifiers, symbolic identifiers,
@@ -470,6 +475,14 @@ def csc_matrix(
 
     :param pattern_only:
         flag for computing sparsity pattern without whole matrix
+
+    :param taken_names:
+        every name already claimed in the model so far; if given, each
+        placeholder name is disambiguated against it (and against
+        placeholders already minted in this call) via
+        :func:`amici.importers.utils.make_name_unique` before being minted,
+        so a placeholder can never alias an unrelated model entity that
+        happens to have the same id (see #3246). Mutated in place.
 
     :return:
         symbol_col_ptrs, symbol_row_vals, sparse_list, symbol_list,
@@ -496,6 +509,8 @@ def csc_matrix(
             symbol_name = f"d{rownames[row].name}_d{colnames[col].name}"
             if identifier:
                 symbol_name += f"_{identifier}"
+            if taken_names is not None:
+                symbol_name = make_name_unique(symbol_name, taken_names)
             symbol_list.append(symbol_with_assumptions(symbol_name))
             if pattern_only:
                 continue

--- a/python/tests/test_derived_symbol_collisions.py
+++ b/python/tests/test_derived_symbol_collisions.py
@@ -121,3 +121,40 @@ def test_conservation_law_and_observable_symbol_collisions(tempdir):
     assert "mobs1_2_ = my[0]" in jy
     assert "sigma_obs1_2_" in jy
     assert "mobs1_ " not in jy
+
+
+@skip_on_valgrind
+def test_sparse_jacobian_placeholder_collision(tempdir):
+    """A parameter literally named after the sparse-Jacobian placeholder
+    AMICI derives for some row/col pair (`d{row}_d{col}`, minted in
+    `csc_matrix`) must not collide with it -- the placeholder is
+    disambiguated instead.
+
+    Checked from generated source rather than by compiling, as in
+    test_conservation_law_and_observable_symbol_collisions above."""
+    model_name = "sparse_jac_placeholder_collision_test"
+    antimony2amici(
+        """
+        model test
+            compartment comp = 1;
+            species A in comp = 10;
+            species B in comp = 0;
+            r1: A -> B; 0.1*A;
+            dflux_r1_dA = 1;
+        end
+        """,
+        model_name=model_name,
+        output_dir=tempdir,
+        observation_model=None,
+        compute_conservation_laws=False,
+        compile=False,
+    )
+
+    # the original id of the colliding parameter is preserved
+    model_cpp = _generated_source(tempdir, f"{model_name}.cpp")
+    assert '"dflux_r1_dA"' in model_cpp
+
+    # the dwdx placeholder for d(flux_r1)/d(A) was disambiguated instead
+    dwdx = _generated_source(tempdir, "dwdx.cpp")
+    assert "dflux_r1_dA_2_ = dwdx[" in dwdx
+    assert "dflux_r1_dA_ =" not in dwdx


### PR DESCRIPTION
Fixes #3246.

Deferred edge case from #3247/#3240: sparse-Jacobian placeholder names (`d{row}_d{col}`, e.g. in `dwdx`/`dwdp`/`dxdotdx_explicit`) are minted the same way as model entities, so an entity literally named like a placeholder aliases it, producing a C++ redeclaration compile error.

`csc_matrix` now takes an optional `taken_names` set and disambiguates each placeholder against it via the existing `make_name_unique` helper; `DEModel._generate_sparse_symbol` passes in every currently-known entity name.

🤖 Generated with [Claude Code](https://claude.com/claude-code)