### PR TITLE
CI: sensitivity checks on SBML test suite

### DIFF
--- a/.github/workflows/test_sbml_semantic_test_suite.yml
+++ b/.github/workflows/test_sbml_semantic_test_suite.yml
@@ -46,6 +46,10 @@ jobs:
       uses: ./.github/actions/install-apt-dependencies
 
     - run: AMICI_PARALLEL_COMPILE="" ./scripts/installAmiciSource.sh
+
+    - name: Install test dependencies
+      run: python3 -m pip install --upgrade git+https://github.com/ICB-DCM/fiddy.git@main
+
     - run: AMICI_PARALLEL_COMPILE="" ./scripts/run-SBMLTestsuite.sh ${{ matrix.cases }}
     - run: mv tests/sbml/amici-semantic-results/results.json tests/sbml/amici-semantic-results/results_${{ matrix.cases }}.json
 

--- a/python/sdist/amici/adapters/fiddy.py
+++ b/python/sdist/amici/adapters/fiddy.py
@@ -179,7 +179,7 @@ def output_labels_for_derivatives(
 def run_simulation_to_function_and_derivative(
     amici_model: AmiciModel,
     *,
-    cache: bool = True,
+    cache: bool = False,
     free_parameter_ids: list[str] = None,
     amici_solver: AmiciSolver = None,
     amici_edata: AmiciExpData = None,
@@ -293,7 +293,7 @@ def simulate_petab_to_function_and_derivative(
     *,
     amici_model: Model,
     free_parameter_ids: list[str] = None,
-    cache: bool = True,
+    cache: bool = False,
     precreate_edatas: bool = True,
     precreate_parameter_mapping: bool = True,
     simulate_petab: Callable[[Any], str] = None,
@@ -416,7 +416,7 @@ def simulate_petab_v2_to_function_and_derivative(
     petab_simulator: PetabSimulator,
     *,
     free_parameter_ids: list[str] = None,
-    cache: bool = True,
+    cache: bool = False,
 ) -> tuple[Type.FUNCTION, Type.FUNCTION]:
     r"""Create a fiddy-checkable ``(function, derivative)`` pair for a
     `PetabSimulator`, e.g. for :func:`fiddy.check_gradient`.

--- a/tests/sbml/conftest.py
+++ b/tests/sbml/conftest.py
@@ -16,22 +16,35 @@ script_dir = Path(__file__).parent.resolve()
 if str(script_dir) not in sys.path:
     sys.path.insert(0, str(script_dir))
 
-# the two independently-reported checks per SBML semantic test suite case
+# the independently-reported checks per SBML semantic test suite case
 SIMULATION_CHECK = "test_sbml_testsuite_case"
-SENSITIVITY_CHECK = "test_sbml_testsuite_case_sensitivity"
+SENSITIVITY_FORWARD_CHECK = "test_sbml_testsuite_case_sensitivity_forward"
+SENSITIVITY_ADJOINT_CHECK = "test_sbml_testsuite_case_sensitivity_adjoint"
+SENSITIVITY_CONSISTENCY_CHECK = (
+    "test_sbml_testsuite_case_sensitivity_consistency"
+)
+CHECKS = (
+    SIMULATION_CHECK,
+    SENSITIVITY_FORWARD_CHECK,
+    SENSITIVITY_ADJOINT_CHECK,
+    SENSITIVITY_CONSISTENCY_CHECK,
+)
+# short suffix per check, used for the `results.json` field names
+_CHECK_SUFFIXES = {
+    SIMULATION_CHECK: "simulation",
+    SENSITIVITY_FORWARD_CHECK: "sensitivity_forward",
+    SENSITIVITY_ADJOINT_CHECK: "sensitivity_adjoint",
+    SENSITIVITY_CONSISTENCY_CHECK: "sensitivity_consistency",
+}
 
 # stores passed SBML semantic test suite IDs, by check
-passed_ids: dict[str, list[str]] = {
-    SIMULATION_CHECK: [],
-    SENSITIVITY_CHECK: [],
-}
+passed_ids: dict[str, list[str]] = {check: [] for check in CHECKS}
 # test tags we encountered (from the simulation check only -- that's what
 # the SBML test suite's own tag-support semantics are about)
 encountered_tags: set[str] = set()
 # failed/skipped tests with error message, by check
 failed_or_skipped_ids: dict[str, dict[str, str]] = {
-    SIMULATION_CHECK: {},
-    SENSITIVITY_CHECK: {},
+    check: {} for check in CHECKS
 }
 
 SBML_SEMANTIC_CASES_DIR = (
@@ -171,29 +184,25 @@ def write_passed_tags(passed_simulation_ids, out=sys.stdout):
         )
         out.write("  " + "\n  ".join(sorted(passed_test_tags)))
 
-    with open(RESULT_PATH / "results.json", "w") as f:
-        json.dump(
-            {
-                "supported_tags": sorted(
-                    passed_test_tags | passed_component_tags
-                ),
-                "encountered_tags": sorted(encountered_tags),
-                "passed_tests_simulation": sorted(passed_simulation_ids),
-                "passed_tests_sensitivity": sorted(
-                    passed_ids[SENSITIVITY_CHECK]
-                ),
-                "failed_or_skipped_simulation": {
-                    k: failed_or_skipped_ids[SIMULATION_CHECK][k]
-                    for k in sorted(failed_or_skipped_ids[SIMULATION_CHECK])
-                },
-                "failed_or_skipped_sensitivity": {
-                    k: failed_or_skipped_ids[SENSITIVITY_CHECK][k]
-                    for k in sorted(failed_or_skipped_ids[SENSITIVITY_CHECK])
-                },
-            },
-            f,
-            indent=2,
+    result = {
+        "supported_tags": sorted(passed_test_tags | passed_component_tags),
+        "encountered_tags": sorted(encountered_tags),
+    }
+    for check in CHECKS:
+        suffix = _CHECK_SUFFIXES[check]
+        ids = (
+            passed_simulation_ids
+            if check == SIMULATION_CHECK
+            else passed_ids[check]
         )
+        result[f"passed_tests_{suffix}"] = sorted(ids)
+        result[f"failed_or_skipped_{suffix}"] = {
+            k: failed_or_skipped_ids[check][k]
+            for k in sorted(failed_or_skipped_ids[check])
+        }
+
+    with open(RESULT_PATH / "results.json", "w") as f:
+        json.dump(result, f, indent=2)
 
 
 def pytest_runtest_logreport(report: "TestReport") -> None:
@@ -201,7 +210,8 @@ def pytest_runtest_logreport(report: "TestReport") -> None:
     if report.when != "call":
         return
     match = re.search(
-        r"::(test_sbml_testsuite_case(?:_sensitivity)?)\[(\d+)\]",
+        r"::(test_sbml_testsuite_case"
+        r"(?:_sensitivity_(?:forward|adjoint|consistency))?)\[(\d+)\]",
         report.nodeid,
     )
     if not match:

--- a/tests/sbml/consolidate_results.py
+++ b/tests/sbml/consolidate_results.py
@@ -13,29 +13,33 @@ from pathlib import Path
 # where all result artifacts have been unpacked to
 result_dir = Path("combined")
 
+CHECKS = (
+    "simulation",
+    "sensitivity_forward",
+    "sensitivity_adjoint",
+    "sensitivity_consistency",
+)
+
 # tags encountered across all tests (from the simulation check only)
 encountered_tags: set[str] = set()
 # tags for which at least one test passed
 supported_tags: set[str] = set()
 
 # test IDs of passed tests, by check
-passed_ids: dict[str, set[str]] = {"simulation": set(), "sensitivity": set()}
+passed_ids: dict[str, set[str]] = {check: set() for check in CHECKS}
 # failed or skipped tests with error message, by check
-failed_or_skipped: dict[str, dict[str, str]] = {
-    "simulation": dict(),
-    "sensitivity": dict(),
-}
+failed_or_skipped: dict[str, dict[str, str]] = {check: {} for check in CHECKS}
 
 for tag_file in result_dir.glob("results_*.json"):
     with open(tag_file) as f:
         cur_tags = json.load(f)
     encountered_tags |= set(cur_tags["encountered_tags"])
     supported_tags |= set(cur_tags["supported_tags"])
-    for check in ("simulation", "sensitivity"):
+    for check in CHECKS:
         passed_ids[check] |= set(cur_tags[f"passed_tests_{check}"])
         failed_or_skipped[check] |= cur_tags[f"failed_or_skipped_{check}"]
 
-for check in ("simulation", "sensitivity"):
+for check in CHECKS:
     num_tests_success = len(passed_ids[check])
     num_tests_total = num_tests_success + len(failed_or_skipped[check])
     frac_tests_passed = num_tests_success / num_tests_total
@@ -57,7 +61,7 @@ print("----------------")
 print()
 print(",".join(sorted(list(unsupported_tags))))
 print()
-for check in ("simulation", "sensitivity"):
+for check in CHECKS:
     print(f"Failed or-skipped tests [{check}]")
     print("-----------------------" + "-" * len(check))
     print()

--- a/tests/sbml/testSBMLSuite.py
+++ b/tests/sbml/testSBMLSuite.py
@@ -7,7 +7,7 @@ Usage:
     pytest tests.sbml.testSBMLSuite -n CORES --dist=loadgroup --cases=SELECTION
         CORES can be an integer or `auto` for all available cores.
         `--dist=loadgroup` is required whenever `-n` is used: each case's
-        simulation and sensitivity checks share one compiled model
+        simulation and sensitivity checks share one compiled model module
         (`compiled_case` fixture) and must run on the same xdist worker.
         SELECTION can be e.g.: `1`, `1,3`, `-3,4,6-7`, or `100-` to select
         specific test cases. If `--cases` is omitted, all cases are run.
@@ -15,30 +15,35 @@ Usage:
 
 from __future__ import annotations
 
+import logging
 import shutil
+from collections.abc import Callable
 from pathlib import Path
 
 import amici
 import diffrax
 import jax
 import jax.numpy as jnp
+import libsbml
 import numpy as np
 import optimistix
 import pandas as pd
 import pytest
+from amici.adapters.fiddy import run_simulation_to_function_and_derivative
 from amici.sim.jax.petab import (
     DEFAULT_CONTROLLER_SETTINGS,
     DEFAULT_ROOT_FINDER_SETTINGS,
 )
 from amici.sim.sundials import (
     AMICI_SUCCESS,
+    ExpData,
     Model,
     SensitivityMethod,
     SensitivityOrder,
     Solver,
     run_simulation,
 )
-from amici.sim.sundials.gradient_check import check_derivatives
+from fiddy import FunctionEvaluationError, check_gradient, check_jacobian
 from utils import (
     apply_settings,
     find_model_file,
@@ -47,30 +52,26 @@ from utils import (
     write_result_file,
 )
 
-# test cases for which sensitivities are to be checked
-#  key: case ID; value: epsilon for finite differences
-_SENSITIVITY_CHECK_CASES = {
+# test cases for which the separate, autodiff-based JAX sensitivity
+# cross-check is additionally run (see `jax_sensitivity_check`)
+_JAX_CHECK_CASES = {
     # parameter-dependent conservation laws
-    "00783": 1.5e-2,
+    "00783",
     # initial events
-    "00995": 1e-3,
+    "00995",
 }
 
 
 @pytest.fixture(scope="session")
 def compiled_case(test_id, sbml_semantic_cases_dir):
-    """Compile and configure a case's model, shared by its simulation and
-    sensitivity test nodes.
+    """Compile a case's model once, reuse simulation and sensitivity tests.
 
-    Model import/compilation is expensive and must happen at most once per
-    `test_id` -- see the `xdist_group`/`scope="session"` comment in
-    `pytest_generate_tests` (conftest.py) for why that requires both
-    consuming test nodes to run on the same xdist worker.
+    For use with pytest-xdist, see conftest.py.
     """
     current_test_path = sbml_semantic_cases_dir / test_id
     model_dir = Path(__file__).parent / "SBMLTestModels" / test_id
     try:
-        model, solver, wrapper = compile_model(
+        model_module, sbml_importer = compile_model(
             current_test_path,
             test_id,
             model_dir,
@@ -82,6 +83,18 @@ def compiled_case(test_id, sbml_semantic_cases_dir):
         pytest.skip(str(err))
 
     settings = read_settings_file(current_test_path, test_id)
+
+    yield model_module, sbml_importer, settings, current_test_path
+
+    shutil.rmtree(model_dir, ignore_errors=True)
+
+
+def _fresh_model_and_solver(
+    model_module, settings: dict, test_id: str
+) -> tuple[Model, Solver, float, float]:
+    """Build a fresh `Model`/`Solver` and set up for test."""
+    model = model_module.get_model()
+    solver = model.create_solver()
     atol, rtol = apply_settings(settings, solver, model, test_id)
     solver.set_sensitivity_order(SensitivityOrder.first)
     solver.set_sensitivity_method(SensitivityMethod.forward)
@@ -89,10 +102,7 @@ def compiled_case(test_id, sbml_semantic_cases_dir):
         # 00885: root-after-reinitialization with FSA with default settings
         solver.set_absolute_tolerance(1e-16)
         solver.set_relative_tolerance(1e-15)
-
-    yield model, solver, wrapper, settings, atol, rtol, current_test_path
-
-    shutil.rmtree(model_dir, ignore_errors=True)
+    return model, solver, atol, rtol
 
 
 def _check_simulation_status(rdata, test_id: str) -> None:
@@ -105,8 +115,9 @@ def _check_simulation_status(rdata, test_id: str) -> None:
 
 
 def test_sbml_testsuite_case(test_id, compiled_case, result_path):
-    model, solver, wrapper, settings, atol, rtol, current_test_path = (
-        compiled_case
+    model_module, sbml_importer, settings, current_test_path = compiled_case
+    model, solver, atol, rtol = _fresh_model_and_solver(
+        model_module, settings, test_id
     )
 
     # parse expected results
@@ -123,43 +134,324 @@ def test_sbml_testsuite_case(test_id, compiled_case, result_path):
 
     # verify
     simulated = verify_results(
-        settings, rdata, results, wrapper, model, atol, rtol
+        settings, rdata, results, sbml_importer, model, atol, rtol
     )
 
     # record results
     write_result_file(simulated, test_id, result_path)
 
 
-def test_sbml_testsuite_case_sensitivity(test_id, compiled_case):
-    """Check the model's sensitivities for the selected cases in
-    `_SENSITIVITY_CHECK_CASES`, via finite differences and against JAX
-    autodiff.
-
-    Reported independently from `test_sbml_testsuite_case`: whether AMICI
-    can correctly *simulate* an SBML feature and whether its *sensitivities*
-    for that feature are correct are different questions, and a case whose
-    simulation is right but whose sensitivities aren't (yet) checked
-    shouldn't count against basic SBML simulation support.
-    """
-    model, solver, wrapper, settings, atol, rtol, current_test_path = (
-        compiled_case
+def _ast_has_piecewise(node: libsbml.ASTNode | None) -> bool:
+    """Recursively check whether a libsbml math AST contains a `piecewise`
+    function anywhere in its tree."""
+    if node is None:
+        return False
+    if node.getType() == libsbml.AST_FUNCTION_PIECEWISE:
+        return True
+    return any(
+        _ast_has_piecewise(node.getChild(i))
+        for i in range(node.getNumChildren())
     )
 
-    epsilon = _SENSITIVITY_CHECK_CASES.get(test_id)
-    if epsilon is None:
-        pytest.skip("No sensitivity check defined for this case")
 
+def _model_has_event_jump_risk(sbml_model: libsbml.Model) -> bool:
+    """Whether this model has an event, or a piecewise formula."""
+    if sbml_model.getNumEvents() > 0:
+        return True
+    for reaction in sbml_model.getListOfReactions():
+        kinetic_law = reaction.getKineticLaw()
+        if kinetic_law is not None and _ast_has_piecewise(
+            kinetic_law.getMath()
+        ):
+            return True
+    return any(
+        _ast_has_piecewise(rule.getMath())
+        for rule in sbml_model.getListOfRules()
+    )
+
+
+# FIXME: Skip list - to be investigated further
+#  test_id -> adjoint_only (whether forward is unaffected)
+_OTHER_KNOWN_SENSITIVITY_CHECK_ISSUES = {
+    "00048": True,
+    "00066": True,
+    "00208": True,
+    "00589": True,
+    "00879": False,
+    "01530": False,
+    "01104": True,
+    "01107": True,
+    "01148": True,
+}
+
+
+def _sensitivity_preflight_checks(
+    model: Model, sbml_importer, test_id: str, uses_adjoint: bool
+):
+    """Skip if a sensitivity check wouldn't be meaningful/known-correct for
+    this SBML feature.
+
+    :param uses_adjoint: Whether the caller's check involves adjoint
+        sensitivities.
+    :return: The current libsbml model.
+    """
+    if not model.get_free_parameter_ids():
+        pytest.skip("No free parameters to differentiate w.r.t.")
+
+    sbml_model = sbml_importer.sbml_model
+    if any(
+        rule.getTypeCode() == libsbml.SBML_ALGEBRAIC_RULE
+        for rule in sbml_model.getListOfRules()
+    ):
+        pytest.skip(
+            "Sensitivities for AlgebraicRule models are known to "
+            "be wrong -- see "
+            "https://github.com/AMICI-dev/AMICI/issues/3250"
+        )
+    if any(
+        species.getBoundaryCondition() or species.getConstant()
+        for species in sbml_model.getListOfSpecies()
+    ):
+        pytest.skip(
+            "Sensitivities for boundary-condition/constant species "
+            "are known to be wrong -- see "
+            "https://github.com/AMICI-dev/AMICI/issues/3249"
+        )
+    if uses_adjoint and model.nx_rdata == 0:
+        pytest.skip(
+            "Adjoint sensitivities for zero-state models are known to crash."
+        )
+    if uses_adjoint and _model_has_event_jump_risk(sbml_model):
+        pytest.skip(
+            "Adjoint sensitivities for (some) events are known to be wrong (https://github.com/AMICI-dev/AMICI/pull/3258)."
+        )
+    if test_id in _OTHER_KNOWN_SENSITIVITY_CHECK_ISSUES:
+        adjoint_only = _OTHER_KNOWN_SENSITIVITY_CHECK_ISSUES[test_id]
+        if uses_adjoint or not adjoint_only:
+            pytest.skip("Known sensitivity-check issue, not yet investigated.")
+    return sbml_model
+
+
+def test_sbml_testsuite_case_sensitivity_forward(test_id, compiled_case):
+    """Finite-difference-check the model's forward sensitivities."""
+    model_module, sbml_importer, settings, current_test_path = compiled_case
+    model, solver, atol, rtol = _fresh_model_and_solver(
+        model_module, settings, test_id
+    )
+    sbml_model = _sensitivity_preflight_checks(
+        model, sbml_importer, test_id, uses_adjoint=False
+    )
+
+    # Test whether base-simulation succeeds. If not, we can skip fail right
+    # away with a clearer message than the FD check's own failure would give.
     rdata = run_simulation(model, solver)
     _check_simulation_status(rdata, test_id)
 
-    check_derivatives(model, solver=solver, epsilon=epsilon)
-    jax_sensitivity_check(
-        current_test_path,
-        test_id,
-        model,
-        rdata,
-        atol,
-        rtol,
+    def check(sensi_solver, point, bounds, retried):
+        sensi_solver.set_sensitivity_method(SensitivityMethod.forward)
+        function, derivative = run_simulation_to_function_and_derivative(
+            amici_model=model,
+            amici_solver=sensi_solver,
+            derivative_variables=["x", "x0", "y", "sigmay"],
+        )
+        expected = derivative(point)
+        # A bare parameter-only model has nothing for `x`/`x0`/`y`/`sigmay` to
+        # report -- `derivative`/`function` then both return an empty
+        # dict
+        if not expected:
+            return None
+        result = check_jacobian(function, point, expected, bounds=bounds)
+        result.assert_success(always_print=True)
+        _assert_check_confirms_something(result, has_events, retried)
+
+    has_events = sbml_model.getNumEvents() > 0
+    _run_sensitivity_check(model, settings, test_id, has_events, check)
+
+    # additionally cross-check against JAX autodiff for a couple of
+    # historically tricky cases
+    if test_id in _JAX_CHECK_CASES:
+        jax_sensitivity_check(
+            current_test_path,
+            test_id,
+            model,
+            rdata,
+            atol,
+            rtol,
+        )
+
+
+@pytest.mark.filterwarnings(
+    # https://github.com/AMICI-dev/AMICI/issues/18
+    "ignore:Adjoint sensitivity analysis for models with discontinuous "
+    "right hand sides .*:UserWarning",
+)
+def test_sbml_testsuite_case_sensitivity_adjoint(test_id, compiled_case):
+    """Finite-difference-check the model's adjoint sensitivities."""
+    model_module, sbml_importer, settings, current_test_path = compiled_case
+    model, solver, atol, rtol = _fresh_model_and_solver(
+        model_module, settings, test_id
+    )
+    sbml_model = _sensitivity_preflight_checks(
+        model, sbml_importer, test_id, uses_adjoint=True
+    )
+
+    # generate synthetic measurements
+    rdata = run_simulation(model, solver)
+    _check_simulation_status(rdata, test_id)
+    # `amici.ExpData(rdata, sigma_y, sigma_z, seed)`
+    edata = ExpData(rdata, 1.0, 1.0, 42)
+
+    def check(sensi_solver, point, bounds, retried):
+        sensi_solver.set_sensitivity_method(SensitivityMethod.adjoint)
+        sensi_solver.set_absolute_tolerance_b(
+            sensi_solver.get_absolute_tolerance()
+        )
+        sensi_solver.set_relative_tolerance_b(
+            sensi_solver.get_relative_tolerance()
+        )
+
+        def _run(atol_quad, rtol_quad):
+            sensi_solver.set_absolute_tolerance_quadratures(atol_quad)
+            sensi_solver.set_relative_tolerance_quadratures(rtol_quad)
+            function, derivative = run_simulation_to_function_and_derivative(
+                amici_model=model,
+                amici_solver=sensi_solver,
+                amici_edata=edata,
+                derivative_variables=["llh"],
+            )
+            return function, derivative(point)
+
+        # Try the tightest quadrature tolerance first: loosening it can
+        # silently corrupt an otherwise-successful backward integration's
+        # result (confirmed on case 00945: keeping this fixed tight gives
+        # ~0.1% error at the same state/backward tolerance that gives ~7%
+        # error if quadrature tolerance also scales alongside it). Only if
+        # that fails outright (NaN) set the quadrature
+        # tolerance to the already-escalated backward tolerance -- some
+        # cases' backward integration genuinely cannot converge *at all*
+        # without that (confirmed on cases 00754/00755/00756).
+        function, expected = _run(1e-16, 1e-15)
+        if expected and np.any(np.isnan(expected["llh"])):
+            function, expected = _run(
+                sensi_solver.get_absolute_tolerance_b(),
+                sensi_solver.get_relative_tolerance_b(),
+            )
+        if not expected:
+            return None
+        # Raise on simulation failure (NaN)
+        if np.any(np.isnan(expected["llh"])):
+            raise FunctionEvaluationError("Simulation failed.")
+        result = check_gradient(
+            function, point, expected["llh"], bounds=bounds
+        )
+        result.assert_success(always_print=True)
+        _assert_check_confirms_something(result, has_events, retried)
+
+    has_events = sbml_model.getNumEvents() > 0
+    _run_sensitivity_check(
+        model, settings, test_id, has_events, check, jitter_seed=43
+    )
+
+
+@pytest.mark.filterwarnings(
+    # https://github.com/AMICI-dev/AMICI/issues/18
+    "ignore:Adjoint sensitivity analysis for models with discontinuous "
+    "right hand sides .*:UserWarning",
+)
+def test_sbml_testsuite_case_sensitivity_consistency(test_id, compiled_case):
+    """Compare forward vs. adjoint sensitivities (`sllh`) against *each other*."""
+    model_module, sbml_importer, settings, current_test_path = compiled_case
+    model, solver, atol, rtol = _fresh_model_and_solver(
+        model_module, settings, test_id
+    )
+    sbml_model = _sensitivity_preflight_checks(
+        model, sbml_importer, test_id, uses_adjoint=True
+    )
+
+    rdata = run_simulation(model, solver)
+    _check_simulation_status(rdata, test_id)
+    edata = ExpData(rdata, 1.0, 1.0, 42)
+
+    def check(sensi_solver, point, bounds, retried):
+        # FSA
+        sensi_solver.set_sensitivity_method(SensitivityMethod.forward)
+        _, fsa_derivative = run_simulation_to_function_and_derivative(
+            amici_model=model,
+            amici_solver=sensi_solver,
+            amici_edata=edata,
+            derivative_variables=["llh"],
+        )
+        fsa_expected = fsa_derivative(point)
+        if not fsa_expected:
+            return None
+
+        # ASA
+        asa_solver = model.create_solver()
+        apply_settings(settings, asa_solver, model, test_id)
+        asa_solver.set_absolute_tolerance(
+            sensi_solver.get_absolute_tolerance()
+        )
+        asa_solver.set_relative_tolerance(
+            sensi_solver.get_relative_tolerance()
+        )
+        asa_solver.set_absolute_tolerance_b(
+            sensi_solver.get_absolute_tolerance()
+        )
+        asa_solver.set_relative_tolerance_b(
+            sensi_solver.get_relative_tolerance()
+        )
+        asa_solver.set_sensitivity_order(SensitivityOrder.first)
+        asa_solver.set_sensitivity_method(SensitivityMethod.adjoint)
+
+        def _run_asa(atol_quad, rtol_quad):
+            asa_solver.set_absolute_tolerance_quadratures(atol_quad)
+            asa_solver.set_relative_tolerance_quadratures(rtol_quad)
+            _, asa_derivative = run_simulation_to_function_and_derivative(
+                amici_model=model,
+                amici_solver=asa_solver,
+                amici_edata=edata,
+                derivative_variables=["llh"],
+            )
+            return asa_derivative(point)
+
+        # Same two-tier quadrature-tolerance strategy (tightest first,
+        # falling back to matching the already-escalated backward
+        # tolerance only if that's NaN) as
+        # `test_sbml_testsuite_case_sensitivity_adjoint`'s `check` -- see
+        # its comment for why.
+        asa_expected = _run_asa(1e-16, 1e-15)
+        if asa_expected and np.any(np.isnan(asa_expected["llh"])):
+            asa_expected = _run_asa(
+                asa_solver.get_absolute_tolerance_b(),
+                asa_solver.get_relative_tolerance_b(),
+            )
+        if not asa_expected:
+            return None
+
+        fsa_sllh = fsa_expected["llh"]
+        asa_sllh = asa_expected["llh"]
+        if np.any(np.isnan(fsa_sllh)) or np.any(np.isnan(asa_sllh)):
+            raise FunctionEvaluationError(
+                "AMICI's forward or adjoint sensitivity computation "
+                "returned NaN (likely a near-tangent event crossing)."
+            )
+        # Tight by default; deliberately loosened once we've already had
+        # to retry at a much looser solver tolerance to get a finite
+        # result at all -- that widening alone causes up to ~1% residual
+        # disagreement between otherwise-correct forward and adjoint
+        # sensitivities (case 00753)
+        rtol = 1e-6 if not retried else 1e-2
+        np.testing.assert_allclose(
+            asa_sllh,
+            fsa_sllh,
+            rtol=rtol,
+            atol=1e-8,
+            err_msg="Forward and adjoint sensitivities disagree",
+        )
+
+    has_events = sbml_model.getNumEvents() > 0
+    _run_sensitivity_check(
+        model, settings, test_id, has_events, check, jitter_seed=44
     )
 
 
@@ -168,8 +460,8 @@ def compile_model(
     test_id: str,
     model_dir: Path,
     generate_sensitivity_code: bool = False,
-) -> tuple[Model, Solver, amici.SbmlImporter]:
-    """Import the given test model to AMICI"""
+):
+    """Import the given test model."""
     model_dir.mkdir(parents=True, exist_ok=True)
 
     sbml_file = find_model_file(sbml_dir, test_id)
@@ -182,13 +474,201 @@ def compile_model(
         generate_sensitivity_code=generate_sensitivity_code,
     )
 
-    # settings
     model_module = amici.import_model_module(model_name, model_dir)
 
-    model = model_module.get_model()
-    solver = model.create_solver()
+    return model_module, sbml_importer
 
-    return model, solver, sbml_importer
+
+# Case 01395-specific: `v1_h`..`v15_h` are Hill coefficients with nominal
+# value exactly 1, acting on species (`p1`, `p2`, ...) that start at
+# exactly 0. The forward-sensitivity RHS (not the state RHS itself)
+# contains a `species**(h-1)` term; reducing `h` even infinitesimally
+# below 1 makes that exponent negative, and `0**(negative)` is `+inf`.
+_HILL_EXPONENT_LOWER_BOUND_OVERRIDES = {
+    "01395": tuple(f"v{i}_h" for i in range(1, 16)),
+}
+
+
+def _derive_generic_bounds(
+    point: np.ndarray, param_ids: tuple[str, ...], test_id: str
+) -> tuple[np.ndarray, np.ndarray]:
+    """Derive a generic, per-parameter valid domain from nominal values
+    alone.
+
+    Without bounds, fiddy might try to evaluate infeasible points.
+    A bound of nominal * (1e-6, 1000) on the same-signed side (never
+    including 0 itself -- needed for case 00313, singular at 0) fixes
+    69/76 previously-failing cases outright. Parameters nominally at 0
+    fall back to (0, 1000): every free parameter in this suite is
+    semantically non-negative.
+
+    :param point: Nominal free-parameter values.
+    :param param_ids: `point`'s parameter IDs, same order -- only used to
+        apply `_HILL_EXPONENT_LOWER_BOUND_OVERRIDES`.
+    :param test_id: The SBML semantic test suite case ID -- ditto.
+    :return: A `(lower, upper)` bounds tuple, same shape as `point`.
+    """
+    lower = np.empty_like(point)
+    upper = np.empty_like(point)
+    positive = point > 0
+    negative = point < 0
+    zero = ~positive & ~negative
+    lower[positive] = np.maximum(point[positive] * 1e-6, 1e-9)
+    upper[positive] = np.maximum(point[positive] * 1000, 1000.0)
+    lower[negative] = np.minimum(point[negative] * 1000, -1000.0)
+    upper[negative] = np.minimum(point[negative] * 1e-6, -1e-9)
+    lower[zero] = 0.0
+    upper[zero] = 1000.0
+    for param_id in _HILL_EXPONENT_LOWER_BOUND_OVERRIDES.get(test_id, ()):
+        idx = param_ids.index(param_id)
+        lower[idx] = point[idx]
+    return lower, upper
+
+
+def _assert_check_confirms_something(
+    result, has_events: bool, retried: bool
+) -> None:
+    """`check_jacobian`/`check_gradient`'s `success` is `True` as long as no
+    direction is confidently *wrong* -- a check where every direction came
+    back "inconclusive" (noise-dominated/discontinuity-suspected) would
+    still report success, having actually confirmed nothing. Require at
+    least one direction, in at least one output component, to have been
+    confirmed converged, so a silent coverage regression fails loudly instead
+    of passing vacuously.
+
+    Exception: for an event-triggered model, if every non-passing direction was
+    flagged `"discontinuity_suspected"`, skip instead of failing.
+    Same for `"noise_dominated"`, but only once we've already had to retry at
+    a much looser tolerance to get a finite result at all (`retried`).
+    """
+    direction_results = (
+        [d for o in result.output_results for d in o.direction_results]
+        if hasattr(result, "output_results")
+        else result.direction_results
+    )
+    if any(r.outcome == "passed" for r in direction_results):
+        return
+    acceptable_statuses = {"discontinuity_suspected"}
+    if retried:
+        acceptable_statuses.add("noise_dominated")
+    if has_events and all(
+        r.estimate.status in acceptable_statuses for r in direction_results
+    ):
+        pytest.skip(
+            "Every checked direction was inconclusive "
+            f"({sorted({r.estimate.status for r in direction_results})})."
+        )
+    raise AssertionError(
+        "check reported success, but every direction was inconclusive -- "
+        "nothing was actually confirmed correct."
+    )
+
+
+def _run_sensitivity_check(
+    model: Model,
+    settings: dict,
+    test_id: str,
+    has_events: bool,
+    check: Callable[
+        [Solver, np.ndarray, tuple[np.ndarray, np.ndarray]], object
+    ],
+    jitter_seed: int | None = None,
+) -> None:
+    """Retry `check` (a sensitivity FD check via fiddy)
+    at looser solver tolerance (event-triggered models only) if the
+    simulation itself fails to produce a finite value.
+
+    An FD-perturbed parameter point can turn a clean event trigger crossing
+    into a near-tangent one (confirmed on cases 00375/00754), triggering
+    AMICI's "root after reinitialization" error. To avoid this error,
+    we retry the check at a looser solver tolerance.
+
+    :param model: The AMICI model.
+    :param settings: This case's parsed `{test_id}-settings.txt`.
+    :param test_id: The SBML semantic test suite case ID.
+    :param has_events: Whether the model has any SBML events -- gates the
+        tolerance-retry loop; non-event models get exactly one attempt.
+    :param check: Called as `check(sensi_solver, point, bounds, retried)`
+        (`retried` is `True` once a looser-than-default tolerance was
+        needed to get this far) -- responsible for configuring
+        `sensi_solver`'s sensitivity method, running the check, and
+        asserting success itself. Returns `None` if there's nothing to check
+        for this model -- in which case `_run_sensitivity_check` returns
+        immediately without retrying; any other return value is ignored.
+    :param jitter_seed: If given, `point` is perturbed by fixed-seed 5%
+        relative Gaussian noise (then clipped back into `bounds`) before
+        checking -- the same "avoid small gradients at nominal value"
+        mitigation `tests/benchmark_models/test_petab_benchmark.py`'s
+        gradient check already uses.
+    """
+    # Forward only ever needs up to 100x (e.g. 00375/00754);
+    # adjoint's backward+quadrature integration can need
+    # much looser tolerance still to get through some event crossings at
+    # all -- confirmed on cases 00026/00041/00074/00745/00746/00747/
+    # 00789/00845/00945 (all fail with CVodeB's error-test repeatedly
+    # failing/`|h| = hmin` up to 1e4x, several needing up to 1e8x).
+    tolerance_multipliers = (1, 10, 100, 1e4, 1e6, 1e8) if has_events else (1,)
+    param_ids = model.get_free_parameter_ids()
+    point = np.asarray(
+        [
+            model.get_free_parameter_by_id(parameter_id)
+            for parameter_id in param_ids
+        ]
+    )
+    bounds = _derive_generic_bounds(point, param_ids, test_id)
+    if jitter_seed is not None:
+        rng = np.random.default_rng(jitter_seed)
+        point = point + rng.standard_normal(len(point)) * point * 0.05
+        point = np.clip(point, *bounds)
+    error = None
+    for multiplier in tolerance_multipliers:
+        # Use a fresh solver every attempt
+        # avoids failures for zero-state models
+        # (this calls `CVodeSensSStolerances` without
+        # having gone through a matching `CVodeSensReInit` for the updated
+        # parameters first, which CVODES rejects with `CV_ILL_INPUT`
+        # "CVODE routine CVodeSensSStolerances failed with error code -40").
+        sensi_solver = model.create_solver()
+        apply_settings(settings, sensi_solver, model, test_id)
+        # start with tightest tolerances, then loosen if needed
+        sensi_solver.set_absolute_tolerance(1e-16)
+        sensi_solver.set_relative_tolerance(1e-15)
+        if multiplier != 1:
+            sensi_solver.set_absolute_tolerance(
+                sensi_solver.get_absolute_tolerance() * multiplier
+            )
+            sensi_solver.set_relative_tolerance(
+                sensi_solver.get_relative_tolerance() * multiplier
+            )
+        sensi_solver.set_sensitivity_order(SensitivityOrder.first)
+
+        # Skip, not fail on "root after reinitialization" errors during FD
+        # checks that occur at any tolerance
+        # (e.g., for 00369/00754/00755/00756/00883/00885).
+        root_after_reinit_messages = []
+        log_handler = logging.Handler()
+        log_handler.emit = lambda record: (
+            root_after_reinit_messages.append(record.getMessage())
+            if "root after reinitialization" in record.getMessage()
+            else None
+        )
+        amici_logger = logging.getLogger("amici.sim.sundials._swig_wrappers")
+        amici_logger.addHandler(log_handler)
+        try:
+            if check(sensi_solver, point, bounds, multiplier != 1) is None:
+                return
+        except FunctionEvaluationError as err:
+            if root_after_reinit_messages:
+                pytest.skip(
+                    "AMICI/CVODES cannot integrate through a near-tangent "
+                    f"event crossing: {root_after_reinit_messages[0]}"
+                )
+            error = err
+            continue
+        finally:
+            amici_logger.removeHandler(log_handler)
+        return
+    raise error
 
 
 def compile_model_jax(sbml_dir: Path, test_id: str, model_dir: Path):


### PR DESCRIPTION
Add fiddy-based finite differences sensitivity checks to the SBML semantic test suite for every case with free parameters. fiddy's check_jacobian self-calibrates step sizes/tolerances, so no per-model tuning is needed.

This surfaced pre-existing sensitivity bugs tracked as #3249, #3250 and #3257. Those cases are skipped here for now.

Closes #1236
Closes #2093 