### PR TITLE
CI: Report SBML simulation and sensitivity checks independently

### DIFF
--- a/scripts/run-SBMLTestsuite.sh
+++ b/scripts/run-SBMLTestsuite.sh
@@ -40,5 +40,5 @@ if [[ -d "${RESULT_DIR}" ]]; then
 fi
 mkdir "${RESULT_DIR}"
 
-pytest "$TEST_SCRIPT" $cases -rfsE -n auto \
+pytest "$TEST_SCRIPT" $cases -rfsE -n auto --dist=loadgroup \
   --cov=amici --cov-report=xml:"$COVERAGE_FILE" --cov-append

--- a/tests/sbml/conftest.py
+++ b/tests/sbml/conftest.py
@@ -16,12 +16,23 @@ script_dir = Path(__file__).parent.resolve()
 if str(script_dir) not in sys.path:
     sys.path.insert(0, str(script_dir))
 
-# stores passed SBML semantic test suite IDs
-passed_ids = []
-# test tags we encountered
+# the two independently-reported checks per SBML semantic test suite case
+SIMULATION_CHECK = "test_sbml_testsuite_case"
+SENSITIVITY_CHECK = "test_sbml_testsuite_case_sensitivity"
+
+# stores passed SBML semantic test suite IDs, by check
+passed_ids: dict[str, list[str]] = {
+    SIMULATION_CHECK: [],
+    SENSITIVITY_CHECK: [],
+}
+# test tags we encountered (from the simulation check only -- that's what
+# the SBML test suite's own tag-support semantics are about)
 encountered_tags: set[str] = set()
-# failed tests with error message
-failed_or_skipped_ids: dict[str, str] = dict()
+# failed/skipped tests with error message, by check
+failed_or_skipped_ids: dict[str, dict[str, str]] = {
+    SIMULATION_CHECK: {},
+    SENSITIVITY_CHECK: {},
+}
 
 SBML_SEMANTIC_CASES_DIR = (
     Path(__file__).parent / "sbml-test-suite" / "cases" / "semantic"
@@ -35,7 +46,7 @@ def result_path() -> Path:
     return RESULT_PATH
 
 
-@pytest.fixture
+@pytest.fixture(scope="session")
 def sbml_semantic_cases_dir() -> Path:
     """directory with sbml semantic test cases"""
     return SBML_SEMANTIC_CASES_DIR
@@ -94,7 +105,25 @@ def pytest_generate_tests(metafunc):
         else:
             # Run all tests
             test_ids = get_all_semantic_case_ids()
-        metafunc.parametrize("test_id", test_ids)
+        # `scope="session"` lets the session-scoped `compiled_case` fixture
+        # (which imports/compiles the model -- expensive, must happen at
+        # most once per test_id) depend on `test_id` at all; without it,
+        # pytest raises `ScopeMismatch`. `xdist_group` keeps both this
+        # test_id's simulation and sensitivity test nodes on the same
+        # xdist worker -- required (not just an optimization) whenever
+        # running with `-n`: `compiled_case`'s cache is per-worker-process,
+        # so if the two nodes for one test_id land on different workers,
+        # each independently recompiles the same model into the same
+        # on-disk directory, which is both wasteful and racy. This only
+        # takes effect when running with `--dist=loadgroup`.
+        metafunc.parametrize(
+            "test_id",
+            [
+                pytest.param(t, marks=pytest.mark.xdist_group(name=t))
+                for t in test_ids
+            ],
+            scope="session",
+        )
 
 
 def pytest_sessionfinish(session, exitstatus):
@@ -106,18 +135,26 @@ def pytest_sessionfinish(session, exitstatus):
     terminalreporter.ensure_newline()
     # parse test names to get passed case IDs (don't know any better way to
     # access fixture values)
-    passed_ids = [format_test_id(_) for _ in passed_ids]
-    if passed_ids or failed_or_skipped_ids:
-        write_passed_tags(passed_ids, terminalreporter)
+    passed_ids = {
+        check: [format_test_id(_) for _ in ids]
+        for check, ids in passed_ids.items()
+    }
+    if any(passed_ids.values()) or any(failed_or_skipped_ids.values()):
+        write_passed_tags(passed_ids[SIMULATION_CHECK], terminalreporter)
     terminalreporter.ensure_newline()
 
 
-def write_passed_tags(passed_ids, out=sys.stdout):
-    """Write tags of passed SBML semantic test cases"""
+def write_passed_tags(passed_simulation_ids, out=sys.stdout):
+    """Write tags of passed SBML semantic test cases
+
+    Tag coverage (what the SBML test suite's own result database tracks)
+    only concerns basic simulation support, not the separate sensitivity
+    check -- so tags are derived from `passed_simulation_ids` alone.
+    """
     passed_component_tags = set()
     passed_test_tags = set()
 
-    for test_id in passed_ids:
+    for test_id in passed_simulation_ids:
         cur_component_tags, cur_test_tags = get_tags_for_test(test_id)
         passed_component_tags |= cur_component_tags
         passed_test_tags |= cur_test_tags
@@ -141,10 +178,17 @@ def write_passed_tags(passed_ids, out=sys.stdout):
                     passed_test_tags | passed_component_tags
                 ),
                 "encountered_tags": sorted(encountered_tags),
-                "passed_tests": sorted(passed_ids),
-                "failed_or_skipped": {
-                    k: failed_or_skipped_ids[k]
-                    for k in sorted(failed_or_skipped_ids)
+                "passed_tests_simulation": sorted(passed_simulation_ids),
+                "passed_tests_sensitivity": sorted(
+                    passed_ids[SENSITIVITY_CHECK]
+                ),
+                "failed_or_skipped_simulation": {
+                    k: failed_or_skipped_ids[SIMULATION_CHECK][k]
+                    for k in sorted(failed_or_skipped_ids[SIMULATION_CHECK])
+                },
+                "failed_or_skipped_sensitivity": {
+                    k: failed_or_skipped_ids[SENSITIVITY_CHECK][k]
+                    for k in sorted(failed_or_skipped_ids[SENSITIVITY_CHECK])
                 },
             },
             f,
@@ -154,24 +198,27 @@ def write_passed_tags(passed_ids, out=sys.stdout):
 
 def pytest_runtest_logreport(report: "TestReport") -> None:
     """Collect test case IDs of passed SBML semantic test suite cases"""
-    if (
-        report.when == "call"
-        and "::test_sbml_testsuite_case[" in report.nodeid
-    ):
-        test_case_id = re.sub(
-            r"^.*::test_sbml_testsuite_case\[(\d+)].*$", r"\1", report.nodeid
-        )
+    if report.when != "call":
+        return
+    match = re.search(
+        r"::(test_sbml_testsuite_case(?:_sensitivity)?)\[(\d+)\]",
+        report.nodeid,
+    )
+    if not match:
+        return
+    check, test_case_id = match.group(1), match.group(2)
 
+    if check == SIMULATION_CHECK:
         global encountered_tags
 
         component_tags, test_tags = get_tags_for_test(test_case_id)
         encountered_tags |= component_tags
         encountered_tags |= test_tags
 
-        if report.outcome == "passed":
-            passed_ids.append(test_case_id)
-        else:
-            failed_or_skipped_ids[test_case_id] = report.longreprtext
+    if report.outcome == "passed":
+        passed_ids[check].append(test_case_id)
+    else:
+        failed_or_skipped_ids[check][test_case_id] = report.longreprtext
 
 
 def get_tags_for_test(test_id: str) -> tuple[set[str], set[str]]:

--- a/tests/sbml/consolidate_results.py
+++ b/tests/sbml/consolidate_results.py
@@ -13,31 +13,36 @@ from pathlib import Path
 # where all result artifacts have been unpacked to
 result_dir = Path("combined")
 
-# tags encountered across all tests
+# tags encountered across all tests (from the simulation check only)
 encountered_tags: set[str] = set()
 # tags for which at least one test passed
 supported_tags: set[str] = set()
 
-# test IDs of passed tests
-passed_ids: set[str] = set()
-# failed or skipped tests with error message
-failed_or_skipped: dict[str, str] = dict()
+# test IDs of passed tests, by check
+passed_ids: dict[str, set[str]] = {"simulation": set(), "sensitivity": set()}
+# failed or skipped tests with error message, by check
+failed_or_skipped: dict[str, dict[str, str]] = {
+    "simulation": dict(),
+    "sensitivity": dict(),
+}
 
 for tag_file in result_dir.glob("results_*.json"):
     with open(tag_file) as f:
         cur_tags = json.load(f)
     encountered_tags |= set(cur_tags["encountered_tags"])
     supported_tags |= set(cur_tags["supported_tags"])
-    passed_ids |= set(cur_tags["passed_tests"])
-    failed_or_skipped |= cur_tags["failed_or_skipped"]
+    for check in ("simulation", "sensitivity"):
+        passed_ids[check] |= set(cur_tags[f"passed_tests_{check}"])
+        failed_or_skipped[check] |= cur_tags[f"failed_or_skipped_{check}"]
 
-num_tests_success = len(passed_ids)
-num_tests_total = num_tests_success + len(failed_or_skipped)
-frac_tests_passed = num_tests_success / num_tests_total
-print(
-    f"{num_tests_success}/{num_tests_total} ≈ "
-    f"{frac_tests_passed:.2%} tests passed."
-)
+for check in ("simulation", "sensitivity"):
+    num_tests_success = len(passed_ids[check])
+    num_tests_total = num_tests_success + len(failed_or_skipped[check])
+    frac_tests_passed = num_tests_success / num_tests_total
+    print(
+        f"[{check}] {num_tests_success}/{num_tests_total} ≈ "
+        f"{frac_tests_passed:.2%} tests passed."
+    )
 
 # tags for which not a single test passed
 unsupported_tags = set(encountered_tags) - set(supported_tags)
@@ -52,10 +57,11 @@ print("----------------")
 print()
 print(",".join(sorted(list(unsupported_tags))))
 print()
-print("Failed or-skipped tests")
-print("-----------------------")
-print()
-for test_id in sorted(failed_or_skipped):
-    msg = failed_or_skipped[test_id]
-    print(f"{test_id}: {msg}")
-print()
+for check in ("simulation", "sensitivity"):
+    print(f"Failed or-skipped tests [{check}]")
+    print("-----------------------" + "-" * len(check))
+    print()
+    for test_id in sorted(failed_or_skipped[check]):
+        msg = failed_or_skipped[check][test_id]
+        print(f"{test_id}: {msg}")
+    print()

--- a/tests/sbml/testSBMLSuite.py
+++ b/tests/sbml/testSBMLSuite.py
@@ -4,8 +4,11 @@ Run SBML Test Suite and verify simulation results
 [https://github.com/sbmlteam/sbml-test-suite/releases]
 
 Usage:
-    pytest tests.sbml.testSBMLSuite -n CORES --cases=SELECTION
+    pytest tests.sbml.testSBMLSuite -n CORES --dist=loadgroup --cases=SELECTION
         CORES can be an integer or `auto` for all available cores.
+        `--dist=loadgroup` is required whenever `-n` is used: each case's
+        simulation and sensitivity checks share one compiled model
+        (`compiled_case` fixture) and must run on the same xdist worker.
         SELECTION can be e.g.: `1`, `1,3`, `-3,4,6-7`, or `100-` to select
         specific test cases. If `--cases` is omitted, all cases are run.
 """
@@ -44,83 +47,120 @@ from utils import (
     write_result_file,
 )
 
+# test cases for which sensitivities are to be checked
+#  key: case ID; value: epsilon for finite differences
+_SENSITIVITY_CHECK_CASES = {
+    # parameter-dependent conservation laws
+    "00783": 1.5e-2,
+    # initial events
+    "00995": 1e-3,
+}
 
-def test_sbml_testsuite_case(test_id, result_path, sbml_semantic_cases_dir):
-    model_dir = None
 
-    # test cases for which sensitivities are to be checked
-    #  key: case ID; value: epsilon for finite differences
-    sensitivity_check_cases = {
-        # parameter-dependent conservation laws
-        "00783": 1.5e-2,
-        # initial events
-        "00995": 1e-3,
-    }
+@pytest.fixture(scope="session")
+def compiled_case(test_id, sbml_semantic_cases_dir):
+    """Compile and configure a case's model, shared by its simulation and
+    sensitivity test nodes.
 
+    Model import/compilation is expensive and must happen at most once per
+    `test_id` -- see the `xdist_group`/`scope="session"` comment in
+    `pytest_generate_tests` (conftest.py) for why that requires both
+    consuming test nodes to run on the same xdist worker.
+    """
+    current_test_path = sbml_semantic_cases_dir / test_id
+    model_dir = Path(__file__).parent / "SBMLTestModels" / test_id
     try:
-        current_test_path = sbml_semantic_cases_dir / test_id
-
-        # parse expected results
-        results_file = current_test_path / f"{test_id}-results.csv"
-        results = pd.read_csv(results_file, delimiter=",")
-        results.rename(
-            columns={c: c.replace(" ", "") for c in results.columns},
-            inplace=True,
-        )
-
-        # setup model
-        model_dir = Path(__file__).parent / "SBMLTestModels" / test_id
         model, solver, wrapper = compile_model(
             current_test_path,
             test_id,
             model_dir,
             generate_sensitivity_code=True,
         )
-        settings = read_settings_file(current_test_path, test_id)
-
-        atol, rtol = apply_settings(settings, solver, model, test_id)
-
-        solver.set_sensitivity_order(SensitivityOrder.first)
-        solver.set_sensitivity_method(SensitivityMethod.forward)
-
-        if test_id == "00885":
-            # 00885: root-after-reinitialization with FSA with default settings
-            solver.set_absolute_tolerance(1e-16)
-            solver.set_relative_tolerance(1e-15)
-
-        # simulate model
-        rdata = run_simulation(model, solver)
-        if rdata["status"] != AMICI_SUCCESS:
-            if test_id in ("00748", "00374", "00369"):
-                pytest.skip("Simulation Failed expectedly")
-            else:
-                raise RuntimeError("Simulation failed unexpectedly")
-
-        # verify
-        simulated = verify_results(
-            settings, rdata, results, wrapper, model, atol, rtol
-        )
-
-        # record results
-        write_result_file(simulated, test_id, result_path)
-
-        # check sensitivities for selected models
-        if epsilon := sensitivity_check_cases.get(test_id):
-            check_derivatives(model, solver=solver, epsilon=epsilon)
-            jax_sensitivity_check(
-                current_test_path,
-                test_id,
-                model,
-                rdata,
-                atol,
-                rtol,
-            )
-
     except amici.importers.sbml.SBMLException as err:
+        # `pytest.skip` from inside a fixture correctly propagates as
+        # SKIPPED to every dependent test, not as a fixture ERROR.
         pytest.skip(str(err))
-    finally:
-        if model_dir:
-            shutil.rmtree(model_dir, ignore_errors=True)
+
+    settings = read_settings_file(current_test_path, test_id)
+    atol, rtol = apply_settings(settings, solver, model, test_id)
+    solver.set_sensitivity_order(SensitivityOrder.first)
+    solver.set_sensitivity_method(SensitivityMethod.forward)
+    if test_id == "00885":
+        # 00885: root-after-reinitialization with FSA with default settings
+        solver.set_absolute_tolerance(1e-16)
+        solver.set_relative_tolerance(1e-15)
+
+    yield model, solver, wrapper, settings, atol, rtol, current_test_path
+
+    shutil.rmtree(model_dir, ignore_errors=True)
+
+
+def _check_simulation_status(rdata, test_id: str) -> None:
+    """Skip/fail consistently for a known-bad vs. a genuinely unexpected
+    base simulation failure."""
+    if rdata["status"] != AMICI_SUCCESS:
+        if test_id in ("00748", "00374", "00369"):
+            pytest.skip("Simulation Failed expectedly")
+        raise RuntimeError("Simulation failed unexpectedly")
+
+
+def test_sbml_testsuite_case(test_id, compiled_case, result_path):
+    model, solver, wrapper, settings, atol, rtol, current_test_path = (
+        compiled_case
+    )
+
+    # parse expected results
+    results_file = current_test_path / f"{test_id}-results.csv"
+    results = pd.read_csv(results_file, delimiter=",")
+    results.rename(
+        columns={c: c.replace(" ", "") for c in results.columns},
+        inplace=True,
+    )
+
+    # simulate model
+    rdata = run_simulation(model, solver)
+    _check_simulation_status(rdata, test_id)
+
+    # verify
+    simulated = verify_results(
+        settings, rdata, results, wrapper, model, atol, rtol
+    )
+
+    # record results
+    write_result_file(simulated, test_id, result_path)
+
+
+def test_sbml_testsuite_case_sensitivity(test_id, compiled_case):
+    """Check the model's sensitivities for the selected cases in
+    `_SENSITIVITY_CHECK_CASES`, via finite differences and against JAX
+    autodiff.
+
+    Reported independently from `test_sbml_testsuite_case`: whether AMICI
+    can correctly *simulate* an SBML feature and whether its *sensitivities*
+    for that feature are correct are different questions, and a case whose
+    simulation is right but whose sensitivities aren't (yet) checked
+    shouldn't count against basic SBML simulation support.
+    """
+    model, solver, wrapper, settings, atol, rtol, current_test_path = (
+        compiled_case
+    )
+
+    epsilon = _SENSITIVITY_CHECK_CASES.get(test_id)
+    if epsilon is None:
+        pytest.skip("No sensitivity check defined for this case")
+
+    rdata = run_simulation(model, solver)
+    _check_simulation_status(rdata, test_id)
+
+    check_derivatives(model, solver=solver, epsilon=epsilon)
+    jax_sensitivity_check(
+        current_test_path,
+        test_id,
+        model,
+        rdata,
+        atol,
+        rtol,
+    )
 
 
 def compile_model(


### PR DESCRIPTION
Preparation for #3253:

Split `test_sbml_testsuite_case` into separate simulation and sensitivity test nodes, sharing one session-scoped model setup fixture so the model is still compiled only once per case. This enables separately skipping/reporting the sensitivity check results.

Requires `--dist=loadgroup` wherever this suite runs with `-n`, so both nodes for a case stay on the same xdist worker -- otherwise they will import the model twice and race on the same on-disk model directory.
