### PR TITLE
Restore original entity id in JAX-backend outward-facing id lists

### DIFF
--- a/python/sdist/amici/exporters/jax/ode_export.py
+++ b/python/sdist/amici/exporters/jax/ode_export.py
@@ -85,9 +85,14 @@ def _jax_return_variables(
 
 
 def _jax_variable_ids(model: DEModel, sym_names: tuple[str, ...]) -> dict:
+    original_ids = model.reserved_symbol_original_ids
     return {
         f"{sym_name.upper()}_IDS": "".join(
-            f'"{s.name}", ' for s in model.sym(sym_name)
+            # public ids must stay exactly as the user named them, even if
+            # amici had to mangle the identifier internally (e.g. an entity
+            # named `p`, which collides with the array-parameter name `p`)
+            f'"{original_ids.get(s.name, s.name)}", '
+            for s in model.sym(sym_name)
         )
         if model.sym(sym_name)
         else "tuple()"
@@ -267,7 +272,8 @@ class ODEExporter:
                 self.model.val("p") + self.model.val("k"), self._code_printer
             ),
             "ALL_P_IDS": "".join(
-                f'"{s.name}", ' for s in self._get_all_p_syms()
+                f'"{self.model.reserved_symbol_original_ids.get(s.name, s.name)}", '
+                for s in self._get_all_p_syms()
             )
             if self._get_all_p_syms()
             else "tuple()",

--- a/python/tests/test_reserved_symbols.py
+++ b/python/tests/test_reserved_symbols.py
@@ -5,7 +5,10 @@ and for the time-symbol."""
 from pathlib import Path
 
 import numpy as np
-from amici.importers.antimony import antimony2amici
+import pytest
+from amici import import_model_module
+from amici.importers.antimony import antimony2amici, antimony2sbml
+from amici.importers.utils import RESERVED_SYMBOLS
 from amici.sim.sundials import AMICI_SUCCESS
 from amici.testing import skip_on_valgrind
 
@@ -39,12 +42,7 @@ def _without_comments(source: str) -> str:
 # pre-defined floating-point-NaN constant, rejected at parse time regardless
 # of context -- `NULL`/`EOF`/`INFINITY` already cover this class of case.)
 RESERVED_SPECIES_IDS = [
-    "x",
-    "p",
-    "k",
-    "h",
-    "w",
-    "y",
+    *RESERVED_SYMBOLS,
     "NULL",
     "int",
     "class",
@@ -144,3 +142,27 @@ def test_species_named_t(tempdir):
     xdot = _generated_source(tempdir, "xdot.cpp")
     assert "amici_t_ = x[0];" in xdot
     assert "-1.0/10.0*amici_t_" in xdot
+
+
+@skip_on_valgrind
+def test_reserved_species_ids_jax(tempdir):
+    """JAX counterpart of ``test_reserved_species_ids``: species named after
+    amici's reserved array-parameter names must report their original id
+    via ``JAXModel.state_ids``, not the internally-mangled ``amici_*`` name.
+    """
+    pytest.importorskip("jax")
+    from amici.importers.sbml import SbmlImporter
+
+    model_name = "reserved_species_test_jax"
+    sbml_str = antimony2sbml(_antimony_model_with_species(RESERVED_SYMBOLS))
+    importer = SbmlImporter(sbml_str, from_file=False)
+    importer.sbml2jax(
+        model_name,
+        output_dir=Path(tempdir) / model_name,
+        observation_model=[],
+        compute_conservation_laws=False,
+    )
+    module = import_model_module(model_name, tempdir)
+    model = module.Model()
+
+    assert tuple(model.state_ids) == tuple(RESERVED_SYMBOLS)


### PR DESCRIPTION
The reserved-symbol rename introduced in 9b17bdd6c (#3239) renames any model entity whose id collides with one of amici's fixed array-parameter names (`x`, `p`, `k`, `h`, `w`, `y`) and restores the original id wherever it's reported outward -- but only the SUNDIALS/C++ exporter was updated to do so. The JAX exporter's state/parameter/observable/expression id lists kept reporting the internally-mangled `amici_*` name instead, breaking the SBML Semantic Test Suite JAX CI job for every test case with an entity literally named `x`, `p`, `k`, or `y` (e.g. cases 01184, 01209, 01234, 01240, 01461, ...).

Fixes both id-list builders in `exporters/jax/ode_export.py` to consult the same `reserved_symbol_original_ids` map the C++ exporter already uses, and adds JAX-specific regression tests mirroring the existing C++ ones.

🤖 Generated with Claude Code

previously failed runs: https://github.com/AMICI-dev/AMICI/actions/workflows/test_sbml_semantic_test_suite_jax.yml