### PR TITLE
Restore original entity id in JAX-backend outward-facing id lists

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,33 +8,39 @@ See also our [versioning policy](https://amici.readthedocs.io/en/latest/versioni
 
 **Fixes**
 
-* There are no more reserved names: previously, model import or
-  compilation could fail — or silently generate incorrect code, with no
-  indication of the actual cause — whenever a model entity's ID collided
-  with a C++ keyword, a standard-library macro (e.g. `NULL`, `EOF`), one
-  of AMICI's fixed array-parameter names (`x`, `p`, `k`, `h`, `w`, `y`),
-  or an AMICI-internally-derived symbol name (e.g. a reaction's own flux
-  symbol, a conservation-law total, an observable's measurement/sigma
-  symbol, or a sparse-Jacobian placeholder like the `dwdx`/`dwdp`/
-  `dxdotdx_explicit` entries named `d{row}_d{col}`). In particular,
-  single-letter entity names used to be a common source of such failures.
-  All of these are now handled transparently: colliding names are
-  disambiguated or renamed internally, with the original ID restored
-  everywhere it's reported (state/parameter/observable/expression IDs,
-  PEtab mapping, ...) — for some single-letter names, this internal
-  renaming previously used an `amici_` prefix that could itself leak into
-  reported IDs; that prefix is now purely an implementation detail and
-  never visible to users. Generated C++ locals are also never aliased
-  across two different quantities that merely happen to print the same
-  name, and generated C++ files no longer rely on unscoped `#define`
+* There are no more reserved names, for either backend: previously, model
+  import or compilation could fail — or silently generate incorrect code,
+  with no indication of the actual cause — whenever a model entity's ID
+  collided with something the generated code already used. That was a C++
+  keyword or standard-library macro (e.g. `NULL`, `EOF`) for the SUNDIALS
+  backend; a Python keyword, one of the generated module's imports
+  (`jnp`, `safe_log`, ...) or one of its methods' own arguments (`self`,
+  `tcl`, `my`, ...) for the JAX backend; AMICI's fixed array-parameter
+  names (`x`, `p`, `k`, `h`, `w`, `y`) for both; or an
+  AMICI-internally-derived symbol name (e.g. a reaction's own flux symbol,
+  a conservation-law total, an observable's measurement/sigma symbol, or a
+  sparse-Jacobian placeholder like the `dwdx`/`dwdp`/`dxdotdx_explicit`
+  entries named `d{row}_d{col}`). In particular, single-letter entity names
+  used to be a common source of such failures.
+  All of these are now handled transparently: each backend's code printer
+  mangles every identifier it prints, so a name that's unsafe in generated
+  code stays an implementation detail of code generation. Only `t` is still
+  renamed at the model level (it denotes simulation time symbolically, not
+  just by name), with the original ID restored everywhere it's reported
+  (state/parameter/observable/expression IDs, PEtab mapping, ...) — this
+  internal renaming previously used an `amici_` prefix that could itself
+  leak into reported IDs; that prefix is now purely an implementation
+  detail and never visible to users. Generated locals are also never
+  aliased across two different quantities that merely happen to print the
+  same name, and generated C++ files no longer rely on unscoped `#define`
   macros for entity names either.
 
   As a side effect, the local variable names used internally in generated
   model code have changed (e.g. `STAT` is now printed as `STAT_`). This
   does not affect the public API — state/parameter/observable IDs are
-  unaffected — but if you inspect or post-process AMICI-generated C++
-  source directly, expect different local variable names (#2226, #2461,
-  #3237, #3240, #3243, #3246).
+  unaffected — but if you inspect or post-process AMICI-generated C++ or
+  JAX source directly, expect different local variable names (#2226,
+  #2461, #3237, #3240, #3243, #3246, #3255).
 
 * Fixed splines being treated as unconditionally time-dependent via
   fragile string matching, rather than through AMICI's normal symbolic

--- a/python/sdist/amici/exporters/_mangling.py
+++ b/python/sdist/amici/exporters/_mangling.py
@@ -1,0 +1,78 @@
+"""Turning model entity ids into identifiers that are safe in generated code.
+
+Both backends emit model entity ids as identifiers in the code they
+generate. A model entity id is only constrained by the source format
+(any SBML ``SId``, any PySB component name), so it may well collide with
+something the target language or the generated code itself already uses:
+a keyword, a standard-library macro, one of the fixed argument names the
+generated functions are written with, or another entity id that isn't
+distinguishable after mangling.
+
+Passing every printed identifier through a single choke point per model
+(:class:`IdentifierMangler`) guarantees none of that can happen, without
+the model itself having to know anything about the target language.
+"""
+
+import re
+
+import sympy as sp
+
+__all__ = ["IdentifierMangler", "mangle_name"]
+
+
+def mangle_name(name: str) -> str:
+    """Make a model-derived identifier safe as a local variable name in
+    generated code.
+
+    Appends `_` so it can never equal a real keyword/macro (in either
+    target language: no C++ keyword, C standard-library macro, Python
+    keyword or builtin ends in an underscore, and neither does any of the
+    fixed argument/variable names of the generated functions). Collapses
+    any SBML-legal `__` run first, and uses `v` instead of `_` as the
+    marker for names already ending in `_`, so the result never contains
+    `__` either (reserved in C++; class-private in Python).
+
+    This is not injective and does not guarantee a unique result on its
+    own (e.g. `"a__b"` and `"a_b"` both collapse to the same string) --
+    callers that need uniqueness across a whole model handle that
+    separately (see :class:`IdentifierMangler`).
+    """
+    name = re.sub(r"_{2,}", "_", name)
+    return f"{name}v" if name.endswith("_") else f"{name}_"
+
+
+class IdentifierMangler:
+    """Assigns each symbol of one model a unique, safe identifier for the
+    generated code.
+
+    One instance per generated model: the mangled name of a given symbol
+    has to be the same everywhere it occurs, and must not be handed to any
+    other symbol of that model.
+    """
+
+    def __init__(self):
+        # mangled-name cache, keyed by original symbol, for this model
+        self._mangled_names: dict[sp.Symbol, str] = {}
+        # mangled names already assigned, for collision detection
+        self._mangled_name_set: set[str] = set()
+
+    def mangle(self, symbol: sp.Symbol) -> str:
+        """Mangle the identifier for `symbol`, deduplicating against prior
+        results for this model.
+
+        The same symbol always yields the same output; distinct symbols
+        never yield the same output -- keyed on the full symbol (name *and*
+        assumptions), not just its name, since two AMICI-internal symbols
+        can otherwise legitimately share a name with a differently-created
+        (e.g. user-entity) symbol of the same name (#3240).
+        """
+        if (cached := self._mangled_names.get(symbol)) is not None:
+            return cached
+        base = mangled = mangle_name(symbol.name)
+        n = 2
+        while mangled in self._mangled_name_set:
+            mangled = f"{base}{n}"
+            n += 1
+        self._mangled_names[symbol] = mangled
+        self._mangled_name_set.add(mangled)
+        return mangled

--- a/python/sdist/amici/exporters/jax/jaxcodeprinter.py
+++ b/python/sdist/amici/exporters/jax/jaxcodeprinter.py
@@ -11,9 +11,54 @@ from sympy.core.function import UndefinedFunction
 from sympy.printing.numpy import NumPyPrinter
 from toposort import toposort
 
+from amici.exporters._mangling import IdentifierMangler
+from amici.importers.utils import amici_time_symbol
+
+#: The generic measurement symbol that observable-specific measurement
+#: symbols are substituted by before code generation. Unlike every other
+#: symbol printed here, it denotes a fixed argument of the generated
+#: ``_nllh`` (see ``jax.template.py``), not a model entity.
+generic_measurement_symbol = sp.Symbol("my")
+
 
 class AmiciJaxCodePrinter(NumPyPrinter):
     """JAX code printer"""
+
+    #: Symbols denoting one of the fixed arguments of the generated
+    #: functions rather than a model entity, mapped to the argument name
+    #: they have to be printed as (see ``jax.template.py``). Keyed on the
+    #: full symbol, so a model entity that merely shares the name is
+    #: unaffected (and gets a mangled name of its own, as any other).
+    _fixed_symbol_names = {
+        amici_time_symbol: "t",
+        generic_measurement_symbol: "my",
+    }
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        # identifier mangling for this model, shared with the C++ backend
+        self._mangler = IdentifierMangler()
+
+    def mangle_identifier(self, symbol: sp.Symbol) -> str:
+        """Mangle the identifier for `symbol` into a safe, unique Python
+        local variable name.
+
+        Every model entity id printed into the generated module -- as the
+        target of an assignment as much as inside an expression -- has to
+        go through here. The generated functions destructure their array
+        arguments into per-entry locals (``x_, y_ = x``), so an unmangled
+        entity id would shadow the argument it was unpacked from (or the
+        module's imports, or a Python keyword), silently corrupting every
+        later use of it in that function.
+
+        See :meth:`amici.exporters._mangling.IdentifierMangler.mangle`.
+        """
+        return self._mangler.mangle(symbol)
+
+    def _print_Symbol(self, expr: sp.Symbol) -> str:
+        if (fixed_name := self._fixed_symbol_names.get(expr)) is not None:
+            return fixed_name
+        return self.mangle_identifier(expr)
 
     def _print_Float(self, expr: sp.Float) -> str:
         # sympy's string printer emits 15 significant digits, which is not
@@ -145,7 +190,8 @@ class AmiciJaxCodePrinter(NumPyPrinter):
         )
         if not replacements:
             return [
-                f"{indent}{s} = {self.doprint(e)}"
+                f"{indent}{self._print_assignment_target(s)} = "
+                f"{self.doprint(e)}"
                 for s, e in zip(symbols, reduced)
             ]
 
@@ -162,10 +208,24 @@ class AmiciJaxCodePrinter(NumPyPrinter):
             for identifier, definition in expr_dict.items()
         }
         return [
-            f"{indent}{sym} = {self.doprint(expr_dict[sym])}"
+            f"{indent}{self._print_assignment_target(sym)} = "
+            f"{self.doprint(expr_dict[sym])}"
             for group in toposort(dependencies)
             for sym in sorted(group, key=str)
         ]
+
+    def _print_assignment_target(self, symbol: sp.Symbol | str) -> str:
+        """Print `symbol` as the left-hand side of an assignment.
+
+        Same identifier as the symbol gets inside an expression -- the two
+        sides have to agree, which they only do if both go through the
+        printer.
+        """
+        return (
+            self.doprint(symbol)
+            if isinstance(symbol, sp.Basic)
+            else str(symbol)
+        )
 
 
 def _jnp_array_str(

--- a/python/sdist/amici/exporters/jax/ode_export.py
+++ b/python/sdist/amici/exporters/jax/ode_export.py
@@ -29,18 +29,27 @@ from amici.exporters.template import apply_template
 from amici.logging import get_logger, log_execution_time, set_log_level
 from amici.sim.jax.model import JAXModel
 
-from .jaxcodeprinter import AmiciJaxCodePrinter, _jnp_array_str
+from .jaxcodeprinter import (
+    AmiciJaxCodePrinter,
+    _jnp_array_str,
+    generic_measurement_symbol,
+)
 
 #: python log manager
 logger = get_logger(__name__, logging.ERROR)
 
 
 def _jax_variable_assignments(
-    model: DEModel, sym_names: tuple[str, ...]
+    model: DEModel,
+    code_printer: AmiciJaxCodePrinter,
+    sym_names: tuple[str, ...],
 ) -> dict:
     return {
         f"{sym_name.upper()}_SYMS": "".join(
-            f"{s.name}, " for s in model.sym(sym_name)
+            # local variable names, so mangled -- never the entity id, which
+            # could shadow the array argument it's unpacked from
+            f"{code_printer.doprint(s)}, "
+            for s in model.sym(sym_name)
         )
         if model.sym(sym_name)
         else "_"
@@ -72,11 +81,12 @@ def _jax_variable_equations(
 
 def _jax_return_variables(
     model: DEModel,
+    code_printer: AmiciJaxCodePrinter,
     eq_names: tuple[str, ...],
 ) -> dict:
     return {
         f"{eq_name.upper()}_RET": _jnp_array_str(
-            s.name for s in model.sym(eq_name)
+            model.sym(eq_name), code_printer
         )
         if model.sym(eq_name) and sp.Matrix(model.eq(eq_name)).shape[0]
         else "jnp.array([])"
@@ -89,8 +99,8 @@ def _jax_variable_ids(model: DEModel, sym_names: tuple[str, ...]) -> dict:
     return {
         f"{sym_name.upper()}_IDS": "".join(
             # public ids must stay exactly as the user named them, even if
-            # amici had to mangle the identifier internally (e.g. an entity
-            # named `p`, which collides with the array-parameter name `p`)
+            # amici had to rename the entity internally (an entity named
+            # `t`, the one name that still collides -- see RESERVED_SYMBOLS)
             f'"{original_ids.get(s.name, s.name)}", '
             for s in model.sym(sym_name)
         )
@@ -246,7 +256,7 @@ class ODEExporter:
         subs_observables = dict(
             zip(
                 self.model.sym("my"),
-                [sp.Symbol("my")] * len(self.model.sym("my")),
+                [generic_measurement_symbol] * len(self.model.sym("my")),
                 strict=True,
             )
         )
@@ -260,9 +270,11 @@ class ODEExporter:
                 self.model, self._code_printer, eq_names, subs, indent
             ),
             # create jax array from concatenation of named variables
-            **_jax_return_variables(self.model, eq_names),
+            **_jax_return_variables(self.model, self._code_printer, eq_names),
             # assign named variables from a jax array
-            **_jax_variable_assignments(self.model, sym_names),
+            **_jax_variable_assignments(
+                self.model, self._code_printer, sym_names
+            ),
             # tuple of variable names (ids as they are unique)
             **_jax_variable_ids(self.model, ("p", "k", "y", "w", "x_rdata")),
             "P_VALUES": _jnp_array_str(
@@ -278,7 +290,8 @@ class ODEExporter:
             if self._get_all_p_syms()
             else "tuple()",
             "ALL_P_SYMS": "".join(
-                f"{s.name}, " for s in self._get_all_p_syms()
+                f"{self._code_printer.doprint(s)}, "
+                for s in self._get_all_p_syms()
             )
             if self._get_all_p_syms()
             else "_",

--- a/python/sdist/amici/exporters/jax/ode_export.py
+++ b/python/sdist/amici/exporters/jax/ode_export.py
@@ -85,9 +85,14 @@ def _jax_return_variables(
 
 
 def _jax_variable_ids(model: DEModel, sym_names: tuple[str, ...]) -> dict:
+    original_ids = model.reserved_symbol_original_ids
     return {
         f"{sym_name.upper()}_IDS": "".join(
-            f'"{s.name}", ' for s in model.sym(sym_name)
+            # public ids must stay exactly as the user named them, even if
+            # amici had to mangle the identifier internally (e.g. an entity
+            # named `p`, which collides with the array-parameter name `p`)
+            f'"{original_ids.get(s.name, s.name)}", '
+            for s in model.sym(sym_name)
         )
         if model.sym(sym_name)
         else "tuple()"
@@ -267,7 +272,8 @@ class ODEExporter:
                 self.model.val("p") + self.model.val("k"), self._code_printer
             ),
             "ALL_P_IDS": "".join(
-                f'"{s.name}", ' for s in self._get_all_p_syms()
+                f'"{self.model.reserved_symbol_original_ids.get(s.name, s.name)}", '
+                for s in self._get_all_p_syms()
             )
             if self._get_all_p_syms()
             else "tuple()",

--- a/python/sdist/amici/exporters/sundials/cxxcodeprinter.py
+++ b/python/sdist/amici/exporters/sundials/cxxcodeprinter.py
@@ -12,25 +12,12 @@ from sympy.printing.cxx import CXX11CodePrinter
 from sympy.utilities.iterables import numbered_symbols
 from toposort import toposort
 
+from amici.exporters._mangling import IdentifierMangler
 from amici.importers.utils import (
     amici_time_symbol,
     make_name_unique,
     symbol_with_assumptions,
 )
-
-
-def _mangle(name: str) -> str:
-    """Make a model-derived identifier safe as a C++ local variable name.
-
-    Appends `_` so it can never equal a real keyword/macro. Collapses any
-    SBML-legal `__` run first, and uses `v` instead of `_` as the marker for
-    names already ending in `_`, so the result never contains `__` either.
-    This is not injective and does not guarantee a unique result on its own
-    (e.g. `"a__b"` and `"a_b"` both collapse to the same string) -- callers
-    that need uniqueness across a whole model handle that separately.
-    """
-    name = re.sub(r"_{2,}", "_", name)
-    return f"{name}v" if name.endswith("_") else f"{name}_"
 
 
 class AmiciCxxCodePrinter(CXX11CodePrinter):
@@ -74,31 +61,16 @@ class AmiciCxxCodePrinter(CXX11CodePrinter):
         else:
             self._fpoptimizer = None
 
-        # mangled-name cache, keyed by original symbol, for this model
-        self._mangled_names: dict[sp.Symbol, str] = {}
-        # mangled names already assigned, for collision detection
-        self._mangled_name_set: set[str] = set()
+        # identifier mangling for this model, shared with the JAX backend
+        self._mangler = IdentifierMangler()
 
     def mangle_identifier(self, symbol: sp.Symbol) -> str:
-        """Mangle the identifier for `symbol`, deduplicating against prior
-        results for this model.
+        """Mangle the identifier for `symbol` into a safe, unique C++ local
+        variable name.
 
-        The same symbol always yields the same output; distinct symbols
-        never yield the same output -- keyed on the full symbol (name *and*
-        assumptions), not just its name, since two AMICI-internal symbols
-        can otherwise legitimately share a name with a differently-created
-        (e.g. user-entity) symbol of the same name (#3240).
+        See :meth:`amici.exporters._mangling.IdentifierMangler.mangle`.
         """
-        if (cached := self._mangled_names.get(symbol)) is not None:
-            return cached
-        base = mangled = _mangle(symbol.name)
-        n = 2
-        while mangled in self._mangled_name_set:
-            mangled = f"{base}{n}"
-            n += 1
-        self._mangled_names[symbol] = mangled
-        self._mangled_name_set.add(mangled)
-        return mangled
+        return self._mangler.mangle(symbol)
 
     def _print_Symbol(self, expr: sp.Symbol) -> str:
         if expr == amici_time_symbol:

--- a/python/sdist/amici/importers/pysb/__init__.py
+++ b/python/sdist/amici/importers/pysb/__init__.py
@@ -389,7 +389,7 @@ def ode_model_from_pysb_importer(
 
     # species/conservation-law/sigma/log-likelihood symbols are all
     # synthetically prefixed (__s{ix}, tcl_s{ix}, sigma_{name}, llh_{name})
-    # so they can never literally match a reserved name (single letters);
+    # so they can never literally match a reserved name (`t`);
     # only parameter and expression/observable names need checking
     #
     # `all_names` is threaded through the rest of this import and mutated

--- a/python/sdist/amici/importers/utils.py
+++ b/python/sdist/amici/importers/utils.py
@@ -24,27 +24,21 @@ __all__ = [
 #
 # `t` is merged into the model's expression graph as an actual sympy.Symbol
 # (amici.importers.sbml._process_time), so it must never collide with a
-# model entity.
+# model entity: a model entity named `t` would not merely *print* like the
+# time symbol, it would *be* the very same sympy symbol, and no amount of
+# mangling downstream could tell the two apart again.
 #
-# `x`, `p`, `k`, `h`, `w`, `y` are the fixed array-parameter names AMICI
-# functions are generated with, for both backends. The C++ printer mangles
-# every identifier it prints (AmiciCxxCodePrinter.mangle_identifier), so
-# a model entity sharing one of these names is safe there -- but the JAX
-# exporter has no such protection: its generated methods destructure the
-# array parameter into per-entry locals *by reusing the parameter's own
-# name* (e.g. `def _xdot(self, t, x, args): x, = x`), so an entity actually
-# named e.g. "x" silently shadows the array parameter for the rest of that
-# function, corrupting any later use of the array itself (e.g. a call like
-# `self._w(t, x, ...)` then passes the already-unpacked scalar instead of
-# the array). Renaming here avoids that regardless of target backend.
+# Nothing else needs reserving. A name that's merely unsafe *in the
+# generated code* -- a keyword, a stdlib macro, one of the fixed argument
+# names the generated functions are written with (`x`, `p`, `k`, `h`, `w`,
+# `y`, `tcl`, `self`, `jnp`, ...) -- is handled where it actually matters,
+# by each backend's code printer mangling every identifier it prints
+# (amici.exporters._mangling.IdentifierMangler). That keeps such names an
+# implementation detail of code generation instead of something the model
+# representation, and everything reporting ids out of it, has to know
+# about.
 RESERVED_SYMBOLS = [
     "t",
-    "x",
-    "p",
-    "k",
-    "h",
-    "w",
-    "y",
 ]
 
 

--- a/python/tests/test_jaxcodeprinter.py
+++ b/python/tests/test_jaxcodeprinter.py
@@ -1,0 +1,98 @@
+"""Tests for the JAX code printer, in particular identifier mangling."""
+
+import keyword
+
+import pytest
+import sympy as sp
+from amici.testing import skip_on_valgrind
+
+pytest.importorskip("jax")
+
+from amici.exporters.jax.jaxcodeprinter import (  # noqa: E402
+    AmiciJaxCodePrinter,
+    generic_measurement_symbol,
+)
+from amici.importers.utils import (  # noqa: E402
+    amici_time_symbol,
+    symbol_with_assumptions,
+)
+
+
+@skip_on_valgrind
+def test_mangle_identifier():
+    """Every model entity id printed into the generated module is mangled,
+    so it can't collide with anything that module already uses."""
+    cp = AmiciJaxCodePrinter()
+
+    # ordinary names just get a trailing underscore
+    assert cp.doprint(sp.Symbol("STAT")) == "STAT_"
+
+    # names already ending in `_` get a bare-letter marker, and internal
+    # `__` runs collapse -- as for the C++ backend, so the two backends
+    # name the same entity the same way
+    assert cp.doprint(sp.Symbol("k_")) == "k_v"
+    assert cp.doprint(sp.Symbol("my__species")) == "my_species_"
+
+    # nothing the generated module itself uses can be produced: amici's
+    # fixed array-parameter names, the generated methods' other arguments
+    # and locals, the module-level imports, and Python keywords all mangle
+    # to something else
+    for name in (
+        *("x", "p", "k", "h", "w", "y"),
+        *("tcl", "op", "np", "my", "iy", "args", "self"),
+        *("jnp", "jr", "eqx", "oo", "safe_log", "safe_div", "JAXModel"),
+        *keyword.kwlist,
+    ):
+        # created the way the importers create model entities
+        mangled = cp.doprint(symbol_with_assumptions(name))
+        assert mangled != name
+        assert not keyword.iskeyword(mangled)
+        assert mangled.isidentifier()
+
+    # distinct inputs that collapse to the same base still get distinct
+    # results
+    assert cp.doprint(sp.Symbol("a__b")) != cp.doprint(sp.Symbol("a_b"))
+
+    # same input -> same output
+    assert cp.doprint(sp.Symbol("STAT")) == "STAT_"
+
+
+@skip_on_valgrind
+def test_fixed_symbols_are_not_mangled():
+    """The two symbols that denote a fixed argument of the generated
+    functions rather than a model entity keep the name that argument has --
+    while a model entity that merely shares their name doesn't."""
+    cp = AmiciJaxCodePrinter()
+
+    assert cp.doprint(amici_time_symbol) == "t"
+    assert cp.doprint(generic_measurement_symbol) == "my"
+
+    # a model entity named `my` is a different symbol and gets a mangled
+    # name of its own (an entity named `t` can't occur -- `t` is the one
+    # name still renamed at model level, see RESERVED_SYMBOLS)
+    entity_my = sp.Symbol("my", real=True)
+    assert entity_my != generic_measurement_symbol  # premise
+    assert cp.doprint(entity_my) == "my_"
+
+
+@skip_on_valgrind
+def test_assignment_targets_are_mangled_consistently():
+    """An assignment's left-hand side has to use the same identifier the
+    symbol gets inside an expression -- otherwise the generated code reads
+    from the unmangled (and possibly shadowed, or syntactically invalid)
+    name."""
+    cp = AmiciJaxCodePrinter()
+
+    # `class` is a Python keyword, `jnp` one of the module's imports
+    class_, jnp_ = sp.Symbol("class"), sp.Symbol("jnp")
+    lines = cp._get_sym_lines(
+        sp.Matrix([class_, jnp_]),
+        sp.Matrix([sp.Float(2.0), 3 * class_]),
+        indent_level=0,
+    )
+
+    assert lines == [
+        f"{cp.doprint(class_)} = 2.0",
+        f"{cp.doprint(jnp_)} = 3*{cp.doprint(class_)}",
+    ]
+    compile("\n".join(lines), "<generated>", "exec")

--- a/python/tests/test_reserved_symbols.py
+++ b/python/tests/test_reserved_symbols.py
@@ -8,7 +8,7 @@ import numpy as np
 import pytest
 from amici import import_model_module
 from amici.importers.antimony import antimony2amici, antimony2sbml
-from amici.importers.utils import RESERVED_SYMBOLS
+from amici.importers.utils import MeasurementChannel
 from amici.sim.sundials import AMICI_SUCCESS
 from amici.testing import skip_on_valgrind
 
@@ -33,16 +33,22 @@ def _without_comments(source: str) -> str:
     return "\n".join(line.split("//")[0] for line in source.splitlines())
 
 
-# amici's own reserved array/argument names (x, p, k, h, w, y) -- renamed
-# internally just like `t`, with the original id restored for anything
-# reported outward; real C++ keywords and known standard-library macros
-# (int, class, EOF, INFINITY, NULL) -- handled by C++ mangling alone, no
-# renaming needed; and the underscore edge cases from #2226's design.
+# Names that are unsafe in the generated C++ -- amici's own fixed
+# array-parameter names (x, p, k, h, w, y), real C++ keywords and known
+# standard-library macros (int, class, EOF, INFINITY, NULL) -- plus the
+# underscore edge cases from #2226's design. None of these is reserved at
+# the model level: they're all handled by the code printer mangling every
+# identifier it prints.
 # (Not `NAN`/`NaN`/`nan`: Antimony reserves those spellings as its own
 # pre-defined floating-point-NaN constant, rejected at parse time regardless
 # of context -- `NULL`/`EOF`/`INFINITY` already cover this class of case.)
 RESERVED_SPECIES_IDS = [
-    *RESERVED_SYMBOLS,
+    "x",
+    "p",
+    "k",
+    "h",
+    "w",
+    "y",
     "NULL",
     "int",
     "class",
@@ -50,6 +56,45 @@ RESERVED_SPECIES_IDS = [
     "INFINITY",
     "k_",
     "my__species",
+]
+
+# The same for the generated JAX module: amici's fixed array-parameter
+# names, every other argument and local the generated methods use, the
+# module-level imports they call into, and Python keywords. Plus `t`, the
+# one name that *is* still renamed at the model level (see RESERVED_SYMBOLS)
+# and must be reported back under its original id.
+JAX_UNSAFE_SPECIES_IDS = [
+    # amici's fixed array-parameter names
+    "x",
+    "p",
+    "k",
+    "h",
+    "w",
+    "y",
+    # further arguments/locals of the generated methods
+    "t",
+    "tcl",
+    "op",
+    "np",
+    "my",
+    "iy",
+    "args",
+    "self",
+    # module-level imports the generated code calls into
+    "jnp",
+    "jr",
+    "eqx",
+    "oo",
+    "safe_log",
+    "safe_div",
+    "Path",
+    "JAXModel",
+    # Python keywords
+    "class",
+    "lambda",
+    "None",
+    "def",
+    "return",
 ]
 
 
@@ -146,23 +191,88 @@ def test_species_named_t(tempdir):
 
 @skip_on_valgrind
 def test_reserved_species_ids_jax(tempdir):
-    """JAX counterpart of ``test_reserved_species_ids``: species named after
-    amici's reserved array-parameter names must report their original id
-    via ``JAXModel.state_ids``, not the internally-mangled ``amici_*`` name.
-    """
+    """JAX counterpart of ``test_reserved_species_ids``: species whose ids
+    are unsafe as identifiers in the generated JAX module import and
+    evaluate correctly, and report their original id.
+
+    The generated methods destructure their array arguments into per-entry
+    locals, so an entity id that isn't mangled would shadow the argument it
+    was unpacked from (or a module-level import, or be a syntax error) --
+    hence checking that the right-hand sides still evaluate, not just that
+    the id lists look right."""
     pytest.importorskip("jax")
+    import jax.numpy as jnp
     from amici.importers.sbml import SbmlImporter
 
+    species_ids = JAX_UNSAFE_SPECIES_IDS
     model_name = "reserved_species_test_jax"
-    sbml_str = antimony2sbml(_antimony_model_with_species(RESERVED_SYMBOLS))
-    importer = SbmlImporter(sbml_str, from_file=False)
-    importer.sbml2jax(
+    sbml_str = antimony2sbml(_antimony_model_with_species(species_ids))
+    SbmlImporter(sbml_str, from_file=False).sbml2jax(
         model_name,
         output_dir=Path(tempdir) / model_name,
         observation_model=[],
         compute_conservation_laws=False,
     )
-    module = import_model_module(model_name, tempdir)
-    model = module.Model()
+    model = import_model_module(model_name, tempdir).Model()
 
-    assert tuple(model.state_ids) == tuple(RESERVED_SYMBOLS)
+    assert tuple(model.state_ids) == tuple(species_ids)
+
+    # each species follows d[id]/dt = -0.1 * [id], starting at 1
+    x0 = model._x0(0.0, model.parameters)
+    empty = jnp.array([])
+    xdot = model._xdot(0.0, x0, (model.parameters, empty, empty))
+    assert np.allclose(x0, 1.0)
+    assert np.allclose(xdot, -0.1)
+
+
+@skip_on_valgrind
+def test_observable_named_my_jax(tempdir):
+    """An observable named `my` must not shadow the generated `_nllh`'s
+    measurement argument, which is called exactly that.
+
+    Unlike a shadowed state, this one produces no error at all: the
+    negative log-likelihood would just silently be computed against the
+    simulated observable instead of the measurement, and come out
+    independent of the data."""
+    pytest.importorskip("jax")
+    import jax.numpy as jnp
+    from amici.importers.sbml import SbmlImporter
+
+    model_name = "observable_named_my_test_jax"
+    sbml_str = antimony2sbml(_antimony_model_with_species(["A"]))
+    SbmlImporter(sbml_str, from_file=False).sbml2jax(
+        model_name,
+        output_dir=Path(tempdir) / model_name,
+        observation_model=[
+            MeasurementChannel(
+                id_="my",
+                formula="A",
+                noise_distribution="normal",
+                sigma=1.0,
+            )
+        ],
+        compute_conservation_laws=False,
+    )
+    model = import_model_module(model_name, tempdir).Model()
+
+    assert tuple(model.observable_ids) == ("my",)
+
+    x0 = model._x0(0.0, model.parameters)  # A(0) = 1, so `my` = 1
+    empty = jnp.array([])
+
+    def nllh(measurement):
+        return model._nllh(
+            0.0,
+            x0,
+            model.parameters,
+            empty,
+            empty,
+            jnp.array([measurement]),
+            0,
+            empty,
+            empty,
+        )
+
+    # normal noise with sigma=1: 0.5*(y - my)**2 + 0.5*log(2*pi)
+    assert np.isclose(nllh(1.0), 0.5 * np.log(2 * np.pi))
+    assert np.isclose(nllh(5.0), 0.5 * 4**2 + 0.5 * np.log(2 * np.pi))

--- a/python/tests/test_reserved_symbols.py
+++ b/python/tests/test_reserved_symbols.py
@@ -5,7 +5,10 @@ and for the time-symbol."""
 from pathlib import Path
 
 import numpy as np
-from amici.importers.antimony import antimony2amici
+import pytest
+from amici import import_model_module
+from amici.importers.antimony import antimony2amici, antimony2sbml
+from amici.importers.utils import RESERVED_SYMBOLS
 from amici.sim.sundials import AMICI_SUCCESS
 from amici.testing import skip_on_valgrind
 
@@ -39,12 +42,7 @@ def _without_comments(source: str) -> str:
 # pre-defined floating-point-NaN constant, rejected at parse time regardless
 # of context -- `NULL`/`EOF`/`INFINITY` already cover this class of case.)
 RESERVED_SPECIES_IDS = [
-    "x",
-    "p",
-    "k",
-    "h",
-    "w",
-    "y",
+    *RESERVED_SYMBOLS,
     "NULL",
     "int",
     "class",
@@ -144,3 +142,27 @@ def test_species_named_t(tempdir):
     xdot = _generated_source(tempdir, "xdot.cpp")
     assert "amici_t_ = x[0];" in xdot
     assert "-1.0/10.0*amici_t_" in xdot
+
+
+@skip_on_valgrind
+def test_reserved_species_ids_jax(tempdir):
+    """JAX counterpart of ``test_reserved_species_ids``: species named after
+    amici's reserved array-parameter names must report their original id
+    via ``JAXModel.state_ids``, not the internally-mangled ``amici_*`` name.
+    """
+    pytest.importorskip("jax")
+    from amici.importers.sbml import SbmlImporter
+
+    model_name = "reserved_species_test_jax"
+    sbml_str = antimony2sbml(_antimony_model_with_species(RESERVED_SYMBOLS))
+    importer = SbmlImporter(sbml_str, from_file=False)
+    importer.sbml2jax(
+        model_name,
+        output_dir=Path(tempdir) / model_name,
+        observation_model=[],
+        compute_conservation_laws=False,
+    )
+    module = import_model_module(model_name, tempdir)
+    model = module.Model()
+
+    assert tuple(model.state_ids) == tuple(RESERVED_SYMBOLS)


### PR DESCRIPTION
The reserved-symbol rename introduced in 9b17bdd6c (#3239) renames any
model entity whose id collides with one of amici's fixed array-parameter
names (x, p, k, h, w, y) and restores the original id wherever it's
reported outward -- but only the SUNDIALS/C++ exporter was updated to do
so. The JAX exporter's state/parameter/observable/expression id lists
kept reporting the internally-mangled `amici_*` name instead, breaking
the SBML Semantic Test Suite JAX CI job for every test case with an
entity literally named x, p, k, or y (e.g. cases 01184, 01209, 01234,
01240, 01461, ...).

Fix both id-list builders in exporters/jax/ode_export.py to consult the
same `reserved_symbol_original_ids` map the C++ exporter already uses,
and add JAX-specific regression tests mirroring the existing C++ ones.

Co-authored-by: Claude Sonnet 5 <noreply@anthropic.com>