### PR TITLE
Fix forward sensitivities for simultaneous, priority-ordered events

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ See also our [versioning policy](https://amici.readthedocs.io/en/latest/versioni
 
 ## v1.X Series
 
-### v1.1.1 (unreleased)
+### v1.2.0 (unreleased)
 
 **Features**
 
@@ -49,6 +49,13 @@ See also our [versioning policy](https://amici.readthedocs.io/en/latest/versioni
   spline with an event trigger that depends on it now raise a clear error
   at import time instead of silently generating incorrect C++, since
   simulating such models is not yet supported (#3245).
+
+* Fixed incorrect forward sensitivities for models with SBML events that
+  have explicit priorities and can trigger simultaneously.
+  Whenever a lower-priority event's assignment depended on a state that a
+  higher-priority event, triggering at the same instant, had just updated,
+  the sensitivity update used a stale, pre-cascade state instead of that
+  already-updated state. The state trajectory itself was unaffected.
 
 ### v1.1 (2026-09-03)
 

--- a/python/tests/test_events.py
+++ b/python/tests/test_events.py
@@ -940,15 +940,6 @@ def test_event_priorities(tempdir):
     edata = ExpData(rdata, 1, 0)
 
     # check forward sensitivities against finite differences
-    # FIXME: sensitivities w.r.t. the bolus parameter are not correct
-    model.set_parameter_list(
-        [
-            ip
-            for ip, par in enumerate(model.get_free_parameter_ids())
-            if par != "two"
-        ]
-    )
-
     check_derivatives(
         model,
         solver=solver,

--- a/src/forwardproblem.cpp
+++ b/src/forwardproblem.cpp
@@ -476,19 +476,30 @@ void EventHandlingSimulator::handle_events(
         // attribute of the event trigger, re-evaluate the trigger if necessary
         // and process or just remove the event from the queue
 
+        // State right before this event's own bolus is applied: either the
+        // state at the time the trigger was originally evaluated (for
+        // `useValuesFromTriggerTime="true"`), or the live state -- which,
+        // for a lower-priority event in a simultaneous-event cascade,
+        // already reflects the updates applied by earlier, higher-priority
+        // events processed earlier in this same `while` loop. This must be
+        // captured *before* `add_state_event_update` overwrites `ws_->sol.x`
+        // below, and is deliberately not `ws_->x_old`, which is fixed to the
+        // state before the whole cascade started.
+        AmiVector const x_old_event
+            = state_old.has_value() ? state_old->sol.x : ws_->sol.x;
+
         // Execute the event
         // Apply bolus to the state and the sensitivities
         model_->add_state_event_update(
-            ws_->sol.x, ie, ws_->sol.t, ws_->xdot, ws_->xdot_old,
-            state_old.has_value() ? state_old->sol.x : ws_->sol.x,
+            ws_->sol.x, ie, ws_->sol.t, ws_->xdot, ws_->xdot_old, x_old_event,
             state_old.has_value() ? state_old->mod : model_->get_model_state()
         );
         if (solver_->computing_fsa()) {
             // compute the new xdot
             model_->fxdot(ws_->sol.t, ws_->sol.x, ws_->sol.dx, ws_->xdot);
             model_->add_state_sensitivity_event_update(
-                ws_->sol.sx, ie, ws_->sol.t, ws_->sol.x, ws_->x_old, ws_->xdot,
-                ws_->xdot_old,
+                ws_->sol.sx, ie, ws_->sol.t, ws_->sol.x, x_old_event,
+                ws_->xdot, ws_->xdot_old,
                 state_old.has_value() ? state_old->sol.sx : ws_->sol.sx,
                 ws_->stau
             );


### PR DESCRIPTION
🤖 Generated with [Claude Code](https://claude.com/claude-code)

For SBML models with explicitly prioritized events that can trigger simultaneously, the sensitivity update for a lower-priority event's own bolus used the state from before the whole simultaneous-event cascade, instead of the (possibly already updated by a higher-priority event) state right before this particular event — unlike the state update itself, which already handled this correctly. The state trajectory was unaffected; only forward sensitivities for such models were wrong.