### PR TITLE
Fix adjoint sensitivities for simultaneously-triggered events

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -67,6 +67,12 @@ See also our [versioning policy](https://amici.readthedocs.io/en/latest/versioni
   terms were evaluated using the post-event state instead of the pre-event
   state. The state trajectory was unaffected (#3257).
 
+* Fixed incorrect adjoint sensitivities for models with multiple events
+  that can trigger at the same time point. Previously, all such
+  simultaneously-triggered events incorrectly shared a single pre-/post-event
+  state snapshot for the adjoint update (#2805).
+
+
 ### v1.1 (2026-09-03)
 
 **BREAKING CHANGES**

--- a/include/amici/forwardproblem.h
+++ b/include/amici/forwardproblem.h
@@ -18,6 +18,37 @@ class SteadyStateProblem;
 class FinalStateStorer;
 
 /**
+ * @brief Pre-/post-application state snapshot for a single event within a
+ * `Discontinuity`.
+ *
+ * A `Discontinuity` can represent several events that trigger
+ * simultaneously (a single time point may satisfy more than one event's
+ * trigger condition). Each such event is applied in turn (e.g., in order
+ * of priority), and -- for adjoint sensitivities -- `deltaxB`/`deltaqB`
+ * need *this* event's own pre-/post-application state, not the
+ * pre-/post-state of the whole simultaneous-event group.
+ */
+struct EventApplication {
+    /** Index of the applied event. */
+    int ie{0};
+
+    /** State immediately before this event's own bolus was applied. */
+    AmiVector x_pre;
+
+    /** `xdot` evaluated at `x_pre`. */
+    AmiVector xdot_pre;
+
+    /** State immediately after this event's own bolus was applied. */
+    AmiVector x_post;
+
+    /** `xdot` evaluated at `x_post`. */
+    AmiVector xdot_post;
+
+    /** State derivative after this event's own bolus (DAE only). */
+    AmiVector dx_post;
+};
+
+/**
  * @brief Data structure to store some state of a simulation at a discontinuity.
  */
 struct Discontinuity {
@@ -26,46 +57,22 @@ struct Discontinuity {
      *
      * @param time
      * @param root_info
-     * @param x_pre
-     * @param xdot_pre
-     * @param x_post
-     * @param xdot_post
      * @param h_pre
      * @param total_cl_pre
      */
     explicit Discontinuity(
         realtype const time,
         std::vector<int> const& root_info = std::vector<int>(),
-        AmiVector const& x_pre = AmiVector(),
-        AmiVector const& xdot_pre = AmiVector(),
-        AmiVector const& x_post = AmiVector(),
-        AmiVector const& xdot_post = AmiVector(),
         std::vector<realtype> const& h_pre = std::vector<realtype>(),
         std::vector<realtype> const& total_cl_pre = std::vector<realtype>(0)
     )
         : time(time)
-        , x_post(x_post)
-        , x_pre(x_pre)
-        , xdot_post(xdot_post)
-        , xdot_pre(xdot_pre)
         , root_info(root_info)
         , h_pre(h_pre)
         , total_cl_pre(total_cl_pre) {}
 
     /** Time of discontinuity. */
     realtype time;
-
-    /** Post-event state vector (dimension nx). */
-    AmiVector x_post;
-
-    /** Pre-event state vector (dimension nx). */
-    AmiVector x_pre;
-
-    /** Post-event differential state vectors (dimension nx). */
-    AmiVector xdot_post;
-
-    /** Pre-event differential state vectors (dimension nx). */
-    AmiVector xdot_pre;
 
     /**
      * @brief Array of flags indicating which root has been found.
@@ -82,12 +89,18 @@ struct Discontinuity {
      */
     std::vector<realtype> h_pre;
 
-    /** time derivative of state (DAE only) post-event */
-    AmiVector dx_post;
-
     /** Total abundances for conservation laws
      (dimension: `nx_rdata - nx_solver`) */
     std::vector<realtype> total_cl_pre;
+
+    /**
+     * @brief Per-event pre-/post-bolus state snapshots, one entry per
+     * event in the exact order in which they were applied (as opposed to
+     * `root_info`, which only records *which* events fired, but neither order
+     * nor intermediate state.)
+     * Only populated when adjoint sensitivities are being computed.
+     */
+    std::vector<EventApplication> event_applications;
 };
 
 /**

--- a/python/tests/test_events.py
+++ b/python/tests/test_events.py
@@ -1092,14 +1092,11 @@ def test_event_uses_values_from_trigger_time(tempdir):
                 ]
             )
         elif sens_method == SensitivityMethod.adjoint:
-            # FIXME: adjoint sensitivities w.r.t. the bolus parameter `three`
-            #  are wrong.
-            #  maybe related to https://github.com/AMICI-dev/AMICI/issues/2805
             model.set_parameter_list(
                 [
                     ip
                     for ip, par in enumerate(model.get_free_parameter_ids())
-                    if par not in ["one", "three"]
+                    if par not in ["one"]
                 ]
             )
 

--- a/src/backwardproblem.cpp
+++ b/src/backwardproblem.cpp
@@ -7,6 +7,8 @@
 #include "amici/solver.h"
 #include "amici/steadystateproblem.h"
 
+#include <ranges>
+
 namespace amici {
 constexpr realtype conv_thresh = 1.0;
 
@@ -182,19 +184,20 @@ void BackwardProblem::handle_postequilibration() {
 void EventHandlingBwdSimulator::handle_event_b(
     Discontinuity const& disc, std::vector<realtype> const* dJzdx
 ) {
-    for (int ie = 0; ie < model_->ne; ie++) {
-
-        if (disc.root_info[ie] != 1) {
-            continue;
-        }
+    // Undo events in the reverse of the order they were applied going
+    // forward (which is not necessarily their index order)
+    for (auto const& application :
+         std::ranges::reverse_view(disc.event_applications)) {
+        auto const ie = application.ie;
 
         model_->add_adjoint_quadrature_event_update(
-            ws_->xQB_, ie, t_, disc.x_post, ws_->xB_, disc.xdot_post,
-            disc.xdot_pre, disc.x_pre, disc.dx_post
+            ws_->xQB_, ie, t_, application.x_post, ws_->xB_,
+            application.xdot_post, application.xdot_pre, application.x_pre,
+            application.dx_post
         );
         model_->add_adjoint_state_event_update(
-            ws_->xB_, ie, t_, disc.x_post, disc.xdot_post, disc.xdot_pre,
-            disc.x_pre, disc.dx_post
+            ws_->xB_, ie, t_, application.x_post, application.xdot_post,
+            application.xdot_pre, application.x_pre, application.dx_post
         );
 
         if (model_->nz > 0) {

--- a/src/forwardproblem.cpp
+++ b/src/forwardproblem.cpp
@@ -403,9 +403,8 @@ void EventHandlingSimulator::handle_events(
     }
     ws_->tlastroot = ws_->sol.t;
 
-    // store the event info and pre-event simulation state
-    // whenever a new event is triggered
-    auto store_pre_event_info
+    // start a new discontinuity record whenever a new event is triggered
+    auto record_new_discontinuity
         = [this, initial_event, edata](bool const seflag) {
               // store Heaviside information at event occurrence
               model_->froot(ws_->sol.t, ws_->sol.x, ws_->sol.dx, ws_->rootvals);
@@ -422,21 +421,7 @@ void EventHandlingSimulator::handle_events(
               store_pre_event_state(seflag, initial_event);
           };
 
-    // store post-event information that is to be saved
-    //  not after processing every single event, but after processing all events
-    //  that did not trigger a secondary event
-    auto store_post_event_info = [this]() {
-        if (solver_->computing_asa()) {
-            // store updated x to compute jump in discontinuity
-            result.discs.back().x_post = ws_->sol.x;
-            result.discs.back().dx_post = ws_->sol.dx;
-            // Update xdot after the state update
-            model_->fxdot(ws_->sol.t, ws_->sol.x, ws_->sol.dx, ws_->xdot);
-            result.discs.back().xdot_post = ws_->xdot;
-        }
-    };
-
-    store_pre_event_info(false);
+    record_new_discontinuity(false);
 
     if (!initial_event) {
         model_->update_heaviside(ws_->roots_found);
@@ -488,6 +473,28 @@ void EventHandlingSimulator::handle_events(
         AmiVector const x_old_event
             = state_old.has_value() ? state_old->sol.x : ws_->sol.x;
 
+        // For adjoint sensitivities, `deltaxB`/`deltaqB` need this event's
+        // own pre-/post-application state. store pre-event state.
+        std::optional<EventApplication> event_application;
+        if (solver_->computing_asa()) {
+            event_application.emplace();
+            event_application->ie = ie;
+            event_application->x_pre = x_old_event;
+            if (result.discs.back().event_applications.empty()) {
+                // First event applied for this discontinuity: `update_heaviside`
+                // above already flipped `h` for the *whole* simultaneous-event
+                // group atomically, before any of its events were applied, so a
+                // fresh `fxdot` call here would incorrectly use post-flip `h`
+                // for what must be a pre-flip rate. `ws_->xdot_old` was already
+                // computed (in `store_pre_event_state`) at this same pre-flip,
+                // pre-cascade state, so reuse it instead of recomputing.
+                event_application->xdot_pre = ws_->xdot_old;
+            } else {
+                model_->fxdot(ws_->sol.t, x_old_event, ws_->sol.dx, ws_->xdot);
+                event_application->xdot_pre = ws_->xdot;
+            }
+        }
+
         // Execute the event
         // Apply bolus to the state and the sensitivities
         model_->add_state_event_update(
@@ -504,18 +511,25 @@ void EventHandlingSimulator::handle_events(
                 ws_->stau
             );
         }
+        // store post-event state
+        if (event_application) {
+            event_application->x_post = ws_->sol.x;
+            event_application->dx_post = ws_->sol.dx;
+            model_->fxdot(ws_->sol.t, ws_->sol.x, ws_->sol.dx, ws_->xdot);
+            event_application->xdot_post = ws_->xdot;
+            result.discs.back().event_applications.push_back(
+                *std::move(event_application)
+            );
+        }
 
         // check if the event assignment triggered another event
         // and add it to the list of pending events if necessary
         if (detect_secondary_events()) {
-            store_post_event_info();
-
-            store_pre_event_info(true);
+            record_new_discontinuity(true);
 
             model_->update_heaviside(ws_->roots_found);
         }
     }
-    store_post_event_info();
 
     // reinitialize the solver after all events have been processed
     solver_->reinit(ws_->sol.t, ws_->sol.x, ws_->sol.dx);
@@ -616,8 +630,6 @@ void EventHandlingSimulator::store_pre_event_state(
             std::ranges::fill(ws_->stau, 0.0);
         }
     } else if (solver_->computing_asa()) {
-        result.discs.back().xdot_pre = ws_->xdot_old;
-        result.discs.back().x_pre = ws_->x_old;
         result.discs.back().h_pre = model_->get_model_state().h;
         result.discs.back().total_cl_pre = model_->get_model_state().total_cl;
     }


### PR DESCRIPTION
Each event applied within a simultaneous-event group now gets its own pre-/post-application state snapshot, rather than all events sharing the state of the whole group.

Fixes #2805
Related to #18 