### PR TITLE
Fix zero dtcldp sensitivity without reintroducing dwdp blow-up

### DIFF
--- a/python/sdist/amici/_symbolic/de_model.py
+++ b/python/sdist/amici/_symbolic/de_model.py
@@ -1167,22 +1167,7 @@ class DEModel:
             )
             return
         elif name == "dtcldp":
-            # check, whether the CL consists of only one state. Then,
-            # sensitivities drop out, otherwise generate symbols
-            self._syms[name] = sp.Matrix(
-                [
-                    [
-                        sp.Symbol(
-                            f"s{tcl.get_id()}__{par.get_id()}",
-                            real=True,
-                        )
-                        for par in self._free_parameters
-                    ]
-                    if self.conservation_law_has_multispecies(tcl)
-                    else [0] * self.num_par()
-                    for tcl in self._conservation_laws
-                ]
-            )
+            self._syms[name] = self._dtcldp_symbols()
             return
         elif name == "x_old":
             length = len(self.eq("xdot"))
@@ -2473,6 +2458,49 @@ class DEModel:
         state_set = set(self.sym("x_rdata"))
         n_species = len(state_set.intersection(tcl.get_val().free_symbols))
         return n_species > 1
+
+    def _dtcldp_symbols(self) -> sp.Matrix:
+        """
+        Builds the symbol matrix for ``dtcldp``, the sensitivity of each
+        conservation law's total abundance w.r.t. the free parameters.
+
+        Multi-species conservation laws keep every entry as a live symbol:
+        if only some of their states get reinitialized after
+        preequilibration while others keep their (formula-less,
+        dynamics-derived) preequilibration values, the recomputed total can
+        depend on parameters invisible to the model's own ``x0``/``sx0``
+        formulas. Single-species conservation laws only ever arise from
+        states with ``dx/dt == 0`` identically, so they're never touched by
+        dynamics in the first place: their sensitivity is fully determined
+        by the free parameters in their own initial-value formula, and all
+        other entries can stay a literal zero. This keeps ``dtcldp`` (and
+        downstream quantities like ``dwdp``) sparse for models with many
+        trivial single-species conservation laws.
+
+        :return:
+            symbol matrix, one row per conservation law
+        """
+        state_by_sym = {
+            state.get_sym(): state for state in self._differential_states
+        }
+
+        def row(tcl: ConservationLaw) -> list[sp.Expr]:
+            if self.conservation_law_has_multispecies(tcl):
+                return [
+                    symbol_with_assumptions(f"s{tcl.get_id()}__{par.get_id()}")
+                    for par in self._free_parameters
+                ]
+
+            (state_sym,) = tcl.get_val().free_symbols
+            init_free_syms = state_by_sym[state_sym].get_val().free_symbols
+            return [
+                symbol_with_assumptions(f"s{tcl.get_id()}__{par.get_id()}")
+                if par.get_sym() in init_free_syms
+                else 0
+                for par in self._free_parameters
+            ]
+
+        return sp.Matrix([row(tcl) for tcl in self._conservation_laws])
 
     def _expr_is_time_dependent(self, expr: sp.Expr) -> bool:
         """Determine whether an expression is time-dependent.

--- a/tests/sbml/testSBMLSuite.py
+++ b/tests/sbml/testSBMLSuite.py
@@ -191,15 +191,6 @@ def _sensitivity_preflight_checks(
             "be wrong -- see "
             "https://github.com/AMICI-dev/AMICI/issues/3250"
         )
-    if any(
-        species.getBoundaryCondition() or species.getConstant()
-        for species in sbml_model.getListOfSpecies()
-    ):
-        pytest.skip(
-            "Sensitivities for boundary-condition/constant species "
-            "are known to be wrong -- see "
-            "https://github.com/AMICI-dev/AMICI/issues/3249"
-        )
     if uses_adjoint and model.nx_rdata == 0:
         pytest.skip(
             "Adjoint sensitivities for zero-state models are known to crash."


### PR DESCRIPTION
Fixes #3249, fixes #3268.

`dtcldp` was hardcoded to `0` for every parameter whenever a conservation law spanned a single species — wrong whenever that species' own initial value depends on a parameter (#3249). #3259 fixed this by making `dtcldp` always symbolic for every `(conservation law, parameter)` pair, which blew up `dwdp`'s sparsity pattern for models with many trivial single-species conservation laws, hanging compilation (#3268); it was reverted.

Single-species conservation laws always come from states with `dx/dt == 0` identically, so their `dtcldp` sensitivity is fully decidable from the state's own initial-value formula: this emits a symbol only for parameters that actually appear there, literal zero otherwise. Multi-species conservation laws stay fully symbolic, since preequilibration followed by partial reinitialization can make their total depend on parameters invisible to any static formula — this is what PEtab test suite cases 0010/0017 protect against.

🤖 Generated with AI assistance.

:eyes: https://github.com/dweindl/AMICI/actions/runs/34533796660